### PR TITLE
Remove dependency on six

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,7 +12,6 @@ build:
 requirements:
   build:
     - setuptools
-    - six
     - toolz
     - fastcache
     - python
@@ -33,7 +32,6 @@ requirements:
     - scs >=1.1.3
     - multiprocess
     - fastcache
-    - six
     - toolz
     - numpy >=1.9
     - scipy >=0.15

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -85,7 +85,6 @@ CVXPY has the following dependencies:
 * Python 2.7 or Python 3.4
 * `setuptools`_ >= 1.4
 * `toolz`_
-* `six <https://pythonhosted.org/six/>`_
 * `fastcache <https://github.com/pbrady/fastcache>`_
 * `multiprocess`_
 * `OSQP`_
@@ -96,7 +95,7 @@ CVXPY has the following dependencies:
 
 To test the CVXPY installation, you additionally need `Nose`_.
 
-CVXPY automatically installs `OSQP`_, `ECOS`_, `SCS`_, `toolz`_, six, fastcache, and
+CVXPY automatically installs `OSQP`_, `ECOS`_, `SCS`_, `toolz`_, fastcache, and
 `multiprocess`_. `NumPy`_ and `SciPy`_ will need to be installed manually,
 as will `Swig`_ . Once you’ve installed these dependencies:
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
                       "scs >= 1.1.3",
                       "multiprocess",
                       "fastcache",
-                      "six",
                       "toolz",
                       "numpy >= 1.14",
                       "scipy >= 0.19"],


### PR DESCRIPTION
There doesn't appear to be any explicit dependency on six
in the entire repository.