### PR TITLE
quad_form to allow indefinite and asymmetric matrices

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -18,6 +18,7 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import cvxpy.interface as intf
+import warnings
 from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.constants import Constant
 from .sum_squares import sum_squares
@@ -55,32 +56,32 @@ def _decomp_quad(P, cond=None, rcond=None, lower=True, check_finite=True):
 
     Returns
     -------
-    sgn : -1 or 1
-        1 if P is positive (semi)definite otherwise -1
     scale : float
         induced matrix 2-norm of P
-    M : 2d ndarray
-        A rectangular ndarray such that P = sgn * scale * dot(M, M.T)
+    M1, M2 : 2d ndarray
+        A rectangular ndarray such that P = scale * (dot(M1, M1.T) - dot(M2, M2.T))
 
     """
+
     w, V = LA.eigh(P, lower=lower, check_finite=check_finite)
-    abs_w = np.absolute(w)
-    sgn_w = np.sign(w)
-    scale, sgn = max(zip(np.absolute(w), np.sign(w)))
+
     if rcond is not None:
         cond = rcond
     if cond in (None, -1):
         t = V.dtype.char.lower()
-        factor = {'f': 1e3, 'd':1e6}
+        factor = {'f': 1e3, 'd': 1e6}
         cond = factor[t] * np.finfo(t).eps
-    scaled_abs_w = abs_w / scale
-    mask = scaled_abs_w > cond
+
+    scale = max(np.absolute(w))
+    w_scaled = w / scale
+    maskp = w_scaled > cond
+    maskn = w_scaled < -cond
     # TODO: allow indefinite quad_form
-    if np.any(w[mask] * sgn < 0):
-        msg = 'P has both positive and negative eigenvalues.'
-        raise CvxPyDomainError(msg)
-    M = V[:, mask] * np.sqrt(scaled_abs_w[mask])
-    return sgn, scale, M
+    if np.any(maskp) and np.any(maskn):
+        warnings.warn("Forming a nonconvex expression quad_form(x, indefinite).")
+    M1 = V[:, maskp] * np.sqrt(w_scaled[maskp])
+    M2 = V[:, maskn] * np.sqrt(-w_scaled[maskn])
+    return scale, M1, M2
 
 def quad_form(x, P):
     """ Alias for :math:`x^T P x`.
@@ -100,7 +101,12 @@ def quad_form(x, P):
         if not np.allclose(P, P.T):
             msg = "P is not symmetric."
             raise CvxPyDomainError(msg)
-        sgn, scale, M = _decomp_quad(P)
-        return sgn * scale * sum_squares(Constant(M.T) * x)
+        scale, M1, M2 = _decomp_quad(P)
+        ret = 0
+        if M1.size > 0:
+            ret += scale * sum_squares(Constant(M1.T) * x)
+        if M2.size > 0:
+            ret -= scale * sum_squares(Constant(M2.T) * x)
+        return ret
     else:
         raise Exception("At least one argument to quad_form must be constant.")

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from __future__ import division
 import cvxpy.interface as intf
 import warnings
 from cvxpy.expressions.expression import Expression
@@ -97,10 +98,8 @@ def quad_form(x, P):
     elif P.is_constant():
         np_intf = intf.get_matrix_interface(np.ndarray)
         P = np_intf.const_to_matrix(P.value)
-        # P must be symmetric.
-        if not np.allclose(P, P.T):
-            msg = "P is not symmetric."
-            raise CvxPyDomainError(msg)
+        # Force symmetry
+        P = (P + P.T) / 2.0
         scale, M1, M2 = _decomp_quad(P)
         ret = 0
         if M1.size > 0:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -701,7 +701,7 @@ class TestProblem(BaseTest):
 
         with self.assertRaises(Exception) as cm:
             Problem(Minimize(quad_form(self.x, [[-1, 0], [0, 9]]))).solve()
-        self.assertEqual(str(cm.exception), "P has both positive and negative eigenvalues.")
+        self.assertEqual(str(cm.exception), "Problem does not follow DCP rules.")
 
         P = [[4, 0], [0, 9]]
         p = Problem(Minimize(quad_form(self.x, P)), [self.x >= 1])

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -38,6 +38,7 @@ import sys
 import scs
 import cvxopt.solvers
 import ecos
+import warnings
 PY2 = sys.version_info < (3, 0)
 if sys.version_info < (3, 0):
     from cStringIO import StringIO
