### PR TITLE
Implement copy function for each atom

### DIFF
--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -59,6 +59,28 @@ class AddExpression(AffAtom):
     def numeric(self, values):
         return reduce(op.add, values)
 
+    # As __init__ takes in the arg_groups instead of args, we need a special
+    # copy() function.
+    def copy(self, args=None):
+        """Returns a shallow copy of the AddExpression atom.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the atom. If args=None, use the
+            current args of the atom.
+
+        Returns
+        -------
+        AddExpression atom
+        """
+        if args is None:
+            args = self.args
+        # Avoid calling __init__() directly as we do not have the args_groups.
+        copy = type(self).__new__(type(self))
+        super(type(copy), copy).__init__(*args)
+        return copy
+
     @staticmethod
     def graph_implementation(arg_objs, size, data=None):
         """Sum the linear expressions.

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -50,6 +50,26 @@ class index(AffAtom):
         """
         return self.key
 
+    # As get_data(self) returns a tuple, the function atom.copy() is confused.
+    # We have to implement another copy() function here.
+    def copy(self, args=None):
+        """Returns a shallow copy of the index atom.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the atom. If args=None, use the
+            current args of the atom.
+
+        Returns
+        -------
+        Index atom
+        """
+        if args is None:
+            args = self.args
+        data = [self.get_data()]
+        return type(self)(*(args + data))
+
     @staticmethod
     def graph_implementation(arg_objs, size, data=None):
         """Index/slice into the expression.

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -122,11 +122,36 @@ class Atom(Expression):
                                                                 data)
             return (graph_obj, constraints + graph_constr)
 
-
     def get_data(self):
         """Returns special info required for graph implementation.
         """
         return None
+
+    def copy(self, args=None):
+        """Returns a shallow copy of the atom.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the atom. If args=None, use the
+            current args of the atom.
+
+        Returns
+        -------
+        Atom
+        """
+        if args is None:
+            args = self.args
+        data = self.get_data()
+        if data is not None:
+            # data is either a tuple or a single object
+            if isinstance(data, tuple):
+                data = list(data)
+            else:
+                data = [data]
+            return type(self)(*(args + data))
+        else:
+            return type(self)(*args)
 
     @abc.abstractmethod
     def graph_implementation(self, arg_objs, size, data=None):

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -190,6 +190,29 @@ class power(Elementwise):
     def get_data(self):
         return self.p, self.w
 
+    def copy(self, args=None):
+        """Returns a shallow copy of the power atom.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the atom. If args=None, use the
+            current args of the atom.
+
+        Returns
+        -------
+        power atom
+        """
+        if args is None:
+            args = self.args
+        # Avoid calling __init__() directly as we do not have p and max_denom.
+        copy = type(self).__new__(type(self))
+        # Emulate __init__()
+        copy.p, copy.w = self.get_data()
+        copy.approx_error = self.approx_error
+        super(type(self), copy).__init__(*args)
+        return copy
+
     @staticmethod
     def graph_implementation(arg_objs, size, data=None):
         """Reduces the atom to an affine expression and list of constraints.

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -267,6 +267,32 @@ class geo_mean(Atom):
     def get_data(self):
         return self.w, self.w_dyad, self.tree
 
+    def copy(self, args=None):
+        """Returns a shallow copy of the geo_mean atom.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the atom. If args=None, use the
+            current args of the atom.
+
+        Returns
+        -------
+        geo_mean atom
+        """
+        if args is None:
+            args = self.args
+        # Avoid calling __init__() directly as we do not have p and max_denom.
+        copy = type(self).__new__(type(self))
+        super(type(self), copy).__init__(*args)
+        # Emulate __init__()
+        copy.w, copy.w_dyad, copy.tree = self.get_data()
+        copy.approx_error = self.approx_error
+        copy.cone_lb = self.cone_lb
+        copy.cone_num_over = self.cone_num_over
+        copy.cone_num = self.cone_num
+        return copy
+
     @staticmethod
     def graph_implementation(arg_objs, size, data=None):
         """Reduces the atom to an affine expression and list of constraints.

--- a/cvxpy/constraints/leq_constraint.py
+++ b/cvxpy/constraints/leq_constraint.py
@@ -106,6 +106,23 @@ class LeqConstraint(u.Canonical, Constraint):
         """
         return self._expr.parameters()
 
