### PR TITLE
simplify and update conda recipe

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,19 @@
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+numpy:
+  - 1.11
+c_compiler:
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+cxx_compiler:
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+zip_keys:
+  -                             # [win]
+    - c_compiler                # [win]
+    - cxx_compiler              # [win]
+    - python                    # [win]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,17 +1,20 @@
+{% set version = "1.0.6" %}
+
 package:
-  name: cvxpy
-  version: "1.0.6"
+  name: cvxpy-base
+  version: {{ version }}
 
 source:
-  path: ..
+  git_url: https://github.com/cvxgrp/cvxpy.git
+  git_tag: v{{ version }}
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: {{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   host:
-    - python
+    - python {{ python }}
     - setuptools
     - numpy >=1.9
   build:
@@ -61,8 +64,18 @@ test:
     - cvxpy.utilities
     - cvxpy.cvxcore.python
 
+outputs:
+  - name: cvxpy-base
+  - name: cvxpy
+    requirements:
+      - {{ pin_subpackage('cvxpy-base', exact=True) }}
+      - osqp
+      - ecos >=2
+      - scs >=1.1.3
+    build:
+      noarch: generic
+
 about:
   home: http://github.com/cvxgrp/cvxpy/
   license: Apache License, Version 2.0
-  license_file: LICENSE
   summary: 'A domain-specific language for modeling convex optimization problems in Python.'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,34 +1,29 @@
+{% set name = "cvxpy" %}
 {% set version = "1.0.6" %}
 
 package:
-  name: cvxpy-base
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  git_url: https://github.com/cvxgrp/cvxpy.git
-  git_tag: v{{ version }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a1b5b3ac31f6ed02649196c34e9b2d23320f170a7b05d6796029d9e7d4fc78d1
 
 build:
-  number: 0
-  script: {{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt
+  number: 1
 
 requirements:
   host:
     - python {{ python }}
-    - numpy {{ numpy }}
-    - setuptools
-  build:
-    - {{ compiler('cxx') }}
   run:
-    - python
-    - {{ pin_compatible('numpy') }}
-    - scipy >=0.15
-    - multiprocess
-    - fastcache
-    - toolz
+    - cvxpy-base
+    - osqp
+    - ecos >=2
+    - scs >=1.1.3
 
 test:
-  # Python imports
+  requires:
+    - nose
   imports:
     - cvxpy
     - cvxpy.atoms
@@ -63,19 +58,38 @@ test:
     - cvxpy.transforms
     - cvxpy.utilities
     - cvxpy.cvxcore.python
+  commands:
+    - nosetests cvxpy
 
 outputs:
   - name: cvxpy-base
-  - name: cvxpy
     requirements:
-      - {{ pin_subpackage('cvxpy-base', exact=True) }}
-      - osqp
-      - ecos >=2
-      - scs >=1.1.3
+      host:
+        - python {{ python }}
+        - numpy {{ numpy }}
+        - setuptools
+      build:
+        - {{ compiler('cxx') }}
+      run:
+        - python
+        - {{ pin_compatible('numpy') }}
+        - scipy >=0.15
+        - multiprocess
+        - fastcache
+        - toolz
     build:
-      noarch: generic
+      script: {{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt
 
 about:
-  home: http://github.com/cvxgrp/cvxpy/
-  license: Apache License, Version 2.0
+  home: http://www.cvxpy.org/
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
   summary: 'A domain-specific language for modeling convex optimization problems in Python.'
+  description: |
+    CVXPY is a Python-embedded modeling language for convex optimization
+    problems. It allows you to express your problem in a natural way that
+    follows the math, rather than in the restrictive standard form required
+    by solvers.
+  doc_url: http://www.cvxpy.org/
+  dev_url: https://github.com/cvxgrp/cvxpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,17 +15,17 @@ build:
 requirements:
   host:
     - python {{ python }}
+    - numpy {{ numpy }}
     - setuptools
-    - numpy >=1.9
   build:
     - {{ compiler('cxx') }}
   run:
     - python
+    - {{ pin_compatible('numpy') }}
+    - scipy >=0.15
     - multiprocess
     - fastcache
     - toolz
-    - numpy >=1.9
-    - scipy >=0.15
 
 test:
   # Python imports

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,36 +10,19 @@ build:
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-  build:
-    - setuptools
-    - six
-    - toolz
-    - fastcache
+  host:
     - python
-    - osqp
-    - ecos >=2
-    - scs >=1.1.3
-    - multiprocess
-    - numpy >=1.14
-    - scipy >=0.15
-    - libgcc
-    - lapack
-    - mkl
-
+    - setuptools
+    - numpy >=1.9
+  build:
+    - {{ compiler('cxx') }}
   run:
     - python
-    - osqp
-    - ecos >=2
-    - scs >=1.1.3
     - multiprocess
     - fastcache
-    - six
     - toolz
     - numpy >=1.9
     - scipy >=0.15
-    - libgcc
-    - lapack
-    - mkl
 
 test:
   # Python imports
@@ -81,4 +64,5 @@ test:
 about:
   home: http://github.com/cvxgrp/cvxpy/
   license: Apache License, Version 2.0
+  license_file: LICENSE
   summary: 'A domain-specific language for modeling convex optimization problems in Python.'

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
                       "scs >= 1.1.3",
                       "multiprocess",
                       "fastcache",
-                      "six",
                       "toolz",
                       "numpy >= 1.14",
                       "scipy >= 0.19"],


### PR DESCRIPTION
Updated to use the Anaconda 5.0 [compiler tools](https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html).

I've also taken the liberty to remove the solvers as `conda`-specific dependencies. I would really like to encourage you to adopt this. For one thing, because the free version of ECOS is GPLv3, you're effectively preventing anyone who is GPL-averse from using cvxpy through conda. But more fundamentally, it reduces the install requirements for people who know exactly which solver they want.

To play devil's advocate, this may confuse users who do not appreciate that at least one solver must be present. A remedy here is to update the documentation but also to print an informative error message when the solver resolution is attempted. I can add that code if you like.

While Anaconda isn't yet putting `cvxpy` into the defaults channel, I am actually building it for a couple of customers, and this is the recipe (or a slight modification of it) is the one that I will be using.