### PR TITLE
RF: Change np.matrix to np.array in several places.

### DIFF
--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -103,10 +103,7 @@ class diag_mat(AffAtom):
         """Extract the diagonal from a square matrix constant.
         """
         # The return type in numpy versions < 1.10 was ndarray.
-        v = np.diag(values[0])
-        if isinstance(v, np.matrix):
-            v = v.A[0]
-        return v
+        return np.diag(values[0])
 
     def shape_from_args(self):
         """A column vector.

--- a/cvxpy/atoms/cummax.py
+++ b/cvxpy/atoms/cummax.py
@@ -57,7 +57,7 @@ class cummax(AxisAtom):
             A NumPy ndarray or None.
         """
         # Grad: 1 for a largest index.
-        value = np.matrix(value).A.ravel(order='F')
+        value = np.array(value).A.ravel(order='F')
         idx = np.argmax(value)
         D = np.zeros((value.size, 1))
         D[idx] = 1

--- a/cvxpy/atoms/cummax.py
+++ b/cvxpy/atoms/cummax.py
@@ -57,7 +57,7 @@ class cummax(AxisAtom):
             A NumPy ndarray or None.
         """
         # Grad: 1 for a largest index.
-        value = np.array(value).A.ravel(order='F')
+        value = np.array(value).ravel(order='F')
         idx = np.argmax(value)
         D = np.zeros((value.size, 1))
         D[idx] = 1

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -76,7 +76,7 @@ class abs(Elementwise):
         # Grad: +1 if positive, -1 if negative.
         rows = self.expr.size
         cols = self.size
-        D = np.matrix(np.zeros(self.expr.shape))
+        D = np.zeros(self.expr.shape)
         D += (values[0] > 0)
         D -= (values[0] < 0)
         return [abs.elemwise_grad_to_diag(D, rows, cols)]

--- a/cvxpy/atoms/elementwise/maximum.py
+++ b/cvxpy/atoms/elementwise/maximum.py
@@ -86,8 +86,8 @@ class maximum(Elementwise):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        max_vals = np.matrix(self.numeric(values))
-        unused = np.matrix(np.ones(max_vals.shape), dtype=bool)
+        max_vals = self.numeric(values)
+        unused = np.ones(max_vals.shape, dtype=bool)
         grad_list = []
         for idx, value in enumerate(values):
             rows = self.args[idx].size

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -87,12 +87,12 @@ class log_det(Atom):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        X = np.matrix(values[0])
+        X = values[0]
         eigen_val = LA.eigvals(X)
         if np.min(eigen_val) > 0:
             # Grad: X^{-1}.T
             D = np.linalg.inv(X).T
-            return [sp.csc_matrix(D.A.ravel(order='F')).T]
+            return [sp.csc_matrix(D.ravel(order='F')).T]
         # Outside domain.
         else:
             return [None]

--- a/cvxpy/atoms/matrix_frac.py
+++ b/cvxpy/atoms/matrix_frac.py
@@ -138,7 +138,7 @@ class MatrixFrac(Atom):
 @wraps(MatrixFrac)
 def matrix_frac(X, P):
     if isinstance(P, np.ndarray):
-        invP = np.matrix(LA.inv(P))
-        return QuadForm(X, (invP + invP.H) / 2.0)
+        invP = LA.inv(P)
+        return QuadForm(X, (invP + np.conj(invP).T) / 2.0)
     else:
         return MatrixFrac(X, P)

--- a/cvxpy/atoms/max.py
+++ b/cvxpy/atoms/max.py
@@ -57,7 +57,7 @@ class max(AxisAtom):
             A NumPy ndarray or None.
         """
         # Grad: 1 for a largest index.
-        value = np.matrix(value).A.ravel(order='F')
+        value = np.array(value).ravel(order='F')
         idx = np.argmax(value)
         D = np.zeros((value.size, 1))
         D[idx] = 1

--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -228,10 +228,9 @@ class Pnorm(AxisAtom):
             value: A numeric value for a column.
 
         Returns:
