### PR TITLE
examples: ADMM Lasso: fix missing variables

### DIFF
--- a/examples/admm_lasso.py
+++ b/examples/admm_lasso.py
@@ -5,6 +5,8 @@ from multiprocessing import Pool
 # Problem data.
 m = 100
 n = 75
+gamma = 1.0
+NUM_PROCS = 2
 np.random.seed(1)
 A = np.random.randn(m, n)
 b = np.random.randn(m, 1)


### PR DESCRIPTION
Similar to #324, this PR fixes an issue in the ADMM Lasso example where variables gamma and NUM_PROCS were previously undefined.

@SteveDiamond Looks like I may have been mistaken about how many examples needed updating. At the moment, it seems only ADMM Lasso had the same issue.