### PR TITLE
Fixed subgradient calculation for absolute values

### DIFF
--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -74,8 +74,14 @@ class abs(Elementwise):
             A list of SciPy CSC sparse matrices or None.
         """
         # Grad: +1 if positive, -1 if negative.
-        rows = self.args[0].shape[0]*self.args[0].shape[1]
-        cols = self.shape[0]*self.shape[1]
+        if self.args[0].shape != ():
+            rows = self.args[0].shape[0]*self.args[0].shape[1]
+        else:
+            rows = 1
+        if self.shape != ():
+            cols = self.shape[0]*self.shape[1]
+        else:
+            cols = 1
         D = np.matrix(np.zeros(self.args[0].shape))
         D += (values[0] > 0)
         D -= (values[0] < 0)

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -74,11 +74,11 @@ class abs(Elementwise):
             A list of SciPy CSC sparse matrices or None.
         """
         # Grad: +1 if positive, -1 if negative.
-        if self.args[0].shape != ():
+        if self.args[0].size != 1:
             rows = self.args[0].shape[0]*self.args[0].shape[1]
         else:
             rows = 1
-        if self.shape != ():
+        if self.size != 1:
             cols = self.shape[0]*self.shape[1]
         else:
             cols = 1

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -76,8 +76,6 @@ class abs(Elementwise):
         # Grad: +1 if positive, -1 if negative.
         rows = self.expr.size
         cols = self.size
-        else:
-            cols = 1
         D = np.matrix(np.zeros(self.expr.shape))
         D += (values[0] > 0)
         D -= (values[0] < 0)

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -74,15 +74,15 @@ class abs(Elementwise):
             A list of SciPy CSC sparse matrices or None.
         """
         # Grad: +1 if positive, -1 if negative.
-        if self.args[0].size != 1:
-            rows = self.args[0].shape[0]*self.args[0].shape[1]
+        if self.expr.size != 1:
+            rows = self.expr.shape[0]*self.expr.shape[1]
         else:
             rows = 1
         if self.size != 1:
             cols = self.shape[0]*self.shape[1]
         else:
             cols = 1
-        D = np.matrix(np.zeros(self.args[0].shape))
+        D = np.matrix(np.zeros(self.expr.shape))
         D += (values[0] > 0)
         D -= (values[0] < 0)
         return [abs.elemwise_grad_to_diag(D, rows, cols)]

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -74,12 +74,8 @@ class abs(Elementwise):
             A list of SciPy CSC sparse matrices or None.
         """
         # Grad: +1 if positive, -1 if negative.
-        if self.expr.size != 1:
-            rows = self.expr.shape[0]*self.expr.shape[1]
-        else:
-            rows = 1
-        if self.size != 1:
-            cols = self.shape[0]*self.shape[1]
+        rows = self.expr.size
+        cols = self.size
         else:
             cols = 1
         D = np.matrix(np.zeros(self.expr.shape))


### PR DESCRIPTION
Hi,

I noticed that the absolute value atom has a few mistakes especially if the shape of the argument is (). This turns up in cases such as defining x = cvx.Variable(), setting y = cvx.abs(x), and querying for y.grad.

I've fixed this issue by setting row and col to 1 if either the inner or outer shapes are ().