### PR TITLE
ENH: Clearer error when rejecting a solver.

### DIFF
--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -176,13 +176,17 @@ class TestProblem(BaseTest):
         self.assertGreater(stats.setup_time, 0)
         self.assertGreater(stats.num_iters, 0)
 
-        
     def test_get_problem_data(self):
         """Test get_problem_data method.
         """
         with self.assertRaises(Exception) as cm:
             Problem(Maximize(Bool())).get_problem_data(s.ECOS)
-        self.assertEqual(str(cm.exception), "The solver ECOS cannot solve the problem.")
+
+        expected = (
+            "The solver ECOS cannot solve the problem because"
+            " it cannot solve mixed-integer problems."
+        )
+        self.assertEqual(str(cm.exception), expected)
 
         data = Problem(Maximize(exp(self.a) + 2)).get_problem_data(s.SCS)
         dims = data["dims"]
@@ -1263,18 +1267,30 @@ class TestProblem(BaseTest):
         """
         with self.assertRaises(Exception) as cm:
             Problem(Minimize(Bool())).solve(solver=s.ECOS)
-        self.assertEqual(str(cm.exception),
-                         "The solver ECOS cannot solve the problem.")
+
+        expected = (
+            "The solver ECOS cannot solve the problem "
+            "because it cannot solve mixed-integer problems."
+        )
+        self.assertEqual(str(cm.exception), expected)
 
         with self.assertRaises(Exception) as cm:
             Problem(Minimize(lambda_max(self.a))).solve(solver=s.ECOS)
-        self.assertEqual(str(cm.exception),
-                         "The solver ECOS cannot solve the problem.")
+
+        expected = (
+            "The solver ECOS cannot solve the problem "
+            "because it cannot solve semidefinite problems."
+        )
+        self.assertEqual(str(cm.exception), expected)
 
         with self.assertRaises(Exception) as cm:
             Problem(Minimize(self.a)).solve(solver=s.SCS)
-        self.assertEqual(str(cm.exception),
-                         "The solver SCS cannot solve the problem.")
+
+        expected = (
+            "The solver SCS cannot solve the problem "
+            "because it cannot solve unconstrained problems."
+        )
+        self.assertEqual(str(cm.exception), expected)
 
     def test_reshape(self):
         """Tests problems with reshape.


### PR DESCRIPTION
Provide a specific error indicating why a given solver was rejected
rather than a generic "could not solve problem" error.

Before/After:

```
(cvxpy) [~/quantopian/cvxpy]@(master:7deee4d172)$ python repro.py
Traceback (most recent call last):
  File "repro.py", line 11, in <module>
    problem.solve(solver='SCS')
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/problem.py", line 207, in solve
    return self._solve(*args, **kwargs)
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/problem.py", line 319, in _solve
    solver.validate_solver(constraints)
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/solvers/solver.py", line 137, in validate_solver
    "The solver %s cannot solve the problem." % self.name()
cvxpy.error.SolverError: The solver SCS cannot solve the problem.

(cvxpy) [~/quantopian/cvxpy]@(master:7deee4d172)$ pb
Switched to branch 'give-a-reason-when-solver-is-rejected'

(cvxpy) [~/quantopian/cvxpy]@(give-a-reason-when-solver-is-rejected:31982de1b0)$ python repro.py
Traceback (most recent call last):
  File "repro.py", line 11, in <module>
    problem.solve(solver='SCS')
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/problem.py", line 207, in solve
    return self._solve(*args, **kwargs)
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/problem.py", line 319, in _solve
    solver.validate_solver(constraints)
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/solvers/solver.py", line 139, in validate_solver
    self._reject_problem("it cannot solve unconstrained problems")
  File "/home/ssanderson/quantopian/cvxpy/cvxpy/problems/solvers/solver.py", line 158, in _reject_problem
    raise SolverError(message)
cvxpy.error.SolverError: The solver SCS cannot solve the problem because it cannot solve unconstrained problems.
```