### PR TITLE
Fix geo_mean bug where row vector input (hstack) wasn't working properly.

### DIFF
--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -313,7 +313,11 @@ class geo_mean(Atom):
         """
         w, w_dyad, tree = data
         t = lu.create_var((1, 1))
-        x_list = [index.get_index(arg_objs[0], [], i, 0) for i in range(len(w))]
+
+        if arg_objs[0].size[1] == 1:
+            x_list = [index.get_index(arg_objs[0], [], i, 0) for i in range(len(w))]
+        if arg_objs[0].size[0] == 1:
+            x_list = [index.get_index(arg_objs[0], [], 0, i) for i in range(len(w))]
 
         #todo: catch cases where we have (0, 0, 1)?
         #todo: what about curvature case (should be affine) in trivial case of (0, 0 , 1), should this behavior match with what we do in power?

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1446,6 +1446,27 @@ class TestProblem(BaseTest):
         self.assertTrue(np.allclose(prob.value, short_geo_mean(x, p)))
         self.assertTrue(np.allclose(x, x_true, 1e-3))
 
+        # the following 3 tests check vstack and hstack input to geo_mean
+        # the following 3 formulations should be equivalent
+        n = 5
+        x_true = np.ones(n)
+        x = Variable(n)
+
+        Problem(Maximize(geo_mean(x)), [x <= 1]).solve()
+        xval = np.array(x.value).flatten()
+        self.assertTrue(np.allclose(xval, x_true, 1e-3))
+
+        y = vstack(*[x[i] for i in range(n)])
+        Problem(Maximize(geo_mean(y)), [x <= 1]).solve()
+        xval = np.array(x.value).flatten()
+        self.assertTrue(np.allclose(xval, x_true, 1e-3))
+
+        y = hstack(*[x[i] for i in range(n)])
+        Problem(Maximize(geo_mean(y)), [x <= 1]).solve()
+        xval = np.array(x.value).flatten()
+        self.assertTrue(np.allclose(xval, x_true, 1e-3))
+
+
     def test_pnorm(self):
         import numpy as np
 


### PR DESCRIPTION
@SteveDiamond, my changes in geo_mean.py to detect and handle row and column vectors differently might be a hack. Is there a better way to do that?