### PR TITLE
Expose `diff_pos`

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -35,6 +35,7 @@ from cvxpy.atoms.mixed_norm import mixed_norm
 from cvxpy.atoms.norm1 import norm1
 from cvxpy.atoms.norm_inf import norm_inf
 from cvxpy.atoms.one_minus_pos import one_minus_pos
+from cvxpy.atoms.one_minus_pos import diff_pos
 from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
 from cvxpy.atoms.pnorm import pnorm, Pnorm
 from cvxpy.atoms.prod import prod, Prod


### PR DESCRIPTION
The `diff_pos` atom is not exposed, but should be.