### PR TITLE
Prepare SuiteSparse to install CVXOPT for testing on CI services

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -40,6 +40,11 @@ if [[ "$DISTRIB" == "conda" ]]; then
     pip install flake8
 
     if [[ "$INSTALL_GLPK" == "true" ]]; then
+
+        wget http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.5.3.tar.gz
+        tar -xf SuiteSparse-4.5.3.tar.gz
+        export CVXOPT_SUITESPARSE_SRC_DIR=$(pwd)/SuiteSparse
+
         # Install GLPK.
         wget http://ftp.gnu.org/gnu/glpk/glpk-4.60.tar.gz
         tar -zxvf glpk-4.60.tar.gz


### PR DESCRIPTION
According to [the installation issues related to CVXOPT v1.1.9](https://github.com/cvxopt/cvxopt/issues/79), we need SuiteSparse to install CVXOPT. This pull request edits continuous_integration/install.sh to do so.

Based on [the discussion about having the option to fetch SuiteSparse automatically](https://github.com/cvxopt/cvxopt/issues/80), we shouldn't need it for long. Until then, this prepares SuiteSparse.