### PR TITLE
RF: Use a 2D np array instead of matrix to represent scalars.

### DIFF
--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -89,7 +89,7 @@ def format_matrix(matrix, shape=None, format='dense'):
     elif(format == 'sparse'):
         return scipy.sparse.coo_matrix(matrix)
     elif(format == 'scalar'):
-        return np.asfortranarray(np.matrix(matrix))
+        return np.asfortranarray([[matrix]])
     else:
         raise NotImplementedError()
 


### PR DESCRIPTION
This partially addresses #567 

This particular line causes a lot of warnings on our tests for the [DIPY](https://github.com/nipy/dipy) project (See https://travis-ci.org/nipy/dipy/jobs/461648463#L8748). 

I ran the test suite locally and it all passes with this change.

I'll also submit a separate PR that introduces similar changes in many other places where the np.matrix class is used, but I figured this one would be easy and quick to triage and review.