### PR TITLE
Fix MIP solution statuses in Mosek

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -459,7 +459,7 @@ class MOSEK(ConicSolver):
         else:
             sol = mosek.soltype.itr  # the solution found via interior point method
 
-        problem_status = task.getprosta(sol) 
+        problem_status = task.getprosta(sol)
         solution_status = task.getsolsta(sol)
 
         status = STATUS_MAP[solution_status]

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -19,6 +19,7 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 
 import cvxpy as cvx
 import numpy as np
+import cvxpy.settings as s
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.reductions.solvers.defines \
     import INSTALLED_SOLVERS
@@ -115,6 +116,12 @@ class TestMIPVariable(BaseTest):
         self.assertAlmostEqual(result, 0.04)
 
         self.assertAlmostEqual(self.y_int.value, 0)
+
+        # Infeasible integer problem
+        obj = cvx.Minimize(0)
+        p = cvx.Problem(obj, [self.y_int == 0.5])
+        result = p.solve(solver=solver)
+        self.assertEqual(p.status in s.INF_OR_UNB, True)
 
     def int_socp(self, solver):
         # Int in objective.


### PR DESCRIPTION
A fix for the Mosek interface. It corrects two situations when solving a problem with integer variables in Mosek resulted in ``SolverError``:

1. When the problem is infeasible - now returns ``s.INFEASIBLE``.
2. When an integer solution was found, but is not optimal - now returns ``s.OPTIMAL_INACCURATE``. I'm not sure this is the best status here, but I don't see a better one. It seems consistent with #480. This happens for example when a time limit was set for the solver.