@@ -699,9 +700,11 @@ class TestProblem(BaseTest):
             Problem(Minimize(quad_form(1, self.A))).solve()
         self.assertEqual(str(cm.exception), "Invalid dimensions for arguments.")
 
-        with self.assertRaises(Exception) as cm:
-            Problem(Minimize(quad_form(self.x, [[-1, 0], [0, 9]]))).solve()
-        self.assertEqual(str(cm.exception), "Problem does not follow DCP rules.")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with self.assertRaises(Exception) as cm:
+                Problem(Minimize(quad_form(self.x, [[-1, 0], [0, 9]]))).solve()
+            self.assertEqual(str(cm.exception), "Problem does not follow DCP rules.")
 
         P = [[4, 0], [0, 9]]
         p = Problem(Minimize(quad_form(self.x, P)), [self.x >= 1])

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -58,29 +58,30 @@ class TestNonOptimal(BaseTest):
     def test_sparse_quad_form(self):
         """Test quad form with a sparse matrix.
         """
-        Q = cvxopt.spdiag([1,1])
-        x = cvxpy.Variable(2,1)
-        cost = cvxpy.quad_form(x,Q)
-        prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1,2]])
+        Q = cvxopt.spdiag([1, 1])
+        x = cvxpy.Variable(2)
+        cost = cvxpy.quad_form(x, Q)
+        prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
         self.assertAlmostEqual(prob.solve(), 5)
 
     def test_non_symmetric(self):
-        """Test error when P is constant and not symmetric.
+        """Test when P is constant and not symmetric.
         """
-        P = np.array([[1, 2], [3, 4]])
-        x = cvxpy.Variable(2,1)
-        with self.assertRaises(Exception) as cm:
-            cvxpy.quad_form(x,P)
-        self.assertEqual(str(cm.exception),
-            "P is not symmetric.")
+        P = np.array([[2, 2], [3, 4]])
+        x = cvxpy.Variable(2)
+        cost = cvxpy.quad_form(x, P)
+        prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
+        self.assertAlmostEqual(prob.solve(), 28)
 
     def test_non_psd(self):
         """Test error when P is symmetric but not definite.
         """
         P = np.array([[1, 0], [0, -1]])
-        x = cvxpy.Variable(2,1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            cvxpy.quad_form(x, P)
-            self.assertEqual(str(w[-1].message),
-                "Forming a nonconvex expression quad_form(x, indefinite).")
+        x = cvxpy.Variable(2)
+        # Forming quad_form is okay
+        cost = cvxpy.quad_form(x, P)
+        prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
+        with self.assertRaises(Exception) as cm:
+            prob.solve()
+        self.assertEqual(str(cm.exception), "Problem does not follow DCP rules.")
+        

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose, assert_equal
 from scipy import linalg
 import cvxopt
 import cvxpy
+import warnings
 
 from cvxpy.tests.base_test import BaseTest
 
@@ -78,7 +79,8 @@ class TestNonOptimal(BaseTest):
         """
         P = np.array([[1, 0], [0, -1]])
         x = cvxpy.Variable(2,1)
-        with self.assertRaises(Exception) as cm:
-            cvxpy.quad_form(x,P)
-        self.assertEqual(str(cm.exception),
-            "P has both positive and negative eigenvalues.")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cvxpy.quad_form(x, P)
+            self.assertEqual(str(w[-1].message),
+                "Forming a nonconvex expression quad_form(x, indefinite).")

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -79,7 +79,9 @@ class TestNonOptimal(BaseTest):
         P = np.array([[1, 0], [0, -1]])
         x = cvxpy.Variable(2)
         # Forming quad_form is okay
-        cost = cvxpy.quad_form(x, P)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cost = cvxpy.quad_form(x, P)
         prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
         with self.assertRaises(Exception) as cm:
             prob.solve()


### PR DESCRIPTION
Some changes to quad_form and related test scripts.

1. Allow asymmetric P: This change is not necessary, but since ``x^T P x`` is a scalar anyway, the specification is unambiguous even when P is asymmetric. This is handled by setting ``P = (P+P^T)/2`` internally and should not touch the original data.
2. Allow indefinite P, but with a warning message: Currently quad_form rejects P with both positive and negative eigenvalues. The behavior of quad_form doesn't change when P is positive or negative semidefinite. With the proposed change, users can use indefinite P, but will get a warning message when that happens. quad_form will then return a difference of convex function. More specifically, when ``P = M1*M1^T - M2*M2^T``, ``quad_form(x, P)`` returns ``sum_squares(M1^T * x) - sum_squares(M2^T * x)``.