### PR TITLE
Add support for tuning MOSEK optimizer parameters

### DIFF
--- a/cvxpy/problems/solvers/mosek_intf.py
+++ b/cvxpy/problems/solvers/mosek_intf.py
@@ -130,7 +130,12 @@ class MOSEK(Solver):
         env = mosek.Env()
         task = env.Task(0, 0)
 
-        self._handle_mosek_params(task, solver_opts.get("mosek_params"))
+        kwargs = sorted(solver_opts.keys())
+        if "mosek_params" in kwargs:
+            self._handle_mosek_params(task, solver_opts["mosek_params"])
+            kwargs.remove("mosek_params")
+        if kwargs:
+            raise ValueError("Invalid keyword-argument '%s'" % kwargs[0])
 
         if verbose:
             # Define a stream printer to grab output from MOSEK

--- a/cvxpy/tests/test_solvers.py
+++ b/cvxpy/tests/test_solvers.py
@@ -425,6 +425,32 @@ class TestSolvers(BaseTest):
                 prob.solve(solver = MOSEK)
             self.assertEqual(str(cm.exception), "The solver %s is not installed." % MOSEK)
 
+    def test_mosek_params(self):
+        if MOSEK in installed_solvers():
+            import numpy as np
+            import numpy.random as rnd
+            import mosek
+
+            n = 10
+            m = 4
+            A = rnd.randn(m, n)
+            x = rnd.randn(n)
+            y = A.dot(x)
+
+            z = Variable(n)
+            objective = Minimize(norm1(z))
+            constraints = [A * z == y[:, np.newaxis]]
+            problem = Problem(objective, constraints)
+            invalid_mosek_params = {
+                "dparam.basis_tol_x": "1e-8"
+            }
+            mosek_params = {
+                mosek.dparam.basis_tol_x: 1e-8,
+                "MSK_IPAR_INTPNT_MAX_ITERATIONS": 20
+            }
+            with self.assertRaises(ValueError):
+                problem.solve(solver=MOSEK, mosek_params=invalid_mosek_params)
+            problem.solve(solver=MOSEK, mosek_params=mosek_params)
 
     def test_gurobi_warm_start(self):
         """Make sure that warm starting Gurobi behaves as expected

--- a/cvxpy/tests/test_solvers.py
+++ b/cvxpy/tests/test_solvers.py
@@ -437,19 +437,25 @@ class TestSolvers(BaseTest):
             x = rnd.randn(n)
             y = A.dot(x)
 
+            # Solve a simple basis pursuit problem for testing purposes.
             z = Variable(n)
             objective = Minimize(norm1(z))
             constraints = [A * z == y[:, np.newaxis]]
             problem = Problem(objective, constraints)
+
             invalid_mosek_params = {
                 "dparam.basis_tol_x": "1e-8"
             }
+            with self.assertRaises(ValueError):
+                problem.solve(solver=MOSEK, mosek_params=invalid_mosek_params)
+
+            with self.assertRaises(ValueError):
+                problem.solve(solver=MOSEK, invalid_kwarg=None)
+
             mosek_params = {
                 mosek.dparam.basis_tol_x: 1e-8,
                 "MSK_IPAR_INTPNT_MAX_ITERATIONS": 20
             }
-            with self.assertRaises(ValueError):
-                problem.solve(solver=MOSEK, mosek_params=invalid_mosek_params)
             problem.solve(solver=MOSEK, mosek_params=mosek_params)
 
     def test_gurobi_warm_start(self):

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -231,7 +231,7 @@ The table below shows the types of problems the solvers can handle.
 | `SCS`_       | X  | X    | X   | X   |     |
 +--------------+----+------+-----+-----+-----+
 
-A special solver `LS`_ is also available. It is unable to solve any of the problem types in the table above, but it recognizes and solves linearly constrained least squares problems very quickly. 
+A special solver `LS`_ is also available. It is unable to solve any of the problem types in the table above, but it recognizes and solves linearly constrained least squares problems very quickly.
 
 Here EXP refers to problems with exponential cone constraints. The exponential cone is defined as
 
@@ -345,7 +345,7 @@ All the solvers can print out information about their progress while solving the
 Setting solver options
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The `ECOS`_, `ECOS_BB`_, `CBC`_, `CVXOPT`_, and `SCS`_ Python interfaces allow you to set solver options such as the maximum number of iterations. You can pass these options along through CVXPY as keyword arguments.
+The `ECOS`_, `ECOS_BB`_, `MOSEK`_, `CBC`_, `CVXOPT`_, and `SCS`_ Python interfaces allow you to set solver options such as the maximum number of iterations. You can pass these options along through CVXPY as keyword arguments.
 
 For example, here we tell SCS to use an indirect method for solving linear equations rather than a direct method.
 
@@ -423,6 +423,15 @@ Here's the complete list of solver options.
 
 ``'mi_rel_eps'``
     relative tolerance, (U-L)/L, between upper and lower bounds (default: 1e-3)
+
+`MOSEK`_ options:
+
+``'mosek_params'``
+    A dictionary of MOSEK parameters. Refer to MOSEK's Python or C API for
+    details. Note that if parameters are given as string-value pairs, parameter
+    names must be of the form ``'MSK_DPAR_BASIS_TOL_X'`` as in the C API.
+    Alternatively, Python enum options like ``'mosek.dparam.basis_tol_x'`` are
+    also supported.
 
 `CVXOPT`_ options:
 


### PR DESCRIPTION
I recently ran into an issue where cvxpy would return infeasible solutions despite reporting an optimal solution status when using MOSEK. Since I wanted to play around with the optimizer parameters, I checked the cvxpy docs and realized there was currently no way to override MOSEK's default parameters, so I hacked up a quick patch to add support for doing so.