### PR TITLE
Efficiency: use generator expressions for any(), all(), sum()

### DIFF
--- a/cvxpy/CVXcanon/tests/python/364A_scripts/material_blend.py
+++ b/cvxpy/CVXcanon/tests/python/364A_scripts/material_blend.py
@@ -44,7 +44,7 @@ for i in range(n):
 
 to_add = [-f[j,i] * p[j] for i in range(n) for j in range(m)]
 obj = sum(to_add)
-obj += sum([f_tilde[i] * pTilde[i] for i in range(n)])
+obj += sum(f_tilde[i] * pTilde[i] for i in range(n))
 
 objective = Maximize(obj)
 problem = Problem(objective, constraints)

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -63,13 +63,13 @@ class AddExpression(AffAtom):
     def is_symmetric(self):
         """Is the expression symmetric?
         """
-        symm_args = all([arg.is_symmetric() for arg in self.args])
+        symm_args = all(arg.is_symmetric() for arg in self.args)
         return self.shape[0] == self.shape[1] and symm_args
 
     def is_hermitian(self):
         """Is the expression Hermitian?
         """
-        herm_args = all([arg.is_hermitian() for arg in self.args])
+        herm_args = all(arg.is_hermitian() for arg in self.args)
         return self.shape[0] == self.shape[1] and herm_args
 
     # As __init__ takes in the arg_groups instead of args, we need a special

--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -41,13 +41,13 @@ class AffAtom(Atom):
         """Is the expression imaginary?
         """
         # Default is most generic argument.
-        return all([arg.is_imag() for arg in self.args])
+        return all(arg.is_imag() for arg in self.args)
 
     def is_complex(self):
         """Is the expression complex valued?
         """
         # Default is most generic argument.
-        return any([arg.is_complex() for arg in self.args])
+        return any(arg.is_complex() for arg in self.args)
 
     def is_atom_convex(self):
         """Is the atom convex?
@@ -72,13 +72,13 @@ class AffAtom(Atom):
         return False
 
     def is_quadratic(self):
-        return all([arg.is_quadratic() for arg in self.args])
+        return all(arg.is_quadratic() for arg in self.args)
 
     def is_qpwa(self):
-        return all([arg.is_qpwa() for arg in self.args])
+        return all(arg.is_qpwa() for arg in self.args)
 
     def is_pwl(self):
-        return all([arg.is_pwl() for arg in self.args])
+        return all(arg.is_pwl() for arg in self.args)
 
     @clru_cache(maxsize=100)
     def is_psd(self):

--- a/cvxpy/atoms/affine/hstack.py
+++ b/cvxpy/atoms/affine/hstack.py
@@ -46,7 +46,7 @@ class Hstack(AffAtom):
     # The shape is the common width and the sum of the heights.
     def shape_from_args(self):
         if self.args[0].ndim == 1:
-            return (sum([arg.size for arg in self.args]),)
+            return (sum(arg.size for arg in self.args),)
         else:
             cols = sum(arg.shape[1] for arg in self.args)
             return (self.args[0].shape[0], cols) + self.args[0].shape[2:]

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -59,7 +59,7 @@ class Atom(Expression):
     def validate_arguments(self):
         """Raises an error if the arguments are invalid.
         """
-        if not self._allow_complex and any([arg.is_complex() for arg in self.args]):
+        if not self._allow_complex and any(arg.is_complex() for arg in self.args):
             raise ValueError(
                 "Arguments to %s cannot be complex." % self.__class__.__name__
             )

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -45,7 +45,7 @@ class Elementwise(Atom):
     def is_symmetric(self):
         """Is the expression symmetric?
         """
-        symm_args = all([arg.is_symmetric() for arg in self.args])
+        symm_args = all(arg.is_symmetric() for arg in self.args)
         return self.shape[0] == self.shape[1] and symm_args
 
     @staticmethod

--- a/cvxpy/atoms/elementwise/maximum.py
+++ b/cvxpy/atoms/elementwise/maximum.py
@@ -50,8 +50,8 @@ class maximum(Elementwise):
         #     ZERO, NEGATIVE = ZERO
         #     UNKNOWN, NEGATIVE = UNKNOWN
         #     NEGATIVE, NEGATIVE = NEGATIVE
-        is_pos = any([arg.is_nonneg() for arg in self.args])
-        is_neg = all([arg.is_nonpos() for arg in self.args])
+        is_pos = any(arg.is_nonneg() for arg in self.args)
+        is_neg = all(arg.is_nonpos() for arg in self.args)
         return (is_pos, is_neg)
 
     def is_atom_convex(self):
@@ -77,7 +77,7 @@ class maximum(Elementwise):
     def is_pwl(self):
         """Is the atom piecewise linear?
         """
-        return all([arg.is_pwl() for arg in self.args])
+        return all(arg.is_pwl() for arg in self.args)
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -81,12 +81,12 @@ class Constraint(u.Canonical):
     def is_imag(self):
         """Is the Leaf imaginary?
         """
-        return all([arg.is_imag() for arg in self.args])
+        return all(arg.is_imag() for arg in self.args)
 
     def is_complex(self):
         """Is the Leaf complex valued?
         """
-        return any([arg.is_complex() for arg in self.args])
+        return any(arg.is_complex() for arg in self.args)
 
     @abc.abstractmethod
     def is_dcp(self):

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -136,7 +136,7 @@ class ExpCone(NonlinearConstraint):
     def is_dcp(self):
         """An exponential constraint is DCP if each argument is affine.
         """
-        return all([arg.is_affine() for arg in self.args])
+        return all(arg.is_affine() for arg in self.args)
 
     def canonicalize(self):
         """Canonicalizes by converting expressions to LinOps.

