### PR TITLE
Avoid useless COO -> CSC sparse matrix convertions

### DIFF
--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -129,7 +129,7 @@ class AffAtom(Atom):
             None
         )
         shape = (offset, self.size)
-        stacked_grad = sp.coo_matrix((V, (J, I)), shape=shape).tocsc()
+        stacked_grad = sp.csc_matrix((V, (J, I)), shape=shape)
         # Break up into per argument matrices.
         grad_list = []
         start = 0

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -51,8 +51,8 @@ def get_diff_mat(dim, axis):
             row_arr.append(i)
             col_arr.append(i-1)
 
-    mat = sp.coo_matrix((val_arr, (row_arr, col_arr)),
-                        (dim, dim)).tocsc()
+    mat = sp.csc_matrix((val_arr, (row_arr, col_arr)),
+                        (dim, dim))
     if axis == 0:
         return mat
     else:

--- a/cvxpy/constraints/utilities.py
+++ b/cvxpy/constraints/utilities.py
@@ -43,7 +43,7 @@ def format_axis(t, X, axis):
     terms = []
     # Make t_mat
     mat_shape = (cone_size, 1)
-    t_mat = sp.coo_matrix(([1.0], ([0], [0])), mat_shape).tocsc()
+    t_mat = sp.csc_matrix(([1.0], ([0], [0])), mat_shape)
     t_mat = lu.create_const(t_mat, mat_shape, sparse=True)
     t_vec = t
     if not t.shape:
@@ -61,7 +61,7 @@ def format_axis(t, X, axis):
     val_arr = (cone_size - 1)*[1.0]
     row_arr = range(1, cone_size)
     col_arr = range(cone_size-1)
-    X_mat = sp.coo_matrix((val_arr, (row_arr, col_arr)), mat_shape).tocsc()
+    X_mat = sp.csc_matrix((val_arr, (row_arr, col_arr)), mat_shape)
     X_mat = lu.create_const(X_mat, mat_shape, sparse=True)
     mul_shape = (cone_size, X.shape[1])
     terms += [lu.mul_expr(X_mat, X, mul_shape)]
@@ -118,5 +118,5 @@ def get_spacing_matrix(shape, spacing, offset):
         val_arr.append(1.0)
         row_arr.append(spacing*var_row + offset)
         col_arr.append(var_row)
-    mat = sp.coo_matrix((val_arr, (row_arr, col_arr)), shape).tocsc()
+    mat = sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
     return lu.create_const(mat, shape, sparse=True)

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -54,8 +54,8 @@ def upper_tri_to_full(n):
                 val_arr.append(1.0)
             count += 1
 
-    return sp.coo_matrix((val_arr, (row_arr, col_arr)),
-                         (n*n, entries)).tocsc()
+    return sp.csc_matrix((val_arr, (row_arr, col_arr)),
+                         (n*n, entries))
 
 
 class Variable(Leaf):

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -170,7 +170,7 @@ class ConicSolver(Solver):
             val_arr.append(np.float64(1.0))
             row_arr.append(spacing*var_row + offset)
             col_arr.append(var_row)
-        return sp.coo_matrix((val_arr, (row_arr, col_arr)), shape).tocsc()
+        return sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
 
     def format_constr(self, problem, constr, exp_cone_order):
         """


### PR DESCRIPTION
It's better to directly create a CSC matrix, than to create a COO only to convert it to a CSC after.