### PR TITLE
Change MatrixCache.F to allow pickling solved problems.

### DIFF
--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -364,7 +364,7 @@ class TestProblem(BaseTest):
         prob1 = Problem(Minimize(self.a), [self.a >= self.b])
         prob2 = Problem(Minimize(2*self.b), [self.a >= 1, self.b >= 2])
         prob3 = Problem(Maximize(-pow(self.b + self.a, 2)), [self.b >= 3])
-    
+
         # simple addition and multiplication
         combo1 = prob1 + 2 * prob2
         combo1_ref = Problem(Minimize(self.a + 4 * self.b), [self.a >= self.b, self.a >= 1, self.b >= 2])
@@ -379,6 +379,14 @@ class TestProblem(BaseTest):
         combo3 = prob1 + 0 * prob2 - 3 * prob3
         combo3_ref = Problem(Minimize(self.a + 3 * pow(self.b + self.a, 2)), [self.a >= self.b, self.a >= 1, self.b >= 3])
         self.assertAlmostEqual(combo3.solve(), combo3_ref.solve())
+
+    # Test pickling solved problems.
+    def test_pickling(self):
+        import pickle
+        problem = Problem(Minimize(square(self.a)))
+        problem.solve()
+        # This will fail if MatrixCache.F is not pickleable
+        pickle.dumps(problem)
 
     # Test scalar LP problems.
     def test_scalar_lp(self):


### PR DESCRIPTION
Previously we couldn't pickle problems that are already solved, as `MatrixCache.F` is a function that cannot be pickled. I changed `MatrixCache.F` to be a function object (thanks to `functools.partial()`) to fix this. This should allow pickling and sending solved problems through `multiprocessing`.