### PR TITLE
Implement solving separable problems in parallel

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,6 +13,7 @@ requirements:
     - python
     - numpy
     - scipy
+    - multiprocess
     - toolz
     - scs
     - ecos
@@ -23,6 +24,7 @@ requirements:
     - numpy
     - scipy
     - cvxopt
+    - multiprocess
     - toolz
     - ecos
     - scs

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -61,6 +61,9 @@ MOSEK = "MOSEK"
 SOLVERS = [ECOS, ECOS_BB, CVXOPT, GLPK,
            GLPK_MI, SCS, GUROBI, ELEMENTAL, MOSEK]
 
+# Parallel (meta) solver
+PARALLEL = "parallel"
+
 # Robust CVXOPT LDL KKT solver.
 ROBUST_KKTSOLVER = "robust"
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -380,15 +380,6 @@ class TestProblem(BaseTest):
         combo3_ref = Problem(Minimize(self.a + 3 * pow(self.b + self.a, 2)), [self.a >= self.b, self.a >= 1, self.b >= 3])
         self.assertAlmostEqual(combo3.solve(), combo3_ref.solve())
 
-    # Test pickling solved problems using dill.
-    def test_pickling(self):
-        import dill as pickle
-        p = CallbackParam(lambda: self.b.value)
-        problem = Problem(Minimize(square(self.a) + p))
-        self.b.value = 2
-        # This will fail if the CallbackParam is not pickleable
-        pickle.dumps(problem, pickle.HIGHEST_PROTOCOL)
-
     # Test solving problems in parallel.
     def test_solve_parallel(self):
         p = Parameter()

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -20,7 +20,7 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 from fractions import Fraction
 import cvxpy.settings as s
 from cvxpy.atoms import *
-from cvxpy.expressions.constants import Constant, Parameter, CallbackParam
+from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variables import Variable, Semidef, Bool, Symmetric
 from cvxpy.problems.objective import *
 from cvxpy.problems.problem import Problem

--- a/cvxpy/transforms/__init__.py
+++ b/cvxpy/transforms/__init__.py
@@ -18,3 +18,4 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from cvxpy.transforms.partial_optimize import partial_optimize
+from cvxpy.transforms.separable_problems import get_separable_problems