+    def copy(self, args=None):
+        """Returns a shallow copy of the constraint.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the constraint. If args=None, use the
+            current args of the atom.
+
+        Returns
+        -------
+        Constraint
+        """
+        if args is None:
+            args = self.args
+        return type(self)(*args)
+
     @property
     def value(self):
         """Does the constraint hold?

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -86,7 +86,7 @@ class Minimize(u.Canonical):
 
         Returns
         -------
-        Constraint
+        Objective
         """
         if args is None:
             args = self.args

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -75,6 +75,23 @@ class Minimize(u.Canonical):
         """
         return self.args[0].is_convex()
 
+    def copy(self, args=None):
+        """Returns a shallow copy of the objective.
+
+        Parameters
+        ----------
+        args : list, optional
+            The arguments to reconstruct the objective. If args=None, use the
+            current args of the objective.
+
+        Returns
+        -------
+        Constraint
+        """
+        if args is None:
+            args = self.args
+        return type(self)(*args)
+
     @property
     def value(self):
         """The value of the objective expression.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -39,6 +39,24 @@ class TestAtoms(BaseTest):
         self.B = Variable(2,2,name='B')
         self.C = Variable(3,2,name='C')
 
+    def test_add_expr_copy(self):
+        """Test the copy function for AddExpresion class.
+        """
+        atom = self.x + self.y
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+        # A new object is constructed, so copy.args == atom.args but copy.args
+        # is not atom.args.
+        self.assertEqual(copy.args, atom.args)
+        self.assertFalse(copy.args is atom.args)
+        self.assertEqual(copy.get_data(), atom.get_data())
+        # Test copy with new args
+        copy = atom.copy(args=[self.A, self.B])
+        self.assertTrue(type(copy) is type(atom))
+        self.assertTrue(copy.args[0] is self.A)
+        self.assertTrue(copy.args[1] is self.B)
+        self.assertEqual(copy.get_data(), atom.get_data())
+
     # Test the normInf class.
     def test_normInf(self):
         exp = self.x+self.y
@@ -97,21 +115,50 @@ class TestAtoms(BaseTest):
                 if p != 1:
                     self.assertEquals(atom.sign, u.Sign.POSITIVE_KEY)
 
+                # Test copy with args=None
+                copy = atom.copy()
+                self.assertTrue(type(copy) is type(atom))
+                # A new object is constructed, so copy.args == atom.args but copy.args
+                # is not atom.args.
+                self.assertEqual(copy.args, atom.args)
+                self.assertFalse(copy.args is atom.args)
+                self.assertEqual(copy.get_data(), atom.get_data())
+                # Test copy with new args
+                copy = atom.copy(args=[self.y])
+                self.assertTrue(type(copy) is type(atom))
+                self.assertTrue(copy.args[0] is self.y)
+                self.assertEqual(copy.get_data(), atom.get_data())
+
+
     # Test the geo_mean class.
     def test_geo_mean(self):
         atom = geo_mean(self.x)
         self.assertEquals(atom.size, (1, 1))
         self.assertEquals(atom.curvature, u.Curvature.CONCAVE_KEY)
         self.assertEquals(atom.sign, u.Sign.POSITIVE_KEY)
+        # Test copy with args=None
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+        # A new object is constructed, so copy.args == atom.args but copy.args
+        # is not atom.args.
+        self.assertEqual(copy.args, atom.args)
+        self.assertFalse(copy.args is atom.args)
+        self.assertEqual(copy.get_data(), atom.get_data())
+        # Test copy with new args
+        copy = atom.copy(args=[self.y])
+        self.assertTrue(type(copy) is type(atom))
+        self.assertTrue(copy.args[0] is self.y)
+        self.assertEqual(copy.get_data(), atom.get_data())
 
-    # Test the geo_mean class.
+
+    # Test the harmonic_mean class.
     def test_harmonic_mean(self):
         atom = harmonic_mean(self.x)
         self.assertEquals(atom.size, (1, 1))
         self.assertEquals(atom.curvature, u.Curvature.CONCAVE_KEY)
         self.assertEquals(atom.sign, u.Sign.POSITIVE_KEY)
 
-    # Test the geo_mean class.
+    # Test the pnorm class.
     def test_pnorm(self):
         atom = pnorm(self.x, p=1.5)
         self.assertEquals(atom.size, (1, 1))
