### PR TITLE
Fixes to the tests

### DIFF
--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -593,7 +593,7 @@ class TestAtoms(BaseTest):
         # Valid.
         huber(self.x, M)
         M.value = 1
-        self.assertAlmostEquals(huber(2, M).value, 3)
+        self.assertAlmostEqual(huber(2, M).value, 3)
         # Invalid.
         M = Parameter(nonpos=True)
         with self.assertRaises(Exception) as cm:
@@ -751,8 +751,8 @@ class TestAtoms(BaseTest):
 
         p2 = Problem(cvxpy.Maximize(square(t[0])), [-t <= x, x <= t])
         g = partial_optimize(p2, [t], [x])
-        self.assertEquals(g.is_convex(), False)
-        self.assertEquals(g.is_concave(), False)
+        self.assertEqual(g.is_convex(), False)
+        self.assertEqual(g.is_concave(), False)
 
     # Test the partial_optimize atom.
     def test_partial_optimize_eval_1norm(self):

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -128,21 +128,21 @@ class TestDomain(BaseTest):
         """
         dom = log(self.a).domain
         Problem(Minimize(self.a), dom).solve()
-        self.assertAlmostEquals(self.a.value, 0)
+        self.assertAlmostEqual(self.a.value, 0)
 
     def test_log1p(self):
         """Test domain for log1p.
         """
         dom = log1p(self.a).domain
         Problem(Minimize(self.a), dom).solve()
-        self.assertAlmostEquals(self.a.value, -1)
+        self.assertAlmostEqual(self.a.value, -1)
 
     def test_entr(self):
         """Test domain for entr.
         """
         dom = entr(self.a).domain
         Problem(Minimize(self.a), dom).solve()
-        self.assertAlmostEquals(self.a.value, 0)
+        self.assertAlmostEqual(self.a.value, 0)
 
     def test_kl_div(self):
         """Test domain for kl_div.
@@ -150,27 +150,27 @@ class TestDomain(BaseTest):
         b = Variable()
         dom = kl_div(self.a, b).domain
         Problem(Minimize(self.a + b), dom).solve()
-        self.assertAlmostEquals(self.a.value, 0)
-        self.assertAlmostEquals(b.value, 0)
+        self.assertAlmostEqual(self.a.value, 0)
+        self.assertAlmostEqual(b.value, 0)
 
     def test_power(self):
         """Test domain for power.
         """
         dom = sqrt(self.a).domain
         Problem(Minimize(self.a), dom).solve()
-        self.assertAlmostEquals(self.a.value, 0)
+        self.assertAlmostEqual(self.a.value, 0)
 
         dom = square(self.a).domain
         Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
-        self.assertAlmostEquals(self.a.value, -100)
+        self.assertAlmostEqual(self.a.value, -100)
 
         dom = ((self.a)**-1).domain
         Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
-        self.assertAlmostEquals(self.a.value, 0)
+        self.assertAlmostEqual(self.a.value, 0)
 
         dom = ((self.a)**3).domain
         Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
-        self.assertAlmostEquals(self.a.value, 0)
+        self.assertAlmostEqual(self.a.value, 0)
 
     def test_log_det(self):
         """Test domain for log_det.
@@ -178,7 +178,7 @@ class TestDomain(BaseTest):
         dom = log_det(self.A + np.eye(2)).domain
         prob = Problem(Minimize(sum(diag(self.A))), dom)
         prob.solve(solver=cvxpy.SCS)
-        self.assertAlmostEquals(prob.value, -2, places=3)
+        self.assertAlmostEqual(prob.value, -2, places=3)
 
     def test_matrix_frac(self):
         """Test domain for matrix_frac.
@@ -186,4 +186,4 @@ class TestDomain(BaseTest):
         dom = matrix_frac(self.x, self.A + np.eye(2)).domain
         prob = Problem(Minimize(sum(diag(self.A))), dom)
         prob.solve(solver=cvxpy.SCS)
-        self.assertAlmostEquals(prob.value, -2, places=3)
+        self.assertAlmostEqual(prob.value, -2, places=3)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -766,16 +766,16 @@ class TestExpressions(BaseTest):
         """Test None as index.
         """
         expr = self.a[None, None]
-        self.assertEquals(expr.shape, (1, 1))
+        self.assertEqual(expr.shape, (1, 1))
 
         expr = self.x[:, None]
-        self.assertEquals(expr.shape, (2, 1))
+        self.assertEqual(expr.shape, (2, 1))
 
         expr = self.x[None, :]
-        self.assertEquals(expr.shape, (1, 2))
+        self.assertEqual(expr.shape, (1, 2))
 
         expr = Constant([1,2])[None, :]
-        self.assertEquals(expr.shape, (1, 2))
+        self.assertEqual(expr.shape, (1, 2))
         self.assertItemsAlmostEqual(expr.value, [1, 2])
 
     def test_out_of_bounds(self):
@@ -790,7 +790,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(str(cm.exception), "Index -100 is out of bounds for axis 0 with size 2.")
 
         exp = self.x[:-100]
-        self.assertEquals(exp.size, (0,))
+        self.assertEqual(exp.size, (0,))
         self.assertItemsAlmostEqual(exp.value, np.array([]))
 
         exp = self.C[100:2]

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1643,7 +1643,7 @@ class TestProblem(BaseTest):
             prob = Problem(cvx.Minimize(cvx.sum(cvx.abs(x-a))), [cvx.pnorm(x, p) >= 0])
             prob.solve()
 
-            self.assertAlmostEquals(prob.value, 0, places=6)
+            self.assertAlmostEqual(prob.value, 0, places=6)
 
     def test_power(self):
         x = Variable()

--- a/cvxpy/tests/test_sign.py
+++ b/cvxpy/tests/test_sign.py
@@ -26,7 +26,7 @@ from cvxpy.tests.base_test import BaseTest
 class TestSign(BaseTest):
     """ Unit tests for the expression/sign class. """
     @classmethod
-    def setup_class(self):
+    def setUpClass(self):
         self.pos = Constant(1)
         self.neg = Constant(-1)
         self.zero = Constant(0)


### PR DESCRIPTION
1. `test_sign.py` failed because the name of unittest's method setUpClass() was wrong. This is now fixed.
2. I renamed `assertAlmostEquals()` to `assertAlmostEqual()` and `assertEquals()` to `assertEqual()`. Those are [deprecated aliases](https://docs.python.org/3/library/unittest.html#deprecated-aliases).