-            A NumPy ndarray matrix or None.
+            A NumPy ndarray or None.
         """
         rows = self.args[0].size
-        value = np.matrix(value)
         # Outside domain.
         if self.p < 1 and np.any(value <= 0):
             return None
@@ -247,4 +246,4 @@ class Pnorm(AxisAtom):
         else:
             nominator = np.power(value, self.p - 1)
             frac = np.divide(nominator, denominator)
-            return np.reshape(frac.A, (frac.size, 1))
+            return np.reshape(frac, (frac.size, 1))

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -89,7 +89,7 @@ def format_matrix(matrix, shape=None, format='dense'):
     elif(format == 'sparse'):
         return scipy.sparse.coo_matrix(matrix)
     elif(format == 'scalar'):
-        return np.asfortranarray(np.matrix(matrix))
+        return np.asfortranarray([[matrix]])
     else:
         raise NotImplementedError()
 

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -147,37 +147,6 @@ class TestInterfaces(BaseTest):
         # shape.
         assert interface.shape(np.array([1, 2, 3])) == (3,)
 
-    # Test numpy matrix interface.
-    def test_numpy_matrix(self):
-        interface = intf.get_matrix_interface(np.matrix)
-        # const_to_matrix
-        mat = interface.const_to_matrix([1, 2, 3])
-        self.assertEqual(interface.shape(mat), (3, 1))
-        mat = interface.const_to_matrix([[1], [2], [3]])
-        self.assertEqual(mat[0, 0], 1)
-        # identity
-        # mat = interface.identity(4)
-        # cvxopt_dense = intf.get_matrix_interface(cvxopt.matrix)
-        # cmp_mat = interface.const_to_matrix(cvxopt_dense.identity(4))
-        # self.assertEqual(interface.shape(mat), interface.shape(cmp_mat))
-        # assert not (mat - cmp_mat).any()
-        # scalar_matrix
-        mat = interface.scalar_matrix(2, (4, 3))
-        self.assertEqual(interface.shape(mat), (4, 3))
-        self.assertEqual(interface.index(mat, (1, 2)), 2)
-        # reshape
-        mat = interface.const_to_matrix([[1, 2, 3], [3, 4, 5]])
-        mat = interface.reshape(mat, (6, 1))
-        self.assertEqual(interface.index(mat, (4, 0)), 4)
-        mat = interface.const_to_matrix(1, convert_scalars=True)
-        self.assertEqual(type(interface.reshape(mat, (1, 1))), type(mat))
-        # index
-        mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
-        self.assertEqual(interface.index(mat, (0, 1)), 3)
-        mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
-        assert not (mat - np.matrix("2 4; 4 6")).any()
-        # Sign
-        self.sign_for_intf(interface)
 
     # Test cvxopt sparse interface.
     def test_scipy_sparse(self):
@@ -212,7 +181,7 @@ class TestInterfaces(BaseTest):
         mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
         self.assertEqual(interface.index(mat, (0, 1)), 3)
         mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
-        assert not (mat - np.matrix("2 4; 4 6")).any()
+        assert not (mat - np.array([[2, 4], [4, 6]])).any()
         # scalar value
         mat = sp.eye(1)
         self.assertEqual(intf.scalar_value(mat), 1.0)
@@ -223,7 +192,6 @@ class TestInterfaces(BaseTest):
         """Test conversion between every pair of interfaces.
         """
         interfaces = [intf.get_matrix_interface(np.ndarray),
-                      intf.get_matrix_interface(np.matrix),
                       intf.get_matrix_interface(sp.csc_matrix)]
         cmp_mat = [[1, 2, 3, 4], [3, 4, 5, 6], [-1, 0, 2, 4]]
         for i in range(len(interfaces)):

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -147,6 +147,37 @@ class TestInterfaces(BaseTest):
         # shape.
         assert interface.shape(np.array([1, 2, 3])) == (3,)
 
+    # Test numpy matrix interface.
+    def test_numpy_matrix(self):
+        interface = intf.get_matrix_interface(np.matrix)
+        # const_to_matrix
+        mat = interface.const_to_matrix([1, 2, 3])
+        self.assertEqual(interface.shape(mat), (3, 1))
+        mat = interface.const_to_matrix([[1], [2], [3]])
+        self.assertEqual(mat[0, 0], 1)
+        # identity
+        # mat = interface.identity(4)
+        # cvxopt_dense = intf.get_matrix_interface(cvxopt.matrix)
+        # cmp_mat = interface.const_to_matrix(cvxopt_dense.identity(4))
+        # self.assertEqual(interface.shape(mat), interface.shape(cmp_mat))
+        # assert not (mat - cmp_mat).any()
+        # scalar_matrix
+        mat = interface.scalar_matrix(2, (4, 3))
+        self.assertEqual(interface.shape(mat), (4, 3))
+        self.assertEqual(interface.index(mat, (1, 2)), 2)
+        # reshape
+        mat = interface.const_to_matrix([[1, 2, 3], [3, 4, 5]])
+        mat = interface.reshape(mat, (6, 1))
+        self.assertEqual(interface.index(mat, (4, 0)), 4)
+        mat = interface.const_to_matrix(1, convert_scalars=True)
+        self.assertEqual(type(interface.reshape(mat, (1, 1))), type(mat))
+        # index
+        mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
+        self.assertEqual(interface.index(mat, (0, 1)), 3)
+        mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
+        assert not (mat - np.matrix("2 4; 4 6")).any()
+        # Sign
+        self.sign_for_intf(interface)
 
     # Test cvxopt sparse interface.
     def test_scipy_sparse(self):
@@ -181,7 +212,7 @@ class TestInterfaces(BaseTest):
         mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
         self.assertEqual(interface.index(mat, (0, 1)), 3)
         mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
-        assert not (mat - np.array([[2, 4], [4, 6]])).any()
+        assert not (mat - np.matrix("2 4; 4 6")).any()
         # scalar value
         mat = sp.eye(1)
         self.assertEqual(intf.scalar_value(mat), 1.0)
@@ -192,6 +223,7 @@ class TestInterfaces(BaseTest):
         """Test conversion between every pair of interfaces.
         """
         interfaces = [intf.get_matrix_interface(np.ndarray),
+                      intf.get_matrix_interface(np.matrix),
                       intf.get_matrix_interface(sp.csc_matrix)]
         cmp_mat = [[1, 2, 3, 4], [3, 4, 5, 6], [-1, 0, 2, 4]]
         for i in range(len(interfaces)):


### PR DESCRIPTION
This addresses #567 and is an expanded version of #637.
    
I introduced no changes in tests or examples, but otherwise I think that I got most cases where `np.matrix` is used. The test suite passes locally, but this clearly offers no guarantee, as I can already see that I have a few places where more fixing is required.