### PR TITLE
Fix entropy atom with scalars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.py[cod]
 *#*
 *.swp
+*.ropeproject
 
 # C extensions
 *.so

--- a/cvxpy/atoms/elementwise/entr.py
+++ b/cvxpy/atoms/elementwise/entr.py
@@ -36,10 +36,11 @@ class entr(Elementwise):
         results = -xlogy(x, x)
         # Return -inf outside the domain
         if np.isscalar(results):
-            return -np.inf
+            if np.isnan(results):
+                return -np.inf
         else:
             results[np.isnan(results)] = -np.inf
-            return results
+        return results
 
     def sign_from_args(self):
         """Returns sign (is positive, is negative) of the expression.


### PR DESCRIPTION
Looks like the entropy atom returns infinity with scalars independently from them being or not in the domain. I made a small fix.

Problem was raised [here](https://stackoverflow.com/questions/50991294/infinity-objective-value-given-by-cvxpy-on-a-convex-program).