### PR TITLE
include COPYING in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft cvxpy/cvxcore/src/
 graft cvxpy/cvxcore/include/Eigen
 graft cvxpy/cvxcore/python
+include COPYING


### PR DESCRIPTION
Makes sure that the `COPYING` file is included in `setup.py sdist` files.