### PR TITLE
Fixed the bug with warm start

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -67,7 +67,7 @@ class OSQP(QpSolver):
             solver, old_data, results = solver_cache[self.name]
             same_pattern = (P.shape == old_data[s.P].shape and
                             all(P.indptr == old_data[s.P].indptr)) and \
-                           (A.shape == old_data[s.A].shape and
+                           (A.shape == old_data['full_A'].shape and
                             all(A.indptr == old_data['full_A'].indptr))
         else:
             same_pattern = False


### PR DESCRIPTION
CVXPY was doing matrix refactorization on a simple lasso example even when warm_start was enabled. This is the code:

     from cvxpy import *
     import numpy as np

     # Problem data
     m = 20
     n = 10
     A = np.random.randn(m, n)
     b = np.random.randn(m)

     # Construct the problem
     x = Variable(n)
     gamma = Parameter(nonneg=True)
     obj = sum_squares(A*x - b) + gamma*norm1(x)
     prob = Problem(Minimize(obj))

     gamma.value = 100.
     for i in range(20):
         prob.solve(warm_start=True, rho=10., verbose=True)
         print("Solve time:", prob.solver_stats.solve_time)

         # Update parameter gamma
         gamma.value = gamma.value / 2

The bug was in comparing current constraint matrix with the cached data.