### PR TITLE
GLPK_MI setting solver params

### DIFF
--- a/cvxpy/problems/solvers/glpk_mi_intf.py
+++ b/cvxpy/problems/solvers/glpk_mi_intf.py
@@ -73,19 +73,19 @@ class GLPK_MI(GLPK):
         import cvxopt, cvxopt.glpk
         data = self.get_problem_data(objective, constraints, cached_data)
         # Save original cvxopt solver options.
-        old_options = cvxopt.solvers.options.copy()
+        old_options = cvxopt.glpk.options.copy()
         # Silence cvxopt if verbose is False.
         if verbose:
-            cvxopt.solvers.options["msg_lev"] = "GLP_MSG_ON"
+            cvxopt.glpk.options["msg_lev"] = "GLP_MSG_ON"
         else:
-            cvxopt.solvers.options["msg_lev"] = "GLP_MSG_OFF"
+            cvxopt.glpk.options["msg_lev"] = "GLP_MSG_OFF"
 
         # Apply any user-specific options.
         # Rename max_iters to maxiters.
         if "max_iters" in solver_opts:
             solver_opts["maxiters"] = solver_opts["max_iters"]
         for key, value in solver_opts.items():
-            cvxopt.solvers.options[key] = value
+            cvxopt.glpk.options[key] = value
 
         try:
             results_tup = cvxopt.glpk.ilp(data[s.C],
@@ -133,3 +133,11 @@ class GLPK_MI(GLPK):
             new_results[s.VALUE] = primal_val + data[s.OFFSET]
 
         return new_results
+
+    def _restore_solver_options(self, old_options):
+        import cvxopt.glpk
+        for key, value in list(cvxopt.glpk.options.items()):
+            if key in old_options:
+                cvxopt.glpk.options[key] = old_options[key]
+            else:
+                del cvxopt.glpk.options[key]

--- a/cvxpy/tests/test_solvers.py
+++ b/cvxpy/tests/test_solvers.py
@@ -129,7 +129,7 @@ class TestSolvers(BaseTest):
             int_var = Int()
             prob = Problem(Minimize(norm(self.x, 1)),
                         [self.x == bool_var, bool_var == 0])
-            prob.solve(solver = GLPK_MI)
+            prob.solve(solver = GLPK_MI, verbose=True)
             self.assertAlmostEqual(prob.value, 0)
             self.assertAlmostEqual(bool_var.value, 0)
             self.assertItemsAlmostEqual(self.x.value, [0, 0])
@@ -143,7 +143,7 @@ class TestSolvers(BaseTest):
                             int_var == 3*bool_var,
                             int_var == 3]
             prob = Problem(objective, constraints)
-            prob.solve(solver = GLPK_MI)
+            prob.solve(solver = GLPK_MI, verbose=True)
             self.assertAlmostEqual(prob.value, -9)
             self.assertAlmostEqual(int_var.value, 3)
             self.assertAlmostEqual(bool_var.value, 1)


### PR DESCRIPTION
Resolves #251 for GLPK_MI. Params need to be explicitly set to cvxopt.glpk.options rather than cvxopt.solvers.options since glpk.ilp is not part of cvxopt LP solvers. 



