### PR TITLE
EHN Show names in repr, if provided.

### DIFF
--- a/cvxpy/expressions/variables/bool_var.py
+++ b/cvxpy/expressions/variables/bool_var.py
@@ -26,14 +26,6 @@ class Bool(Variable):
         obj, constr = super(Bool, self).canonicalize()
         return (obj, constr + [BoolConstr(obj)])
 
-    def __repr__(self):
-        """String to recreate the object.
-        """
-        if self._name_given:
-            return "Bool(%d, %d, '%s')" % (self._rows, self._cols, self._name)
-        else:
-            return "Bool(%d, %d)" % self.size
-
     def is_positive(self):
         """Is the expression positive?
         """

--- a/cvxpy/expressions/variables/bool_var.py
+++ b/cvxpy/expressions/variables/bool_var.py
@@ -29,7 +29,10 @@ class Bool(Variable):
     def __repr__(self):
         """String to recreate the object.
         """
-        return "Bool(%d, %d)" % self.size
+        if self._name_given:
+            return "Bool(%d, %d, '%s')" % (self._rows, self._cols, self._name)
+        else:
+            return "Bool(%d, %d)" % self.size
 
     def is_positive(self):
         """Is the expression positive?

--- a/cvxpy/expressions/variables/int_var.py
+++ b/cvxpy/expressions/variables/int_var.py
@@ -25,11 +25,3 @@ class Int(Variable):
         """
         obj, constr = super(Int, self).canonicalize()
         return (obj, constr + [IntConstr(obj)])
-
-    def __repr__(self):
-        """String to recreate the object.
-        """
-        if self._name_given:
-            return "Int(%d, %d, '%s')" % (self._rows, self._cols, self._name)
-        else:
-            return "Int(%d, %d)" % self.size

--- a/cvxpy/expressions/variables/int_var.py
+++ b/cvxpy/expressions/variables/int_var.py
@@ -29,4 +29,7 @@ class Int(Variable):
     def __repr__(self):
         """String to recreate the object.
         """
-        return "Int(%d, %d)" % self.size
+        if self._name_given:
+            return "Int(%d, %d, '%s')" % (self._rows, self._cols, self._name)
+        else:
+            return "Int(%d, %d)" % self.size

--- a/cvxpy/expressions/variables/nonneg.py
+++ b/cvxpy/expressions/variables/nonneg.py
@@ -29,7 +29,11 @@ class NonNegative(Variable):
         return (obj, constr + [lu.create_geq(obj)])
 
     def __repr__(self):
