### PR TITLE
Fixed and improved Cbc-interface

### DIFF
--- a/examples/tsp_mip.py
+++ b/examples/tsp_mip.py
@@ -25,21 +25,21 @@ from cvxpy import *
 
 np.random.seed(1)
 
-N = 10
+N = 5
 distances = np.random.rand(N, N)
 distances = (distances + distances.T)/2  # make symmetric = symmetric-TSP
 
 # VARS
-x = Bool(N, N)
-u = Int(N)
+x = Variable((N, N), boolean=True)
+u = Variable(N, integer=True)
 
 # CONSTRAINTS
 constraints = []
 for j in range(N):
-    indices = range(0, j) + range(j + 1, N)
+    indices = np.hstack((np.arange(0, j), np.arange(j + 1, N)))
     constraints.append(sum(x[indices, j]) == 1)
 for i in range(N):
-    indices = range(0, i) + range(i + 1, N)
+    indices = np.hstack((np.arange(0, i), np.arange(i + 1, N)))
     constraints.append(sum(x[i, indices]) == 1)
 
 for i in range(1, N):
@@ -53,4 +53,4 @@ obj = Minimize(sum(multiply(distances, x)))
 # SOLVE
 prob = Problem(obj, constraints)
 prob.solve(verbose=True)
-print prob.value
+print(prob.value)


### PR DESCRIPTION
## STATUS
Not ready to merge!

### Bug

I think commit ef5f95477 broke Cbc (mip_tsp.py breaks after changes needed for 1.0).

The problem is rooted in:

    model.addConstraint(x[idxs] >= 0)

where *lhs* will not have the same dimension as the problem, needed for this overloaded-usage.

I still feel somewhat uneasy with cylp (and it's nearly non-happening development), but i made use of the ```A * x >= 0``` approach in the past (with success), while explicit usage of bound-setters crashed (maybe i should recheck that). In regards to this usage, the sparse-matrix approach i used here should be quite efficient.

### Other changes

I also changed the calls in regards to solving for Cbc and Clp, as i realized a few weeks ago, that preprocessing never seemed to be used (Cbc was slower than GPLK and i wondered why). One should probably check this if it's doing the expected (i'm pretty sure Clp-usage does):

-  for **Cbc**: [this usage](https://github.com/sschnug/kemeny_ranking/blob/master/kemeny.py#L167) worked great for me, but it will probably use all Cbc-CLI defaults including cutting-planes
    - maybe there is some merit just to use this as a good default for MIPs (cutting-planes pre-selected)
    - only question then: still allow manual selection?
    - values returned also need re-mapping (i think those are the original Cbc-lib status codes)
- for **Clp**: [this usage / like commited](https://github.com/sschnug/footrule_ranking/blob/master/solver.py#L103) will use preprocessing, advanced crashing-stuff and co. as observed (and i think heuristics to choose primal/dual)