### PR TITLE
fixed issue 364

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ env_*
 
 # pycharm
 .idea
+*.pyproj

--- a/cvxpy/expressions/variables/bool_var.py
+++ b/cvxpy/expressions/variables/bool_var.py
@@ -30,13 +30,3 @@ class Bool(Variable):
         """String to recreate the object.
         """
         return "Bool(%d, %d)" % self.size
-
-    def is_positive(self):
-        """Is the expression positive?
-        """
-        return True
-
-    def is_negative(self):
-        """Is the expression negative?
-        """
-        return False


### PR DESCRIPTION
After upgrading cvxpy from version 0.3.4 to 0.4.10 the mixed integer optimisation using ECOS_BB seems to be failing with an error "ValueError: Invalid sign for Bool value". The problem is caused by the method is_positive() which now returns True. Bool is neither positive nor negative though. 

The method is_negative() override returns the same value as the base class version (Variable class) so it's redundant. 

Original issue:  https://github.com/cvxgrp/cvxpy/issues/364 