### PR TITLE
Glpk

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -24,7 +24,7 @@ from cvxpy.expressions.constants import Parameter, CallbackParam, Constant
 from cvxpy.problems.problem import Problem
 from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.error import SolverError
-from cvxpy.settings import (CVXOPT, ECOS, ECOS_BB, SCS,
+from cvxpy.settings import (CVXOPT, CVXOPT_GLPK, ECOS, ECOS_BB, SCS,
 OPTIMAL, UNBOUNDED, INFEASIBLE, SOLVER_ERROR,
 OPTIMAL_INACCURATE, UNBOUNDED_INACCURATE, INFEASIBLE_INACCURATE)
 

--- a/cvxpy/problems/solvers/cvxopt_glpk_intf.py
+++ b/cvxpy/problems/solvers/cvxopt_glpk_intf.py
@@ -1,0 +1,153 @@
+"""
+Copyright 2013 Steven Diamond
+
+This file is part of CVXPY.
+
+CVXPY is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+CVXPY is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.problems.solvers.solver import Solver
+import cvxopt
+import cvxopt.solvers
+
+class CVXOPT_GLPK(Solver):
+    """An interface for the CVXOPT solver.
+    """
+    def name(self):
+        """The name of the solver.
+        """
+        return s.CVXOPT_GLPK
+
+    def matrix_intf(self):
+        """The interface for matrices passed to the solver.
+        """
+        return intf.CVXOPT_SPARSE_INTF
+
+    def vec_intf(self):
+        """The interface for vectors passed to the solver.
+        """
+        return intf.CVXOPT_DENSE_INTF
+
+    def split_constr(self, constr_map):
+        """Extracts the equality, inequality, and nonlinear constraints.
+
+        Parameters
+        ----------
+        constr_map : dict
+            A dict of the canonicalized constraints.
+
+        Returns
+        -------
+        tuple
+            (eq_constr, ineq_constr, nonlin_constr)
+        """
+        return (constr_map[s.EQ], constr_map[s.LEQ], constr_map[s.EXP])
+
+    def solve(self, objective, constraints, cached_data,
+              warm_start, verbose, solver_opts):
+        """Returns the result of the call to the solver.
+
+        Parameters
+        ----------
+        objective : LinOp
+            The canonicalized objective.
+        constraints : list
+            The list of canonicalized cosntraints.
+        cached_data : dict
+            A map of solver name to cached problem data.
+        warm_start : bool
+            Not used.
+        verbose : bool
+            Should the solver print output?
+        solver_opts : dict
+            Additional arguments for the solver.
+
+        Returns
+        -------
+        tuple
+            (status, optimal value, primal, equality dual, inequality dual)
+        """
+        data = self.get_problem_data(objective, constraints, cached_data)
+        # Save original cvxopt solver options.
+        old_options = cvxopt.solvers.options
+        # Silence cvxopt if verbose is False.
+        if verbose:
+            cvxopt.solvers.options["msg_lev"] = "GLP_MSG_ON"
+        else:
+            cvxopt.solvers.options["msg_lev"] = "GLP_MSG_OFF"
+
+        # Apply any user-specific options.
+        # Rename max_iters to maxiters.
+        if "max_iters" in solver_opts:
+            solver_opts["maxiters"] = solver_opts["max_iters"]
+        for key, value in solver_opts.items():
+            cvxopt.solvers.options[key] = value
+
+        # Always do 1 step of iterative refinement after solving KKT system.
+        if not "refinement" in cvxopt.solvers.options:
+            cvxopt.solvers.options["refinement"] = 1
+
+        try:
+            results_dict = cvxopt.solvers.lp(data[s.C],
+                                             data[s.G],
+                                             data[s.H],
+                                             data[s.A],
+                                             data[s.B],
+                                             solver = "glpk")
+
+         # Catch exceptions in CVXOPT and convert them to solver errors.
+        except ValueError:
+            results_dict = {"status": "unknown"}
+
+        # Restore original cvxopt solver options.
+        cvxopt.solvers.options = old_options
+        return self.format_results(results_dict, data[s.DIMS],
+                                   data[s.OFFSET], cached_data)
+
+
+    def format_results(self, results_dict, dims, obj_offset, cached_data):
+        """Converts the solver output into standard form.
+
+        Parameters
+        ----------
+        results_dict : dict
+            The solver output.
+        dims : dict
+            The cone dimensions in the canonicalized problem.
+        obj_offset : float, optional
+            The constant term in the objective.
+        cached_data : dict
+            A map of solver name to cached problem data.
+
+        Returns
+        -------
+        dict
+            The solver output in standard form.
+        """
+        new_results = {}
+        status = s.SOLVER_STATUS[s.CVXOPT][results_dict['status']]
+        new_results[s.STATUS] = status
+        if new_results[s.STATUS] in s.SOLUTION_PRESENT:
+            primal_val = results_dict['primal objective']
+            new_results[s.VALUE] = primal_val + obj_offset
+            new_results[s.PRIMAL] = results_dict['x']
+            new_results[s.EQ_DUAL] = results_dict['y']
+            if dims[s.EXP_DIM]:
+                new_results[s.INEQ_DUAL] = results_dict['zl']
+            else:
+                new_results[s.INEQ_DUAL] = results_dict['z']
+
+        return new_results

--- a/cvxpy/problems/solvers/utilities.py
+++ b/cvxpy/problems/solvers/utilities.py
@@ -20,7 +20,8 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 from cvxpy.problems.solvers.ecos_intf import ECOS
 from cvxpy.problems.solvers.ecos_bb_intf import ECOS_BB
 from cvxpy.problems.solvers.cvxopt_intf import CVXOPT
+from cvxpy.problems.solvers.cvxopt_glpk_intf import CVXOPT_GLPK
 from cvxpy.problems.solvers.scs_intf import SCS
 
-solver_intf = [ECOS(), ECOS_BB(), CVXOPT(), SCS()]
+solver_intf = [ECOS(), ECOS_BB(), CVXOPT(), CVXOPT_GLPK(), SCS()]
 SOLVERS = {solver.name():solver for solver in solver_intf}

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -54,6 +54,7 @@ CVXOPT_STATUS = {'optimal': OPTIMAL,
                  'primal infeasible': INFEASIBLE,
                  'dual infeasible': UNBOUNDED,
                  'unknown': SOLVER_ERROR}
+CVXOPT_GLPK = "CVXOPT_GLPK"
 ECOS = "ECOS"
 ECOS_STATUS = {0: OPTIMAL,
                1: INFEASIBLE,
@@ -77,12 +78,13 @@ SCS_STATUS = {"Solved": OPTIMAL,
               "Indeterminate": SOLVER_ERROR}
 
 SOLVER_STATUS = {CVXOPT: CVXOPT_STATUS,
+                 CVXOPT_GLPK: CVXOPT_STATUS,
                  ECOS: ECOS_STATUS,
                  ECOS_BB: ECOS_STATUS,
                  SCS: SCS_STATUS}
 
 # Solver capabilities.
-SOLVERS = [ECOS, ECOS_BB, CVXOPT, SCS]
+SOLVERS = [ECOS, ECOS_BB, CVXOPT, CVXOPT_GLPK, SCS]
 SDP_CAPABLE = [CVXOPT, SCS]
 EXP_CAPABLE = [CVXOPT, SCS]
 SOCP_CAPABLE = [ECOS, ECOS_BB, CVXOPT, SCS]

--- a/cvxpy/tests/test_solvers.py
+++ b/cvxpy/tests/test_solvers.py
@@ -92,3 +92,18 @@ class TestSolvers(BaseTest):
                        max_iters=20, verbose=True, kktsolver="chol",
                        refinement=2, warm_start=True)
         self.assertItemsAlmostEqual(self.x.value, [0, 0])
+
+    def test_cvxopt_glpk(self):
+        prob = Problem(Minimize(norm(self.x, 1)), [self.x == 0])
+        prob.solve(solver = CVXOPT_GLPK)
+        self.assertItemsAlmostEqual(self.x.value, [0, 0])
+
+        # Example from http://cvxopt.org/userguide/coneprog.html?highlight=solvers.lp#cvxopt.solvers.lp
+        objective = Minimize(-4 * self.x[0] - 5 * self.x[1])
+        constraints = [ 2 * self.x[0] + self.x[1] <= 3,
+                        self.x[0] + 2 * self.x[1] <= 3,
+                        self.x[0] >= 0,
+                        self.x[1] >= 0]
+        prob = Problem(objective, constraints)
+        prob.solve(solver = CVXOPT_GLPK)
+        self.assertItemsAlmostEqual(self.x.value, [1, 1])


### PR DESCRIPTION
Adding an interface for GLPK (called through CVXOPT).

CVXOPT must be installed with GLPK support which can be done with:

```bash
CVXOPT_BUILD_GLPK=1 CVXOPT_GLPK_LIB_DIR=/path/to/glpk-4.55/lib CVXOPT_GLPK_INC_DIR=/path/to/glpk-4.55/include pip install cvxopt
```

Added a test for GLPK output and put it in `test_solvers.py`--wasn't sure if this was the right location

Had to modify `test_verbose()` in `test_problem.py` so that it would capture GLPK's output (which is not under the control of python's `sys.stdout`).  It's a bit of a hack, but it seems to work.