@@ -167,6 +214,21 @@ class TestAtoms(BaseTest):
         self.assertEquals(atom.size, (1, 1))
         self.assertEquals(atom.curvature, u.Curvature.CONCAVE_KEY)
         self.assertEquals(atom.sign, u.Sign.POSITIVE_KEY)
+
+        # Test copy with args=None
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+        # A new object is constructed, so copy.args == atom.args but copy.args
+        # is not atom.args.
+        self.assertEqual(copy.args, atom.args)
+        self.assertFalse(copy.args is atom.args)
+        self.assertEqual(copy.get_data(), atom.get_data())
+        # Test copy with new args
+        copy = atom.copy(args=[self.y])
+        self.assertTrue(type(copy) is type(atom))
+        self.assertTrue(copy.args[0] is self.y)
+        self.assertEqual(copy.get_data(), atom.get_data())
+
 
     def test_quad_over_lin(self):
         # Test quad_over_lin DCP.
@@ -468,6 +530,23 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
             "M must be a non-negative scalar constant.")
 
+        # Test copy with args=None
+        atom = huber(self.x, 2)
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+        # A new object is constructed, so copy.args == atom.args but copy.args
+        # is not atom.args.
+        self.assertEqual(copy.args, atom.args)
+        self.assertFalse(copy.args is atom.args)
+        # As get_data() returns a Constant, we have to check the value
+        self.assertEqual(copy.get_data().value, atom.get_data().value)
+        # Test copy with new args
+        copy = atom.copy(args=[self.y])
+        self.assertTrue(type(copy) is type(atom))
+        self.assertTrue(copy.args[0] is self.y)
+        self.assertEqual(copy.get_data().value, atom.get_data().value)
+
+
     def test_sum_largest(self):
         """Test the sum_largest atom and related atoms.
         """
@@ -486,6 +565,25 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
             "Second argument must be a positive integer.")
 
+        # Test copy with args=None
+        atom = sum_largest(self.x, 2)
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+        # A new object is constructed, so copy.args == atom.args but copy.args
+        # is not atom.args.
+        self.assertEqual(copy.args, atom.args)
+        self.assertFalse(copy.args is atom.args)
+        self.assertEqual(copy.get_data(), atom.get_data())
+        # Test copy with new args
+        copy = atom.copy(args=[self.y])
+        self.assertTrue(type(copy) is type(atom))
+        self.assertTrue(copy.args[0] is self.y)
+        self.assertEqual(copy.get_data(), atom.get_data())
+        # Test copy with lambda_sum_largest, which is in fact an AddExpression
+        atom = lambda_sum_largest(Variable(2, 2), 2)
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+
     def test_sum_smallest(self):
         """Test the sum_smallest atom and related atoms.
         """
@@ -498,6 +596,27 @@ class TestAtoms(BaseTest):
             lambda_sum_smallest(Variable(2,2), 2.4)
         self.assertEqual(str(cm.exception),
             "Second argument must be a positive integer.")
