### PR TITLE
add axis parameter to pnorm(x, 2)

### DIFF
--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -134,7 +134,17 @@ class pnorm(AxisAtom):
         if self.p < 0 and np.any(values == 0):
             return 0.0
 
-        return np.linalg.norm(values, float(self.p), axis=self.axis, keepdims=True)
+        retval = np.linalg.norm(values, float(self.p), axis=self.axis)
+
+        # NOTE: workaround for NumPy <=1.9 and no keepdims for norm()
+        if self.axis is not None:
+            if self.axis == 0:
+                retval = np.reshape(retval, (1, self.args[0].size[1]))
+            else:  # self.axis == 1:
+                retval = np.reshape(retval, (self.args[0].size[0], 1))
+
+        return retval
+
 
     def validate_arguments(self):
         super(pnorm, self).validate_arguments()

--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -288,7 +288,7 @@ class pnorm(AxisAtom):
                 t = lu.create_var(size)
                 return t, [SOC_Elemwise(
                     t, [lu.index(x, size, (slice(0, x.size[0]), slice(i, i+1)))
-                        for i in xrange(x.size[1])])]
+                        for i in range(x.size[1])])]
 
         if p == np.inf:
             t_ = lu.promote(t, x.size)

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -147,6 +147,8 @@ atoms = [
         (pnorm, (1, 1), [[1, 2, 3]], Constant([3.7416573867739413])),
         (lambda x: pnorm(x, 1), (1, 1), [[1.1, 2, -3]], Constant([6.1])),
         (lambda x: pnorm(x, 2), (1, 1), [[1.1, 2, -3]], Constant([3.7696153649941531])),
+        (lambda x: pnorm(x, 2, axis=0), (1, 2), [ [[1,2],[3,4]] ], Constant([math.sqrt(5), 5.]).T),
+        (lambda x: pnorm(x, 2, axis=1), (2, 1), [ [[1,2],[4,5]] ], Constant([math.sqrt(17), math.sqrt(29)])),
         (lambda x: pnorm(x, 'inf'), (1, 1), [[1.1, 2, -3]], Constant([3])),
         (lambda x: pnorm(x, 3), (1, 1), [[1.1, 2, -3]], Constant([3.3120161866074733])),
         (lambda x: pnorm(x, 5.6), (1, 1), [[1.1, 2, -3]], Constant([3.0548953718931089])),


### PR DESCRIPTION
Hi Steven,

This makes it much easier to write sum-of-norms regularization e.g. without unrolling the sum (for example, network lasso paper you dont need |E| terms, http://web.stanford.edu/~hallac/Network_Lasso.pdf)

This is consistent with how linalg.norm() works, although i just added the code for p=2 for now.

Cheers,
Matt