### PR TITLE
in parade route example, store solution as `xsol`

### DIFF
--- a/examples/notebooks/WWW/parade_route.ipynb
+++ b/examples/notebooks/WWW/parade_route.ipynb
@@ -298,7 +298,8 @@
       "    w = 2/(tau+np.abs(x))\n",
       "    fig = plt.figure(figsize=(5,5))\n",
       "    ax = fig.add_subplot(111)\n",
-      "    ax.plot(x,'o')"
+      "    ax.plot(x,'o')\n",
+      "xsol = x"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
The parade route example doesn't run the last cell correctly since `xsol` isn't defined. This simply fixes that. Now the notebook runs without error for me.

I suppose to verify, you can download and run the file.
https://raw.githubusercontent.com/jwkvam/cvxpy/fix-parade-route/examples/notebooks/WWW/parade_route.ipynb