--- a/cvxpy/transforms/separable_problems.py
+++ b/cvxpy/transforms/separable_problems.py
@@ -1,0 +1,97 @@
+"""
+Copyright 2013 Steven Diamond
+
+This file is part of CVXPY.
+
+CVXPY is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+CVXPY is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from cvxpy.problems.problem import Problem
+from cvxpy.expressions import types
+from cvxpy.expressions.constants import Constant
+
+import itertools
+from scipy.sparse import dok_matrix, csgraph
+
+
+def get_separable_problems(problem):
+    """Return a list of separable problems whose sum is the original one.
+
+    Parameters
+    ----------
+    problem : Problem
+        A problem that consists of separable (sub)problems.
+
+    Returns
+    -------
+    List
+        A list of problems which are separable whose sum is the original one.
+    """
+    # obj_terms contains the terms in the objective functions. We have to
+    # deal with the special case where the objective function is not a sum.
+    if isinstance(problem.objective.args[0], types.add_expr()):
+        obj_terms = problem.objective.args[0].args
+    else:
+        obj_terms = [problem.objective.args[0]]
+    # Remove constant terms, which will be appended to the first separable
+    # problem.
+    constant_terms = [term for term in obj_terms if term.is_constant()]
+    obj_terms = [term for term in obj_terms if not term.is_constant()]
+
+    constraints = problem.constraints
+    num_obj_terms = len(obj_terms)
+    num_terms = len(obj_terms) + len(constraints)
+
+    # Objective terms and constraints are indexed from 0 to num_terms - 1.
+    var_sets = [frozenset(func.variables()) for func in obj_terms + constraints
+                ]
+    all_vars = frozenset().union(*var_sets)
+
+    adj_matrix = dok_matrix((num_terms, num_terms), dtype=bool)
+    for var in all_vars:
+        # Find all functions that contain this variable
+        term_ids = [i for i, var_set in enumerate(var_sets) if var in var_set]
+        # Add an edge between any two objetive terms/constraints sharing
+        # this variable.
+        if len(term_ids) > 1:
+            for i, j in itertools.combinations(term_ids, 2):
+                adj_matrix[i, j] = adj_matrix[j, i] = True
+    num_components, labels = csgraph.connected_components(adj_matrix,
+                                                          directed=False)
+
+    # After splitting, construct subproblems from appropriate objective
+    # terms and constraints.
+    term_ids_per_subproblem = [[] for _ in range(num_components)]
+    for i, label in enumerate(labels):
+        term_ids_per_subproblem[label].append(i)
+    problem_list = []
+    for index in range(num_components):
+        terms = [obj_terms[i] for i in term_ids_per_subproblem[index]
+                 if i < num_obj_terms]
+        # If we just call sum, we'll have an extra 0 in the objective.
+        obj = sum(terms[1:], terms[0]) if terms else Constant(0)
+        constrs = [constraints[i - num_obj_terms]
+                   for i in term_ids_per_subproblem[index]
+                   if i >= num_obj_terms]
+        problem_list.append(Problem(problem.objective.copy([obj]), constrs))
+    # Append constant terms to the first separable problem.
+    if constant_terms:
+        # Avoid adding an extra 0 in the objective
+        sum_constant_terms = sum(constant_terms[1:], constant_terms[0])
+        if problem_list:
+            problem_list[0].objective.args[0] += sum_constant_terms
+        else:
+            problem_list.append(Problem(problem.objective.copy(
+                [sum_constant_terms])))
+    return problem_list

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -134,6 +134,7 @@ CVXPY has the following dependencies:
 * Python 2.7 or Python 3.4
 * `setuptools`_ >= 1.4
 * `toolz`_
+* `multiprocess`_
 * `CVXOPT`_ >= 1.1.6
 * `ECOS`_ >= 2
 * `SCS`_ >= 1.0.1
@@ -143,11 +144,10 @@ CVXPY has the following dependencies:
 
 To test the CVXPY installation, you additionally need `Nose`_.
 
-CVXPY automatically installs `ECOS`_, `CVXOPT`_, `SCS`_, and `toolz`_.
-`NumPy`_ and `SciPy`_ will need to be installed manually.
-You may also need to install `Swig`_ to build `CVXcanon`_.
-Once you’ve
-installed `NumPy`_, `SciPy`_, and `Swig`_, installing CVXPY from source is simple:
+CVXPY automatically installs `ECOS`_, `CVXOPT`_, `SCS`_, `toolz`_, and
+`multiprocess`_. `NumPy`_ and `SciPy`_ will need to be installed manually. You
+may also need to install `Swig`_ to build `CVXcanon`_. Once you’ve installed
+`NumPy`_, `SciPy`_, and `Swig`_, installing CVXPY from source is simple:
 
 1. Clone the `CVXPY git repository`_.
 2. Navigate to the top-level of the cloned directory and run
@@ -192,6 +192,7 @@ See the `Elemental <http://libelemental.org/>`_ website for installation instruc
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
 .. _website: https://store.continuum.io/cshop/anaconda/
 .. _setuptools: https://pypi.python.org/pypi/setuptools
+.. _multiprocess: https://github.com/uqfoundation/multiprocess/
 .. _toolz: http://github.com/pytoolz/toolz/
 .. _CVXOPT: http://cvxopt.org/
 .. _ECOS: http://github.com/ifa-ethz/ecos

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
                       "toolz",
                       "numpy >= 1.8",
                       "scipy >= 0.13",
-                      "CVXcanon >= 0.0.21"],
+                      "CVXcanon >= 0.0.22"],
     use_2to3=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     install_requires=["cvxopt >= 1.1.6",
                       "ecos >= 2",
                       "scs >= 1.1.3",
+                      "multiprocess",
                       "toolz",
                       "numpy >= 1.8",
                       "scipy >= 0.13",


### PR DESCRIPTION
If problem is separable, we split it into smaller problems and solve them in parallel.
To enable the option, run `problem.solve(parallel=True)`.

I cache the separable problems (as a list) by decorating `problem._separable_problems` with `lazyprop`. I'm still not sure how I should detect if the objective or constraint has changed to recompute these separable problems.