### PR TITLE
fix for issue #608

### DIFF
--- a/cvxpy/atoms/affine/unary_operators.py
+++ b/cvxpy/atoms/affine/unary_operators.py
@@ -28,7 +28,7 @@ class UnaryOperator(AffAtom):
         super(UnaryOperator, self).__init__(expr)
 
     def name(self):
-        return self.OP_NAME + self.args[0].name()
+        return "%s(%s)" % (self.OP_NAME, self.args[0].name())
 
     # Applies the unary operator to the value.
     def numeric(self, values):


### PR DESCRIPTION
The bug reported in issue #608 is just an issue with printing unary operators. This fix puts parens around unary operator arguments. 