### PR TITLE
Option to dump task file from MOSEK

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -265,9 +265,13 @@ class MOSEK(ConicSolver):
         # Parse all user-specified parameters (override default logging
         # parameters if applicable).
         kwargs = sorted(solver_opts.keys())
+        save_file = None
         if 'mosek_params' in kwargs:
             self._handle_mosek_params(task, solver_opts['mosek_params'])
             kwargs.remove('mosek_params')
+        if 'save_file' in kwargs:
+            save_file = solver_opts['save_file']
+            kwargs.remove('save_file')
         if 'bfs' in kwargs:
             kwargs.remove('bfs')
         if kwargs:
@@ -403,6 +407,8 @@ class MOSEK(ConicSolver):
 
         task.putclist(np.arange(len(c)), c)
         task.putobjsense(mosek.objsense.minimize)
+        if save_file:
+            task.writedata(save_file)
         task.optimize()
 
         if verbose:

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -659,6 +659,11 @@ See `OSQP documentation <http://osqp.org/docs/interfaces/solver_settings.html>`_
     Alternatively, Python enum options like ``'mosek.dparam.basis_tol_x'`` are
     also supported.
 
+``'save_file'``
+    The name of a file where MOSEK will save the problem just before optimization.
+    Refer to MOSEK documentation for a list of supported file formats. File format
+    is chosen based on the extension.
+
 `CVXOPT`_ options:
 
 ``'max_iters'``


### PR DESCRIPTION
This adds an optional filename where MOSEK will dump the task data, for example

```
prob.solve(solver=MOSEK, save_file="dump.opf")
```

It is useful if the users can dump the problem for debugging esp. if the optimizer failed or crashed. Occasionally can be used for checking how cvxpy transformed the problem.

Online docs updated accordingly.

Tested in python 2.7 and 3.5.