### PR TITLE
fix issue 608

### DIFF
--- a/cvxpy/atoms/affine/unary_operators.py
+++ b/cvxpy/atoms/affine/unary_operators.py
@@ -28,7 +28,7 @@ class UnaryOperator(AffAtom):
         super(UnaryOperator, self).__init__(expr)
 
     def name(self):
-        return self.OP_NAME + self.args[0].name()
+        return self.OP_NAME + "(" + self.args[0].name() + ")"
 
     # Applies the unary operator to the value.
     def numeric(self, values):


### PR DESCRIPTION
It seems like just the string representation is wrong.
```
import cvxpy as cvx
x = cvx.Variable()
expr = -(1+x)
prob = cvx.Problem(cvx.Minimize(x), [expr == 0])
prob.solve()
```
gives the correct value `-1.0`.
The easy fix would be to just use brackets, in particular since this method is meant for all unary operators. So we get `-(var0 + 1.0)`