### PR TITLE
Readme: syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CVXPY is a Python-embedded modeling language for convex optimization problems. I
 
 For example, the following code solves a least-squares problem where the variable is constrained by lower and upper bounds:
 
-```
+```python
 from cvxpy import *
 import numpy
 


### PR DESCRIPTION
Just a quick PR to add syntax highlighting to the readme.

Instead of


    ```
    from cvxpy import *
    # ...
    ```


We have 


    ```python
    from cvxpy import *
    # ...
    ```