--- a/cvxpy/constraints/nonlinear.py
+++ b/cvxpy/constraints/nonlinear.py
@@ -37,7 +37,7 @@ class NonlinearConstraint(Constraint):
         self.f = f
         self.vars_ = vars_
         # The shape of vars_ in f(vars_)
-        self.x_shape = (sum([np.prod(v.shape, dtype=int) for v in self.vars_]), 1)
+        self.x_shape = (sum(np.prod(v.shape, dtype=int) for v in self.vars_), 1)
         super(NonlinearConstraint, self).__init__(self.vars_, constr_id)
 
     def block_add(self, matrix, block, vert_offset, horiz_offset, rows, cols,

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -134,7 +134,7 @@ class SOC(Constraint):
     def is_dcp(self):
         """An SOC constraint is DCP if each of its arguments is affine.
         """
-        return all([arg.is_affine() for arg in self.args])
+        return all(arg.is_affine() for arg in self.args)
 
     # TODO hack
     def canonicalize(self):

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -216,7 +216,7 @@ class Leaf(expression.Expression):
         """Is the Leaf symmetric?
         """
         return self.is_scalar() or \
-            any([self.attributes[key] for key in ['diag', 'symmetric', 'PSD', 'NSD']])
+            any(self.attributes[key] for key in ['diag', 'symmetric', 'PSD', 'NSD'])
 
     def is_imag(self):
         """Is the Leaf imaginary?

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -120,7 +120,7 @@ class Leaf(expression.Expression):
             self.integer_idx = []
 
         # Only one attribute be True (except can be boolean and integer).
-        true_attr = sum([1 for k, v in self.attributes.items() if v])
+        true_attr = sum(1 for k, v in self.attributes.items() if v)
         if boolean and integer:
             true_attr -= 1
         if true_attr > 1:

--- a/cvxpy/problems/problem_data/matrix_data.py
+++ b/cvxpy/problems/problem_data/matrix_data.py
@@ -45,7 +45,7 @@ class MatrixCache(object):
         self.coo_tup = coo_tup
         self.const_vec = const_vec
         self.constraints = constraints
-        rows = sum([np.prod(c.shape, dtype=int) for c in constraints])
+        rows = sum(np.prod(c.shape, dtype=int) for c in constraints)
         cols = x_length
         self.shape = (rows, cols)
         self.param_coo_tup = ([], [], [])
@@ -141,7 +141,7 @@ class MatrixData(object):
         -------
         ((V, I, J), array)
         """
-        rows = sum([np.prod(c.shape, dtype=int) for c in constraints])
+        rows = sum(np.prod(c.shape, dtype=int) for c in constraints)
         COO = ([], [], [])
         const_vec = self.vec_intf.zeros((rows, 1))
         return MatrixCache(COO, const_vec, constraints, x_length)
@@ -239,7 +239,7 @@ class MatrixData(object):
         Oracle function.
         """
         import cvxopt
-        rows = int(sum([np.prod(c.shape, dtype=int) for c in nonlin_constr]))
+        rows = int(sum(np.prod(c.shape, dtype=int) for c in nonlin_constr))
         cols = int(self.sym_data.x_length)
         var_offsets = self.sym_data.var_offsets
 

--- a/cvxpy/problems/solvers/glpk_mi_intf.py
+++ b/cvxpy/problems/solvers/glpk_mi_intf.py
@@ -98,8 +98,8 @@ class GLPK_MI(GLPK):
                                           data[s.H],
                                           data[s.A],
                                           data[s.B],
-                                          set([int(i) for i in data[s.INT_IDX]]),
-                                          set([int(i) for i in data[s.BOOL_IDX]]))
+                                          set(int(i) for i in data[s.INT_IDX]),
+                                          set(int(i) for i in data[s.BOOL_IDX]))
             results_dict = {}
             results_dict["status"] = results_tup[0]
             results_dict["x"] = results_tup[1]

--- a/cvxpy/problems/solvers/ls_intf.py
+++ b/cvxpy/problems/solvers/ls_intf.py
@@ -83,8 +83,8 @@ class LS(Solver):
         # TODO: handle affine objective
         return (prob.is_dcp() and prob.objective.args[0].is_quadratic() and
                 not prob.objective.args[0].is_affine() and
-                all([isinstance(c, eqc.Zero) for c in prob.constraints]) and
-                all([not v.domain for v in prob.variables()])  # no implicit variable domains
+                all(isinstance(c, eqc.Zero) for c in prob.constraints) and
+                all(not v.domain for v in prob.variables())  # no implicit variable domains
                 # (TODO: domains are not implemented yet)
                 )
 

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/aff_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/aff_canon.py
@@ -25,9 +25,9 @@ def separable_canon(expr, real_args, imag_args, real2imag):
     """Canonicalize linear functions that are seprable
        in real and imaginary parts.
     """
-    if all([val is None for val in imag_args]):
+    if all(val is None for val in imag_args):
         outputs = (expr.copy(real_args), None)
-    elif all([val is None for val in real_args]):
+    elif all(val is None for val in real_args):
         outputs = (None, expr.copy(imag_args))
     else:  # Mixed real_args and imaginaries.
         for idx, real_val in enumerate(real_args):

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -33,7 +33,7 @@ class Complex2Real(Reduction):
 
     def accepts(self, problem):
         leaves = problem.variables() + problem.parameters() + problem.constants()
-        return any([l.is_complex() for l in leaves])
+        return any(l.is_complex() for l in leaves)
 
     def apply(self, problem):
         inverse_data = InverseData(problem)
@@ -123,5 +123,5 @@ class Complex2Real(Reduction):
                 leaf_map[expr] = result
             return result
         else:
-            assert all([v is None for v in imag_args])
+            assert all(v is None for v in imag_args)
             return expr.copy(real_args), None

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -89,9 +89,9 @@ class ConeDims(object):
         dimension of the PSD cone of k by k matrices is k.
     """
     def __init__(self, constr_map):
-        self.zero = sum([c.size for c in constr_map[Zero]])
-        self.nonpos = sum([c.size for c in constr_map[NonPos]])
-        self.exp = sum([c.num_cones() for c in constr_map[ExpCone]])
+        self.zero = sum(c.size for c in constr_map[Zero])
+        self.nonpos = sum(c.size for c in constr_map[NonPos])
+        self.exp = sum(c.num_cones() for c in constr_map[ExpCone])
         self.soc = [dim for c in constr_map[SOC] for dim in c.cone_sizes()]
         self.psd = [c.shape[0] for c in constr_map[PSD]]
 
@@ -206,7 +206,7 @@ class ConicSolver(Solver):
             coeff, offset = ConicSolver.get_coeff_offset(arg)
             coeffs.append(coeff.tocsr())
             offsets.append(offset)
-        height = sum([c.shape[0] for c in coeffs])
+        height = sum(c.shape[0] for c in coeffs)
 
         if type(constr) in [NonPos, Zero]:
             # Both of these constraints have but a single argument.

--- a/cvxpy/reductions/solvers/conic_solvers/ls_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ls_conif.py
@@ -86,9 +86,9 @@ class LS(Solver):
         # TODO: handle affine objective
         return (prob.is_dcp() and prob.objective.args[0].is_quadratic() and
                 not prob.objective.args[0].is_affine() and
-                all([isinstance(c, eqc.Zero) for c in prob.constraints]) and
-                all([type(v) in allowedVariables for v in prob.variables()]) and
-                all([not v.domain for v in prob.variables()])  # no implicit variable domains
+                all(isinstance(c, eqc.Zero) for c in prob.constraints) and
+                all(type(v) in allowedVariables for v in prob.variables()) and
+                all(not v.domain for v in prob.variables())  # no implicit variable domains
                 # (TODO: domains are not implemented yet)
                 )
 

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -309,7 +309,7 @@ class MOSEK(ConicSolver):
                 dims = data[s.DIMS]
                 n0 = len(c)
                 n = n0 + sum(dims[s.SOC_DIM]) + sum(dims[s.EXP_DIM])
-                psd_total_dims = sum([el ** 2 for el in dims[s.PSD_DIM]])
+                psd_total_dims = sum(el ** 2 for el in dims[s.PSD_DIM])
                 m = len(h)
                 num_bool = len(data[s.BOOL_IDX])
                 num_int = len(data[s.INT_IDX])
@@ -519,19 +519,19 @@ class MOSEK(ConicSolver):
         dual_vars = dict()
 
         # Dual variables for the inequality constraints
-        suc_len = sum([ell for _, ell in inverse_data['suc_slacks']])
+        suc_len = sum(ell for _, ell in inverse_data['suc_slacks'])
         suc = [0.] * suc_len
         task.getsucslice(sol, 0, suc_len, suc)
         dual_vars.update(MOSEK.parse_dual_vars(suc, inverse_data['suc_slacks']))
 
         # Dual variables for the original equality constraints
-        y_len = sum([ell for _, ell in inverse_data['y_slacks']])
+        y_len = sum(ell for _, ell in inverse_data['y_slacks'])
         y = [0.] * y_len
         task.getyslice(sol, suc_len, suc_len + y_len, y)
         dual_vars.update(MOSEK.parse_dual_vars(y, inverse_data['y_slacks']))
 
         # Dual variables for SOC and EXP constraints
-        snx_len = sum([ell for _, ell in inverse_data['snx_slacks']])
+        snx_len = sum(ell for _, ell in inverse_data['snx_slacks'])
         if snx_len > 0:
             snx = np.zeros(snx_len)
             task.getsnxslice(sol, inverse_data['n0'], inverse_data['n0'] + snx_len, snx)

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -94,7 +94,7 @@ class TestNonlinearAtoms(BaseTest):
         for k in range(kK):
             objkl += cvx.kl_div(v_prob[k, 0], p_refProb[k, 0])
 
-        constrs = [sum([v_prob[k, 0] for k in range(kK)]) == 1]
+        constrs = [sum(v_prob[k, 0] for k in range(kK)) == 1]
         klprob = cvx.Problem(cvx.Minimize(objkl), constrs)
         p_refProb.value = npSPriors
         if cvx.CVXOPT in cvx.installed_solvers():

--- a/cvxpy/tests/test_scs.py
+++ b/cvxpy/tests/test_scs.py
@@ -115,7 +115,7 @@ class TestSCS(BaseTest):
         for k in range(kK):
             objkl += cvx.kl_div(v_prob[k, 0], p_refProb[k, 0])
 
-        constrs = [sum([v_prob[k, 0] for k in range(kK)]) == 1]
+        constrs = [sum(v_prob[k, 0] for k in range(kK)) == 1]
         klprob = cvx.Problem(cvx.Minimize(objkl), constrs)
         p_refProb.value = npSPriors
         result = klprob.solve(solver=cvx.SCS, verbose=True)

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -44,8 +44,8 @@ class TestShape(unittest.TestCase):
         self.assertEqual(shape.sum_shapes([(1,), (3, 4)]), (3, 4))
         self.assertEqual(shape.sum_shapes([(3, 4), (1,)]), (3, 4))
 
-        self.assertEqual(shape.sum_shapes([tuple([]), (3, 4)]), (3, 4))
-        self.assertEqual(shape.sum_shapes([(3, 4), tuple([])]), (3, 4))
+        self.assertEqual(shape.sum_shapes([tuple(), (3, 4)]), (3, 4))
+        self.assertEqual(shape.sum_shapes([(3, 4), tuple()]), (3, 4))
 
         self.assertEqual(shape.sum_shapes([(1, 1), (4,)]), (1, 4))
         self.assertEqual(shape.sum_shapes([(4,), (1, 1)]), (1, 4))

--- a/cvxpy/transforms/indicator.py
+++ b/cvxpy/transforms/indicator.py
@@ -95,7 +95,7 @@ class indicator(Expression):
         Returns:
             A numpy matrix or a scalar.
         """
-        if all([cons.value for cons in self.args]):
+        if all(cons.value for cons in self.args):
             return 0
         else:
             return np.infty

--- a/cvxpy/transforms/scalarize.py
+++ b/cvxpy/transforms/scalarize.py
@@ -31,7 +31,7 @@ def weighted_sum(objectives, weights):
       A Minimize/Maximize objective.
     """
     num_objs = len(objectives)
-    return sum([objectives[i]*weights[i] for i in range(num_objs)])
+    return sum(objectives[i]*weights[i] for i in range(num_objs))
 
 
 def targets_and_priorities(objectives, priorities, targets, limits=None, off_target=1e-5):

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -43,7 +43,7 @@ def validate_key(key, shape):
     if len(key) == 0:
         raise IndexError("An index cannot be empty.")
     # Change single indices for vectors into double indices.
-    none_count = sum([1 for elem in key if elem is None])
+    none_count = sum(1 for elem in key if elem is None)
     slices = len(key) - none_count
     if slices > len(shape):
         raise IndexError("Too many indices for expression.")

--- a/cvxpy/utilities/shape.py
+++ b/cvxpy/utilities/shape.py
@@ -19,7 +19,7 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 
 
 def squeezed(shape):
-    return tuple([dim for dim in shape if dim != 1])
+    return tuple(dim for dim in shape if dim != 1)
 
 
 def sum_shapes(shapes):

--- a/cvxpy/utilities/sign.py
+++ b/cvxpy/utilities/sign.py
@@ -27,8 +27,8 @@ def sum_signs(exprs):
     Returns:
         The sign (is pos, is neg) of the sum.
     """
-    is_pos = all([expr.is_nonneg() for expr in exprs])
-    is_neg = all([expr.is_nonpos() for expr in exprs])
+    is_pos = all(expr.is_nonneg() for expr in exprs)
+    is_neg = all(expr.is_nonpos() for expr in exprs)
     return (is_pos, is_neg)
 
 


### PR DESCRIPTION
When using the `any()` and `all()` Python built-in functions, it's more efficient to pass the parameters as [generator expressions](https://www.python.org/dev/peps/pep-0289/) than as list comprehensions.

We can *[take out the brackets](https://youtu.be/OSGv2VnC0go?t=47m49s)* as Raymond Hettinger suggests and enjoy the lazy evaluation of logic conditions. :-)