### PR TITLE
more efficient project() for PSD/NSD

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -290,11 +290,13 @@ class Leaf(expression.Expression):
                 val = np.diag(val)
             return sp.diags([val], [0])
         elif self.attributes['hermitian']:
-            return (val + np.conj(val).T)/2
+            return (val + np.conj(val).T)/2.
         elif any([self.attributes[key] for
                   key in ['symmetric', 'PSD', 'NSD']]):
+            if val.dtype.kind in 'ib':
+                val = val.astype(np.float)
             val = val + val.T
-            val /= 2
+            val /= 2.
             if self.attributes['symmetric']:
                 return val
             w, V = LA.eigh(val)

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -293,15 +293,22 @@ class Leaf(expression.Expression):
             return (val + np.conj(val).T)/2
         elif any([self.attributes[key] for
                   key in ['symmetric', 'PSD', 'NSD']]):
-            val = (val + val.T)/2
+            val = val + val.T
+            val /= 2
             if self.attributes['symmetric']:
                 return val
             w, V = LA.eigh(val)
             if self.attributes['PSD']:
-                w = np.maximum(w, 0)
+                bad = w < 0
+                if not bad.any():
+                    return val
+                w[bad] = 0
             else:  # NSD
-                w = np.minimum(w, 0)
-            return V.dot(np.diag(w)).dot(V.T)
+                bad = w > 0
+                if not bad.any():
+                    return val
+                w[bad] = 0
+            return (V * w).dot(V.T)
         else:
             return val
 


### PR DESCRIPTION
I passed in a 102x102 PSD Parameter whose smallest eigenvalue was 1e-4, but the numerical error caused by the reconstruction in `project` made it think the matrix wasn't PSD. This changes `project` to just return the (symmetrized) array if it doesn't actually need to change.

Also be a little more efficient by dividiing by 2 inplace, and using broadcasting instead of constructing a diagonal matrix and calling `dot` with it.