### PR TITLE
callback params now store the atom they represent, not just cb function

### DIFF
--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -153,7 +153,7 @@ class Atom(Expression):
             # Parameterized expressions are evaluated later.
             if self.parameters():
                 rows, cols = self.size
-                param = CallbackParam(lambda: self.value, rows, cols)
+                param = CallbackParam(self, rows, cols)
                 return param.canonical_form
             # Non-parameterized expressions are evaluated immediately.
             else:

--- a/cvxpy/expressions/constants/callback_param.py
+++ b/cvxpy/expressions/constants/callback_param.py
@@ -26,18 +26,18 @@ class CallbackParam(Parameter):
     """
     PARAM_COUNT = 0
 
-    def __init__(self, callback, rows=1, cols=1, name=None, sign="unknown"):
-        self._callback = callback
+    def __init__(self, atom, rows=1, cols=1, name=None, sign="unknown"):
+        self.atom = atom
         super(CallbackParam, self).__init__(rows, cols, name, sign)
 
     @property
     def value(self):
         """Evaluate the callback to get the value.
         """
-        return self._validate_value(self._callback())
+        return self._validate_value(self.atom.value)
 
     def get_data(self):
         """Returns info needed to reconstruct the expression besides the args.
         """
-        return [self._callback, self._rows, self._cols,
+        return [self.atom, self._rows, self._cols,
                 self._name, self.sign_str]


### PR DESCRIPTION
Doesn't change much, but is helpful for codegen.