+
+    def test_index(self):
+        """Test the copy function for index.
+        """
+        # Test copy with args=None
+        size = (5, 4)
+        A = Variable(*size)
+        atom = A[0:2, 0:1]
+        copy = atom.copy()
+        self.assertTrue(type(copy) is type(atom))
+        # A new object is constructed, so copy.args == atom.args but copy.args
+        # is not atom.args.
+        self.assertEqual(copy.args, atom.args)
+        self.assertFalse(copy.args is atom.args)
+        self.assertEqual(copy.get_data(), atom.get_data())
+        # Test copy with new args
+        B = Variable(4, 5)
+        copy = atom.copy(args=[B])
+        self.assertTrue(type(copy) is type(atom))
+        self.assertTrue(copy.args[0] is B)
+        self.assertEqual(copy.get_data(), atom.get_data())
 
     def test_bmat(self):
         """Test the bmat atom.

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -66,6 +66,19 @@ class TestConstraints(unittest.TestCase):
             (self.x == self.y)
         self.assertEqual(str(cm.exception), "Incompatible dimensions (2, 1) (3, 1)")
 
+        # Test copy with args=None
+        copy = constr.copy()
+        self.assertTrue(type(copy) is type(constr))
+        # A new object is constructed, so copy.args == constr.args but copy.args
+        # is not constr.args.
+        self.assertEqual(copy.args, constr.args)
+        self.assertFalse(copy.args is constr.args)
+        # Test copy with new args
+        copy = constr.copy(args=[self.A, self.B])
+        self.assertTrue(type(copy) is type(constr))
+        self.assertTrue(copy.args[0] is self.A)
+        self.assertTrue(copy.args[1] is self.B)
+
     def test_leq_constraint(self):
         """Test the LeqConstraint class.
         """
@@ -86,6 +99,20 @@ class TestConstraints(unittest.TestCase):
             (self.x <= self.y)
         self.assertEqual(str(cm.exception), "Incompatible dimensions (2, 1) (3, 1)")
 
+        # Test copy with args=None
+        copy = constr.copy()
+        self.assertTrue(type(copy) is type(constr))
+        # A new object is constructed, so copy.args == constr.args but copy.args
+        # is not constr.args.
+        self.assertEqual(copy.args, constr.args)
+        self.assertFalse(copy.args is constr.args)
+        # Test copy with new args
+        copy = constr.copy(args=[self.A, self.B])
+        self.assertTrue(type(copy) is type(constr))
+        self.assertTrue(copy.args[0] is self.A)
+        self.assertTrue(copy.args[1] is self.B)
+
+
     def test_psd_constraint(self):
         """Test the PSD constraint <<.
         """
@@ -104,6 +131,20 @@ class TestConstraints(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             (self.x >> self.y)
         self.assertEqual(str(cm.exception), "Non-square matrix in positive definite constraint.")
+
+        # Test copy with args=None
+        copy = constr.copy()
+        self.assertTrue(type(copy) is type(constr))
+        # A new object is constructed, so copy.args == constr.args but copy.args
+        # is not constr.args.
+        self.assertEqual(copy.args, constr.args)
+        self.assertFalse(copy.args is constr.args)
+        # Test copy with new args
+        copy = constr.copy(args=[self.B, self.A])
+        self.assertTrue(type(copy) is type(constr))
+        self.assertTrue(copy.args[0] is self.B)
+        self.assertTrue(copy.args[1] is self.A)
+
 
     def test_nsd_constraint(self):
         """Test the PSD constraint <<.

--- a/cvxpy/tests/test_objectives.py
+++ b/cvxpy/tests/test_objectives.py
@@ -57,6 +57,20 @@ class TestObjectives(unittest.TestCase):
         self.assertEqual(str(cm.exception),
             "The 'minimize' objective must resolve to a scalar.")
 
+        # Test copy with args=None
+        copy = obj.copy()
+        self.assertTrue(type(copy) is type(obj))
+        # A new object is constructed, so copy.args == obj.args but copy.args
+        # is not obj.args.
+        self.assertEqual(copy.args, obj.args)
+        self.assertFalse(copy.args is obj.args)
+        # Test copy with new args
+        copy = obj.copy(args=[square(self.z)])
+        self.assertTrue(type(copy) is type(obj))
+        self.assertTrue(copy.args[0].args[0] is self.z)
+
+
+
     # Test the Maximize class.
     def test_maximize(self):
         exp = self.x + self.z
@@ -71,6 +85,21 @@ class TestObjectives(unittest.TestCase):
             Maximize(self.y).canonical_form
         self.assertEqual(str(cm.exception),
             "The 'maximize' objective must resolve to a scalar.")
+
+        # Test copy with args=None
+        copy = obj.copy()
+        self.assertTrue(type(copy) is type(obj))
+        # A new object is constructed, so copy.args == obj.args but copy.args
+        # is not obj.args.
+        self.assertEqual(copy.args, obj.args)
+        self.assertFalse(copy.args is obj.args)
+        # Test copy with new args
+        copy = obj.copy(args=[-square(self.x)])
+        self.assertTrue(type(copy) is type(obj))
+        self.assertTrue(copy.args[0].args[0].args[0] is self.x)
+
+
+
 
     # Test is_dcp for Minimize and Maximize
     def test_is_dcp(self):


### PR DESCRIPTION
This function allows one to create a (shallow) copy of an atom, with an optional ARGS parameters to change the args of the atom.

This commit includes a a generic `copy()` function for all atoms and 4 specific `copy()` functions for AddExpression, index, power, and geo_mean.