-        return "NonNegative(%d, %d)" % self.size
+        if self._name_given:
+            return "NonNegative(%d, %d, '%s')" % (self._rows, self._cols,
+                                                  self._name)
+        else:
+            return "NonNegative(%d, %d)" % self.size
 
     def is_positive(self):
         """Is the expression positive?

--- a/cvxpy/expressions/variables/nonneg.py
+++ b/cvxpy/expressions/variables/nonneg.py
@@ -28,13 +28,6 @@ class NonNegative(Variable):
         obj, constr = super(NonNegative, self).canonicalize()
         return (obj, constr + [lu.create_geq(obj)])
 
-    def __repr__(self):
-        if self._name_given:
-            return "NonNegative(%d, %d, '%s')" % (self._rows, self._cols,
-                                                  self._name)
-        else:
-            return "NonNegative(%d, %d)" % self.size
-
     def is_positive(self):
         """Is the expression positive?
         """

--- a/cvxpy/expressions/variables/variable.py
+++ b/cvxpy/expressions/variables/variable.py
@@ -31,8 +31,10 @@ class Variable(Leaf):
         self._cols = cols
         self.id = lu.get_id()
         if name is None:
+            self._name_given = False
             self._name = "%s%d" % (s.VAR_PREFIX, self.id)
         else:
+            self._name_given = True
             self._name = name
         self.primal_value = None
         super(Variable, self).__init__()
@@ -105,4 +107,8 @@ class Variable(Leaf):
     def __repr__(self):
         """String to recreate the object.
         """
-        return "Variable(%d, %d)" % self.size
+        if self._name_given:
+            return "Variable(%d, %d, '%s')" % (self._rows, self._cols,
+                                               self._name)
+        else:
+            return "Variable(%d, %d)" % self.size

--- a/cvxpy/expressions/variables/variable.py
+++ b/cvxpy/expressions/variables/variable.py
@@ -108,7 +108,8 @@ class Variable(Leaf):
         """String to recreate the object.
         """
         if self._name_given:
-            return "Variable(%d, %d, '%s')" % (self._rows, self._cols,
-                                               self._name)
+            return "%s(%d, %d, '%s')" % (self.__class__.__name__, self.size[0],
+                                         self.size[1], self._name)
         else:
-            return "Variable(%d, %d)" % self.size
+            return "%s(%d, %d)" % (self.__class__.__name__, self.size[0],
+                                   self.size[1])

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -63,8 +63,8 @@ class TestExpressions(BaseTest):
         self.assertEqual(x.canonical_form[0].size, (2, 1))
         self.assertEqual(x.canonical_form[1], [])
 
-        self.assertEqual(repr(self.x), "Variable(2, 1)")
-        self.assertEqual(repr(self.A), "Variable(2, 2)")
+        self.assertEqual(repr(self.x), "Variable(2, 1, 'x')")
+        self.assertEqual(repr(self.A), "Variable(2, 2, 'A')")
 
         # # Scalar variable
         # coeff = self.a.coefficients()
@@ -84,6 +84,20 @@ class TestExpressions(BaseTest):
         # mat = coeffs[self.A.id][1]
         # self.assertEqual(mat.shape, (2,4))
         # self.assertEqual(mat[0,2], 1)
+
+    def test_variable_repr(self):
+        x = Variable(name='x')
+        y = NonNegative(name='y')
+
+        self.assertEqual(repr(x), "Variable(1, 1, 'x')")
+        self.assertEqual(repr(y), "NonNegative(1, 1, 'y')")
+
+        x = Variable()
+        y = NonNegative()
+
+        self.assertEqual(repr(x), "Variable(1, 1)")
+        self.assertEqual(repr(y), "NonNegative(1, 1)")
+
 
     def test_assign_var_value(self):
         """Test assigning a value to a variable.

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -23,10 +23,10 @@ class TestMIPVariable(BaseTest):
     """ Unit tests for the expressions/shape module. """
 
     def setUp(self):
-        self.x_bool = Bool()
+        self.x_bool = Bool(name='x')
         self.y_int = Int()
         self.A_bool = Bool(3, 2)
-        self.B_int = Int(2, 3)
+        self.B_int = Int(2, 3, name='B')
 
     def test_mip_consistency(self):
         """Test that MIP problems are deterministic.
@@ -54,8 +54,14 @@ class TestMIPVariable(BaseTest):
     def test_mip_print(self):
         """Test to string methods for Bool/Int vars.
         """
-        self.assertEqual(repr(self.x_bool), "Bool(1, 1)")
-        self.assertEqual(repr(self.B_int), "Int(2, 3)")
+        self.assertEqual(repr(self.x_bool), "Bool(1, 1, 'x')")
+        self.assertEqual(repr(self.B_int), "Int(2, 3, 'B')")
+
+        x = Bool()
+        B = Int(2, 3)
+
+        self.assertEqual(repr(x), "Bool(1, 1)")
+        self.assertEqual(repr(B), "Int(2, 3)")
 
     # def test_bool_prob(self):
     #     # Bool in objective.


### PR DESCRIPTION
Addresses #368.

I've chosen to show the name of the variables only if it was provided while variable initialization; otherwise there is no benefit from seeing it.

Also, I've not update the `repr` for `Symmetric` and `Semidef` variables because their `repr` do not conform to the default pattern currently.

I'll be happy to make any stylistic changes.