### PR TITLE
example: consensus ADMM: add missing variables

### DIFF
--- a/examples/consensus_admm.py
+++ b/examples/consensus_admm.py
@@ -5,6 +5,8 @@ from multiprocessing import Pool
 # Problem data.
 m = 100
 n = 75
+gamma = 1.0
+NUM_PROCS = 2
 np.random.seed(1)
 A = np.random.randn(m, n)
 b = np.random.randn(m, 1)


### PR DESCRIPTION
The consensus ADMM example was missing two variables: gamma (for
weighting the L_1 norm) and NUM_PROCS (the number of threads of the
multiprocessing pool).

Related: since I've noticed multiple examples with similar issues (i.e. missing problem variables), would the maintainers prefer a bulk PR that attempts to update all the example scripts? Or one PR per example?