### PR TITLE
Fix for log_sum_exp

### DIFF
--- a/cvxpy/atoms/log_sum_exp.py
+++ b/cvxpy/atoms/log_sum_exp.py
@@ -71,7 +71,7 @@ class log_sum_exp(AxisAtom):
     def sign_from_args(self):
         """Returns sign (is positive, is negative) of the expression.
         """
-        return (True, False)
+        return (False, False)
 
     def is_atom_convex(self):
         """Is the atom convex?
@@ -86,7 +86,7 @@ class log_sum_exp(AxisAtom):
     def is_incr(self, idx):
         """Is the composition non-decreasing in argument idx?
         """
-        return False
+        return True
 
     def is_decr(self, idx):
         """Is the composition non-increasing in argument idx?


### PR DESCRIPTION
`log_sum_exp` is erroneously marked as non-increasing and positive.

This seems to have been introduced in
https://github.com/cvxgrp/cvxpy/commit/9366ccb54440ae0354f52cfbd14f30cba371b4db#diff-e6d9effeb355db619cf5bf6d59da6685