### PR TITLE
Replace deprecated functions calls

### DIFF
--- a/cvxpy/atoms/elementwise/minimum.py
+++ b/cvxpy/atoms/elementwise/minimum.py
@@ -88,8 +88,8 @@ class minimum(Elementwise):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        min_vals = np.matrix(self.numeric(values))
-        unused = np.matrix(np.ones(min_vals.shape), dtype=bool)
+        min_vals = np.array(self.numeric(values))
+        unused = np.array(np.ones(min_vals.shape), dtype=bool)
         grad_list = []
         for idx, value in enumerate(values):
             rows = self.args[idx].size

--- a/cvxpy/atoms/min.py
+++ b/cvxpy/atoms/min.py
@@ -57,7 +57,7 @@ class min(AxisAtom):
             A NumPy ndarray or None.
         """
         # Grad: 1 for a largest index.
-        value = np.matrix(value).A.ravel(order='F')
+        value = np.array(value).ravel(order='F')
         idx = np.argmin(value)
         D = np.zeros((value.size, 1))
         D[idx] = 1

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -102,8 +102,8 @@ class QuadForm(Atom):
                                self.args[1])
 
     def _grad(self, values):
-        x = np.matrix(values[0])
-        P = np.matrix(values[1])
+        x = np.array(values[0])
+        P = np.array(values[1])
         D = 2 * np.dot(P, x.T)
         return [sp.csc_matrix(D.A.ravel(order='F')).T]
 

--- a/cvxpy/interface/numpy_interface/ndarray_interface.py
+++ b/cvxpy/interface/numpy_interface/ndarray_interface.py
@@ -64,7 +64,7 @@ class NDArrayInterface(base.BaseMatrixInterface):
 
     # Get the value of the passed matrix, interpreted as a scalar.
     def scalar_value(self, matrix):
-        return numpy.asscalar(matrix)
+        return matrix.item()
 
     # A matrix with all entries equal to the given scalar value.
     def scalar_matrix(self, value, shape):

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -46,7 +46,7 @@ class ConeMatrixStuffing(MatrixStuffing):
         # Extract to c.T * x + r
         C, R = extractor.affine(problem.objective.expr)
 
-        c = np.asarray(C.todense()).flatten()
+        c = C.toarray().flatten()
         boolean, integer = extract_mip_idx(problem.variables())
         x = Variable(extractor.N, boolean=boolean, integer=integer)
 

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import numpy as np
-
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
 from cvxpy.reductions.matrix_stuffing import extract_mip_idx, MatrixStuffing

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -411,7 +411,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cvxpy.sum(Variable(2)).curvature, s.AFFINE)
         self.assertEqual(cvxpy.sum(Variable((2, 1)), keepdims=True).shape, (1, 1))
         # Mixed curvature.
-        mat = np.mat("1 -1")
+        mat = np.array([[1, -1]])
         self.assertEqual(cvxpy.sum(mat*square(Variable(2))).curvature, s.UNKNOWN)
 
         # Test with axis argument.
@@ -692,11 +692,11 @@ class TestAtoms(BaseTest):
         """Test the bmat atom.
         """
         v_np = np.ones((3, 1))
-        expr = bmat([[v_np, v_np], [np.zeros((2, 1)), np.mat([1, 2]).T]])
+        expr = np.vstack([np.hstack([v_np, v_np]), np.hstack([np.zeros((2, 1)), np.array([[1, 2]]).T])])
         self.assertEqual(expr.shape, (5, 2))
-        const = np.bmat([[v_np, v_np],
-                         [np.zeros((2, 1)), np.mat([1, 2]).T]])
-        self.assertItemsAlmostEqual(expr.value, const)
+        const = np.vstack([np.hstack([v_np, v_np]),
+                         np.hstack([np.zeros((2, 1)), np.array([[1, 2]]).T])])
+        self.assertItemsAlmostEqual(expr, const)
 
     def test_conv(self):
         """Test the conv atom.

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -53,7 +53,7 @@ if MOSEK in INSTALLED_SOLVERS:
     SOLVERS_TO_TRY.append(MOSEK)
     SOLVER_TO_TOL[MOSEK] = 1e-6
 
-v_np = np.matrix([-1., 2, -2]).T
+v_np = np.array([-1., 2, -2]).T
 
 # Defined here to be used in KNOWN_SOLVER_ERRORS
 log_sum_exp_axis_0 = lambda x: log_sum_exp(x, axis=0, keepdims=True)
@@ -90,8 +90,8 @@ atoms = [
         (kl_div, tuple(), [math.e, 1], Constant([1])),
         (kl_div, tuple(), [math.e, math.e], Constant([0])),
         (kl_div, (2,), [[math.e, 1], 1], Constant([1, 0])),
-        (lambda x: kron(np.matrix("1 2; 3 4"), x), (4, 4), [np.matrix("5 6; 7 8")],
-            Constant(np.kron(np.matrix("1 2; 3 4").A, np.matrix("5 6; 7 8").A))),
+        (lambda x: kron(np.array([[1, 2], [3, 4]]), x), (4, 4), [np.array([[5, 6], [7, 8]])],
+            Constant(np.kron(np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]])))),
         (lambda_max, tuple(), [[[2, 0], [0, 1]]], Constant([2])),
         (lambda_max, tuple(), [[[2, 0, 0], [0, 3, 0], [0, 0, 1]]], Constant([3])),
 

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -144,13 +144,13 @@ class TestConstraints(BaseTest):
         assert constr.dual_value is None
         with self.assertRaises(ValueError):
             constr.value()
-        self.A.save_value(np.matrix("2 -1; 1 2"))
-        self.B.save_value(np.matrix("1 0; 0 1"))
+        self.A.save_value(np.array([[2, -1], [1, 2]]))
+        self.B.save_value(np.array([[1, 0], [0, 1]]))
         assert constr.value()
         self.assertAlmostEqual(constr.violation(), 0)
         self.assertAlmostEqual(constr.residual, 0)
 
-        self.B.save_value(np.matrix("3 0; 0 3"))
+        self.B.save_value(np.array([[3, 0], [0, 3]]))
         assert not constr.value()
         self.assertAlmostEqual(constr.violation(), 1)
         self.assertAlmostEqual(constr.residual, 1)
@@ -181,10 +181,10 @@ class TestConstraints(BaseTest):
         assert constr.dual_value is None
         with self.assertRaises(ValueError):
             constr.value()
-        self.B.save_value(np.matrix("2 -1; 1 2"))
-        self.A.save_value(np.matrix("1 0; 0 1"))
+        self.B.save_value(np.array([[2, -1], [1, 2]]))
+        self.A.save_value(np.array([[1, 0], [0, 1]]))
         assert constr.value()
-        self.A.save_value(np.matrix("3 0; 0 3"))
+        self.A.save_value(np.array([[3, 0], [0, 3]]))
         assert not constr.value()
 
         with self.assertRaises(Exception) as cm:

--- a/cvxpy/tests/test_convolution.py
+++ b/cvxpy/tests/test_convolution.py
@@ -105,8 +105,8 @@ class TestConvolution(BaseTest):
         """
         import numpy as np
         N = 5
-        y = np.asmatrix(np.random.randn(N, 1))
-        h = np.asmatrix(np.random.randn(2, 1))
+        y = np.random.randn(N, 1)
+        h = np.random.randn(2, 1)
         x = cvx.Variable(N)
         v = cvx.conv(h, x)
         obj = cvx.Minimize(cvx.sum(cvx.multiply(y, v[0:N])))

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -61,12 +61,12 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(dcp.variables()[0].value, 0.0)
 
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
-        self.assertAlmostEquals(dgp.value, 1.0)
-        self.assertAlmostEquals(x.value, 1.0)
+        self.assertAlmostEqual(dgp.value, 1.0)
+        self.assertAlmostEqual(x.value, 1.0)
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 1.0)
-        self.assertAlmostEquals(x.value, 1.0)
+        self.assertAlmostEqual(dgp.value, 1.0)
+        self.assertAlmostEqual(x.value, 1.0)
 
     def test_basic_gp(self):
         x, y, z = cvxpy.Variable((3,), pos=True)
@@ -90,13 +90,13 @@ class TestDgp2Dcp(BaseTest):
         dcp = dgp2dcp.reduce()
         opt = dcp.solve()
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
-        self.assertAlmostEquals(dgp.value, 6.0)
-        self.assertAlmostEquals(x.value, 1.0)
-        self.assertAlmostEquals(y.value, 4.0)
+        self.assertAlmostEqual(dgp.value, 6.0)
+        self.assertAlmostEqual(x.value, 1.0)
+        self.assertAlmostEqual(y.value, 4.0)
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 6.0)
-        self.assertAlmostEquals(x.value, 1.0)
+        self.assertAlmostEqual(dgp.value, 6.0)
+        self.assertAlmostEqual(x.value, 1.0)
 
     def test_prod(self):
         X = np.arange(12).reshape((4, 3))
@@ -171,13 +171,13 @@ class TestDgp2Dcp(BaseTest):
         dcp = dgp2dcp.reduce()
         opt = dcp.solve()
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
-        self.assertAlmostEquals(dgp.value, 6.0)
-        self.assertAlmostEquals(x.value, 1.0)
-        self.assertAlmostEquals(y.value, 4.0)
+        self.assertAlmostEqual(dgp.value, 6.0)
+        self.assertAlmostEqual(x.value, 1.0)
+        self.assertAlmostEqual(y.value, 4.0)
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 6.0)
-        self.assertAlmostEquals(x.value, 1.0)
+        self.assertAlmostEqual(dgp.value, 6.0)
+        self.assertAlmostEqual(x.value, 1.0)
 
     def test_minimum(self):
         x = cvxpy.Variable(pos=True)
@@ -192,9 +192,9 @@ class TestDgp2Dcp(BaseTest):
         
         dgp = cvxpy.Problem(obj, constr)
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 1.0 / (2.0 + 6.0))
-        self.assertAlmostEquals(x.value, 1.0)
-        self.assertAlmostEquals(y.value, 4.0)
+        self.assertAlmostEqual(dgp.value, 1.0 / (2.0 + 6.0))
+        self.assertAlmostEqual(x.value, 1.0)
+        self.assertAlmostEqual(y.value, 4.0)
 
     def test_min(self):
         x = cvxpy.Variable(pos=True)
@@ -209,9 +209,9 @@ class TestDgp2Dcp(BaseTest):
         
         dgp = cvxpy.Problem(obj, constr)
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 1.0 / (2.0 + 6.0))
-        self.assertAlmostEquals(x.value, 1.0)
-        self.assertAlmostEquals(y.value, 4.0)
+        self.assertAlmostEqual(dgp.value, 1.0 / (2.0 + 6.0))
+        self.assertAlmostEqual(x.value, 1.0)
+        self.assertAlmostEqual(y.value, 4.0)
 
     def test_sum_largest(self):
         self.skipTest("Enable test once sum_largest is implemented.")
@@ -224,13 +224,13 @@ class TestDgp2Dcp(BaseTest):
         dcp.solve()
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
         opt = 6.0
-        self.assertAlmostEquals(dgp.value, opt)
-        self.assertAlmostEquals((x[0] * x[1] * x[2] * x[3]).value, 16,
+        self.assertAlmostEqual(dgp.value, opt)
+        self.assertAlmostEqual((x[0] * x[1] * x[2] * x[3]).value, 16,
                                 places=2)
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, opt)
-        self.assertAlmostEquals((x[0] * x[1] * x[2] * x[3]).value, 16,
+        self.assertAlmostEqual(dgp.value, opt)
+        self.assertAlmostEqual((x[0] * x[1] * x[2] * x[3]).value, 16,
                                 places=2)
 
         # An unbounded problem.
@@ -242,14 +242,14 @@ class TestDgp2Dcp(BaseTest):
         dgp2dcp = cvxpy.reductions.Dgp2Dcp(dgp)
         dcp = dgp2dcp.reduce()
         opt = dcp.solve()
-        self.assertEquals(dcp.value, -float("inf"))
+        self.assertEqual(dcp.value, -float("inf"))
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
-        self.assertAlmostEquals(dgp.value, 0.0)
-        self.assertAlmostEquals(dgp.status, "unbounded")
+        self.assertAlmostEqual(dgp.value, 0.0)
+        self.assertAlmostEqual(dgp.status, "unbounded")
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 0.0)
-        self.assertAlmostEquals(dgp.status, "unbounded")
+        self.assertAlmostEqual(dgp.value, 0.0)
+        self.assertAlmostEqual(dgp.status, "unbounded")
 
         # Another unbounded problem.
         x = cvxpy.Variable(2, pos=True)
@@ -258,14 +258,14 @@ class TestDgp2Dcp(BaseTest):
         dgp2dcp = cvxpy.reductions.Dgp2Dcp(dgp)
         dcp = dgp2dcp.reduce()
         opt = dcp.solve()
-        self.assertEquals(dcp.value, -float("inf"))
+        self.assertEqual(dcp.value, -float("inf"))
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
-        self.assertAlmostEquals(dgp.value, 0.0)
-        self.assertAlmostEquals(dgp.status, "unbounded")
+        self.assertAlmostEqual(dgp.value, 0.0)
+        self.assertAlmostEqual(dgp.status, "unbounded")
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, 0.0)
-        self.assertAlmostEquals(dgp.status, "unbounded")
+        self.assertAlmostEqual(dgp.value, 0.0)
+        self.assertAlmostEqual(dgp.status, "unbounded")
 
         # Composition with posynomials.
         x = cvxpy.Variable((4,), pos=True)
@@ -280,22 +280,22 @@ class TestDgp2Dcp(BaseTest):
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
         # opt = 3 * sqrt(4) * sqrt(4) + (4 * 4 + 0.5 * 4 * epsilon) = 28
         opt = 28.0
-        self.assertAlmostEquals(dgp.value, opt, places=2)
-        self.assertAlmostEquals((x[0] * x[1]).value, 16.0, places=2)
-        self.assertAlmostEquals(x[3].value, 0.0, places=2)
+        self.assertAlmostEqual(dgp.value, opt, places=2)
+        self.assertAlmostEqual((x[0] * x[1]).value, 16.0, places=2)
+        self.assertAlmostEqual(x[3].value, 0.0, places=2)
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertAlmostEquals(dgp.value, opt, places=2)
-        self.assertAlmostEquals((x[0] * x[1]).value, 16.0, places=2)
-        self.assertAlmostEquals(x[3].value, 0.0, places=2)
+        self.assertAlmostEqual(dgp.value, opt, places=2)
+        self.assertAlmostEqual((x[0] * x[1]).value, 16.0, places=2)
+        self.assertAlmostEqual(x[3].value, 0.0, places=2)
 
     def test_div(self):
       x = cvxpy.Variable(pos=True)
       y = cvxpy.Variable(pos=True)
       p = cvxpy.Problem(cvxpy.Minimize(x * y), [y / 3  <= x, y >= 1])
-      self.assertAlmostEquals(p.solve(gp=True), 1.0 / 3.0)
-      self.assertAlmostEquals(y.value, 1.0)
-      self.assertAlmostEquals(x.value, 1.0 / 3.0)
+      self.assertAlmostEqual(p.solve(gp=True), 1.0 / 3.0)
+      self.assertAlmostEqual(y.value, 1.0)
+      self.assertAlmostEqual(x.value, 1.0 / 3.0)
 
     def test_geo_mean(self):
         x = cvxpy.Variable(3, pos=True)
@@ -305,18 +305,18 @@ class TestDgp2Dcp(BaseTest):
         dgp2dcp = cvxpy.reductions.Dgp2Dcp(dgp)
         dcp = dgp2dcp.reduce()
         dcp.solve()
-        self.assertEquals(dcp.value, -float("inf"))
+        self.assertEqual(dcp.value, -float("inf"))
         dgp.unpack(dgp2dcp.retrieve(dcp.solution))
-        self.assertEquals(dgp.value, 0.0)
-        self.assertEquals(dgp.status, "unbounded")
+        self.assertEqual(dgp.value, 0.0)
+        self.assertEqual(dgp.status, "unbounded")
         dgp._clear_solution()
         dgp.solve(gp=True)
-        self.assertEquals(dgp.value, 0.0)
-        self.assertEquals(dgp.status, "unbounded")
+        self.assertEqual(dgp.value, 0.0)
+        self.assertEqual(dgp.status, "unbounded")
 
     def test_solving_non_dgp_problem_raises_error(self):
         problem = cvxpy.Problem(cvxpy.Minimize(-1.0 * cvxpy.Variable()), [])
-        with self.assertRaisesRegexp(error.DGPError, "Problem does not follow "
+        with self.assertRaisesRegex(error.DGPError, "Problem does not follow "
           "DGP rules. However, the problem does follow DCP rules. "
           "Consider calling this function with `gp=False`."):
             problem.solve(gp=True)
@@ -328,7 +328,7 @@ class TestDgp2Dcp(BaseTest):
         problem = cvxpy.Problem(
           cvxpy.Minimize(cvxpy.Variable(pos=True) * cvxpy.Variable(pos=True)),
             [])
-        with self.assertRaisesRegexp(error.DCPError, "Problem does not follow "
+        with self.assertRaisesRegex(error.DCPError, "Problem does not follow "
           "DCP rules. However, the problem does follow DGP rules. "
           "Consider calling this function with `gp=True`."):
             problem.solve()

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -316,7 +316,7 @@ class TestDgp2Dcp(BaseTest):
 
     def test_solving_non_dgp_problem_raises_error(self):
         problem = cvxpy.Problem(cvxpy.Minimize(-1.0 * cvxpy.Variable()), [])
-        with self.assertRaisesRegex(error.DGPError, "Problem does not follow "
+        with self.assertRaisesRegexp(error.DGPError, "Problem does not follow "
           "DGP rules. However, the problem does follow DCP rules. "
           "Consider calling this function with `gp=False`."):
             problem.solve(gp=True)
@@ -328,7 +328,7 @@ class TestDgp2Dcp(BaseTest):
         problem = cvxpy.Problem(
           cvxpy.Minimize(cvxpy.Variable(pos=True) * cvxpy.Variable(pos=True)),
             [])
-        with self.assertRaisesRegex(error.DCPError, "Problem does not follow "
+        with self.assertRaisesRegexp(error.DCPError, "Problem does not follow "
           "DCP rules. However, the problem does follow DGP rules. "
           "Consider calling this function with `gp=True`."):
             problem.solve()

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -110,7 +110,7 @@ class TestDomain(BaseTest):
     #     dom = lambda_max(self.A).domain
     #     A0 = [[1, 2], [3, 4]]
     #     Problem(Minimize(norm2(self.A-A0)), dom).solve()
-    #     self.assertItemsAlmostEqual(self.A.value, np.matrix([[1, 2.5], [2.5, 4]]))
+    #     self.assertItemsAlmostEqual(self.A.value, np.array([[1, 2.5], [2.5, 4]]))
 
     def test_pnorm(self):
         """ Test domain for pnorm.

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -33,10 +33,10 @@ class TestExamples(BaseTest):
         # fashion: P = {x : a_i'*x <= b_i, i=1,...,m} where x is in R^2
 
         # Generate the input data
-        a1 = np.matrix("2; 1")
-        a2 = np.matrix(" 2; -1")
-        a3 = np.matrix("-1;  2")
-        a4 = np.matrix("-1; -2")
+        a1 = np.array([2, 1])
+        a2 = np.array([2, -1])
+        a3 = np.array([-1, 2])
+        a4 = np.array([-1, -2])
         b = np.ones(4)
 
         # Create and solve the model
@@ -326,17 +326,17 @@ class TestExamples(BaseTest):
 
     def test_log_det(self):
         # Generate data
-        x = np.matrix("0.55  0.0;"
-                      "0.25  0.35;"
-                      "-0.2   0.2;"
-                      "-0.25 -0.1;"
-                      "-0.0  -0.3;"
-                      "0.4  -0.2").T
+        x = np.array([[0.55, 0.0],
+                      [0.25, 0.35],
+                      [-0.2, 0.2],
+                      [-0.25, -0.1],
+                      [-0.0, -0.3],
+                      [0.4, -0.2]]).T
         (n, m) = x.shape
 
         # Create and solve the model
-        A = cvx.Variable((n, n));
-        b = cvx.Variable((n, 1));
+        A = cvx.Variable((n, n))
+        b = cvx.Variable(n)
         obj = cvx.Maximize(cvx.log_det(A))
         constraints = []
         for i in range(m):
@@ -354,7 +354,7 @@ class TestExamples(BaseTest):
         n = 100  # 10000
         m = 10  # 100
         pbar = (np.ones((n, 1)) * .03 +
-                np.matrix(np.append(np.random.rand(n - 1, 1), 0)).T * .12)
+                np.array(np.append(np.random.rand(n - 1, 1), 0)).T * .12)
 
         F = sp.rand(m, n, density=0.01)
         F.data = np.ones(len(F.data))
@@ -646,7 +646,7 @@ class TestExamples(BaseTest):
         np.random.seed(1)
         m = 5
         n = 2
-        X = np.matrix(np.ones((m, n)))
+        X = np.ones((m, n))
         w = cvx.Variable(n)
 
         expr2 = [cvx.log_sum_exp(cvx.hstack([0, X[i, :]*w])) for i in range(m)]

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -651,7 +651,7 @@ class TestExpressions(BaseTest):
         with self.assertRaises(Exception) as cm:
             (self.x/[2, 2, 3])
         print(cm.exception)
-        self.assertRegex(str(cm.exception),
+        self.assertRegexpMatches(str(cm.exception),
                          "Incompatible shapes for division.*")
 
         c = Constant([3.0, 4.0, 12.0])

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -651,7 +651,7 @@ class TestExpressions(BaseTest):
         with self.assertRaises(Exception) as cm:
             (self.x/[2, 2, 3])
         print(cm.exception)
-        self.assertRegexpMatches(str(cm.exception),
+        self.assertRegex(str(cm.exception),
                          "Incompatible shapes for division.*")
 
         c = Constant([3.0, 4.0, 12.0])

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -151,7 +151,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(var.name(), "x.T")
         self.assertEqual(var.shape, (1, 2))
 
-        x.save_value(np.matrix([1, 2]).T)
+        x.save_value(np.array([[1, 2]]).T)
         self.assertEqual(var.value[0, 0], 1)
         self.assertEqual(var.value[0, 1], 2)
 
@@ -269,8 +269,9 @@ class TestExpressions(BaseTest):
         m, n = 10, 5
         A = np.random.randn(m, n) + 1j * np.random.randn(m, n)  # a random complex matrix
         A = np.dot(A.T.conj(), A)  # a random Hermitian positive definite matrix
-        A = np.bmat([[np.real(A), -np.imag(A)],
-                     [np.imag(A), np.real(A)]])
+        A = np.vstack([np.hstack([np.real(A), -np.imag(A)]),
+                     np.hstack([np.imag(A), np.real(A)])])
+
         p = Parameter(shape=(2*n, 2*n), PSD=True)
         p.value = A
         self.assertItemsAlmostEqual(p.value, A)

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -46,14 +46,14 @@ class TestGrad(BaseTest):
         """Test gradient for affine_prod
         """
         expr = self.C * self.A
-        self.C.value = np.matrix([[1, -2], [3, 4], [-1, -3]])
-        self.A.value = np.matrix([[3, 2], [-5, 1]])
+        self.C.value = np.array([[1, -2], [3, 4], [-1, -3]])
+        self.A.value = np.array([[3, 2], [-5, 1]])
 
-        self.assertItemsAlmostEqual(expr.grad[self.C].todense(),
-                                    np.matrix([[3, 0, 0, 2, 0, 0], [0, 3, 0, 0, 2, 0], [0, 0, 3, 0, 0, 2],
+        self.assertItemsAlmostEqual(expr.grad[self.C].toarray(),
+                                    np.array([[3, 0, 0, 2, 0, 0], [0, 3, 0, 0, 2, 0], [0, 0, 3, 0, 0, 2],
                                                [-5, 0, 0, 1, 0, 0], [0, -5, 0, 0, 1, 0], [0, 0, -5, 0, 0, 1]]))
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(),
-                                    np.matrix([[1, 3, -1, 0, 0, 0], [-2, 4, -3, 0, 0, 0],
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(),
+                                    np.array([[1, 3, -1, 0, 0, 0], [-2, 4, -3, 0, 0, 0],
                                                [0, 0, 0, 1, 3, -1], [0, 0, 0, -2, 4, -3]]))
 
     def test_pnorm(self):
@@ -61,14 +61,14 @@ class TestGrad(BaseTest):
         """
         expr = pnorm(self.x, 1)
         self.x.value = [-1, 0]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [-1, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [-1, 0])
 
         self.x.value = [0, 10]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [0, 1])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [0, 1])
 
         expr = pnorm(self.x, 2)
         self.x.value = [-3, 4]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), np.matrix([[-3.0/5], [4.0/5]]))
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), np.array([[-3.0/5], [4.0/5]]))
 
         expr = pnorm(self.x, 0.5)
         self.x.value = [-1, 2]
@@ -80,57 +80,57 @@ class TestGrad(BaseTest):
 
         expr = pnorm(self.x, 2)
         self.x.value = [0, 0]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [0, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [0, 0])
 
         expr = pnorm(self.x[:,None], 2, axis=1)
         self.x.value = [1, 2]
         val = np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = pnorm(self.A, 2)
-        self.A.value = np.matrix([[2, -2], [2, 2]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [0.5, 0.5, -0.5, 0.5])
+        self.A.value = np.array([[2, -2], [2, 2]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0.5, 0.5, -0.5, 0.5])
 
         expr = pnorm(self.A, 2, axis=0)
-        self.A.value = np.matrix([[3, -3], [4, 4]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), np.matrix([[0.6, 0], [0.8, 0], [0, -0.6], [0, 0.8]]))
+        self.A.value = np.array([[3, -3], [4, 4]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), np.array([[0.6, 0], [0.8, 0], [0, -0.6], [0, 0.8]]))
 
         expr = pnorm(self.A, 2, axis=1)
-        self.A.value = np.matrix([[3, -4], [4, 3]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), np.matrix([[0.6, 0], [0, 0.8], [-0.8, 0], [0, 0.6]]))
+        self.A.value = np.array([[3, -4], [4, 3]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), np.array([[0.6, 0], [0, 0.8], [-0.8, 0], [0, 0.6]]))
 
         expr = pnorm(self.A, 0.5)
-        self.A.value = np.matrix([[3, -4], [4, 3]])
+        self.A.value = np.array([[3, -4], [4, 3]])
         self.assertAlmostEqual(expr.grad[self.A], None)
 
     def test_log_sum_exp(self):
         expr = log_sum_exp(self.x)
         self.x.value = [0, 1]
         e = np.exp(1)
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [1.0/(1+e), e/(1+e)])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [1.0/(1+e), e/(1+e)])
 
         expr = log_sum_exp(self.A)
-        self.A.value = np.matrix([[0, 1], [-1, 0]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [1.0/(2+e+1.0/e), 1.0/e/(2+e+1.0/e), e/(2+e+1.0/e), 1.0/(2+e+1.0/e)])
+        self.A.value = np.array([[0, 1], [-1, 0]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1.0/(2+e+1.0/e), 1.0/e/(2+e+1.0/e), e/(2+e+1.0/e), 1.0/(2+e+1.0/e)])
 
         expr = log_sum_exp(self.A, axis=0)
-        self.A.value = np.matrix([[0, 1], [-1, 0]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(),
-                                    np.transpose(np.matrix([[1.0/(1+1.0/e), 1.0/e/(1+1.0/e), 0, 0], [0, 0, e/(1+e), 1.0/(1+e)]])))
+        self.A.value = np.array([[0, 1], [-1, 0]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(),
+                                    np.transpose(np.array([[1.0/(1+1.0/e), 1.0/e/(1+1.0/e), 0, 0], [0, 0, e/(1+e), 1.0/(1+e)]])))
 
     def test_geo_mean(self):
         """Test gradient for geo_mean
         """
         expr = geo_mean(self.x)
         self.x.value = [1, 2]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [np.sqrt(2)/2, 1.0/2/np.sqrt(2)])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [np.sqrt(2)/2, 1.0/2/np.sqrt(2)])
 
         self.x.value = [0, 2]
         self.assertAlmostEqual(expr.grad[self.x], None)
 
         expr = geo_mean(self.x, [1, 0])
         self.x.value = [1, 2]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [1, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [1, 0])
 
         # No exception for single weight.
         self.x.value = [-1, 2]
@@ -141,13 +141,13 @@ class TestGrad(BaseTest):
         """
         expr = lambda_max(self.A)
         self.A.value = [[2, 0], [0, 1]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [1, 0, 0, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 0, 0])
 
         self.A.value = [[1, 0], [0, 2]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [0, 0, 0, 1])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 0, 0, 1])
 
         self.A.value = [[1, 0], [0, 1]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [0, 0, 0, 1])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 0, 0, 1])
 
     def test_matrix_frac(self):
         """Test gradient for matrix_frac
@@ -155,8 +155,8 @@ class TestGrad(BaseTest):
         expr = matrix_frac(self.A, self.B)
         self.A.value = np.eye(2)
         self.B.value = np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [2, 0, 0, 2])
-        self.assertItemsAlmostEqual(expr.grad[self.B].todense(), [-1, 0, 0, -1])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [2, 0, 0, 2])
+        self.assertItemsAlmostEqual(expr.grad[self.B].toarray(), [-1, 0, 0, -1])
 
         self.B.value = np.zeros((2, 2))
         self.assertAlmostEqual(expr.grad[self.A], None)
@@ -165,46 +165,46 @@ class TestGrad(BaseTest):
         expr = matrix_frac(self.x[:, None], self.A)
         self.x.value = [2, 3]
         self.A.value = np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [4, 6])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [-4, -6, -6, -9])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [4, 6])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [-4, -6, -6, -9])
 
         expr = matrix_frac(self.x, self.A)
         self.x.value = [2, 3]
         self.A.value = np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [4, 6])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [-4, -6, -6, -9])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [4, 6])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [-4, -6, -6, -9])
 
     def test_norm_nuc(self):
         """Test gradient for norm_nuc
         """
         expr = normNuc(self.A)
         self.A.value = [[10, 4], [4, 30]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [1, 0, 0, 1])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 0, 1])
 
     def test_log_det(self):
         """Test gradient for log_det
         """
         expr = log_det(self.A)
         self.A.value = 2*np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), 1.0/2*np.eye(2))
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), 1.0/2*np.eye(2))
 
-        mat = np.matrix([[1, 2], [3, 5]])
-        self.A.value = mat.T*mat
+        mat = np.array([[1, 2], [3, 5]])
+        self.A.value = mat.T.dot(mat)
         val = np.linalg.inv(self.A.value).T
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
         self.A.value = np.zeros((2, 2))
         self.assertAlmostEqual(expr.grad[self.A], None)
 
-        self.A.value = -np.matrix([[1, 2], [3, 4]])
+        self.A.value = -np.array([[1, 2], [3, 4]])
         self.assertAlmostEqual(expr.grad[self.A], None)
 
         K = Variable((8, 8))
         expr = log_det(K[[1,2]][:,[1,2]])
         K.value = np.eye(8)
         val = np.zeros((8,8))
-        val[[1,2],[1,2]] = 1
-        self.assertItemsAlmostEqual(expr.grad[K].todense(), val)
+        val[[1, 2], [1, 2]] = 1
+        self.assertItemsAlmostEqual(expr.grad[K].toarray(), val)
 
     def test_quad_over_lin(self):
         """Test gradient for quad_over_lin
@@ -212,7 +212,7 @@ class TestGrad(BaseTest):
         expr = quad_over_lin(self.x, self.a)
         self.x.value = [1, 2]
         self.a.value = 2
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [1, 2])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [1, 2])
         self.assertAlmostEqual(expr.grad[self.a], [-1.25])
 
         self.a.value = 0
@@ -222,7 +222,7 @@ class TestGrad(BaseTest):
         expr = quad_over_lin(self.A, self.a)
         self.A.value = np.eye(2)
         self.a.value = 2
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [1, 0, 0, 1])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 0, 1])
         self.assertAlmostEqual(expr.grad[self.a], [-0.5])
 
         expr = quad_over_lin(self.x, self.a) + quad_over_lin(self.y, self.a)
@@ -230,8 +230,8 @@ class TestGrad(BaseTest):
         self.a.value = 2
         self.y.value = [1, 2]
         self.a.value = 2
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [1, 2])
-        self.assertItemsAlmostEqual(expr.grad[self.y].todense(), [1, 2])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [1, 2])
+        self.assertItemsAlmostEqual(expr.grad[self.y].toarray(), [1, 2])
         self.assertAlmostEqual(expr.grad[self.a], [-2.5])
 
     def test_max(self):
@@ -239,29 +239,29 @@ class TestGrad(BaseTest):
         """
         expr = max(self.x)
         self.x.value = [2, 1]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), [1, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [1, 0])
 
         expr = max(self.A)
-        self.A.value = np.matrix([[1, 2], [4, 3]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [0, 1, 0, 0])
+        self.A.value = np.array([[1, 2], [4, 3]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 1, 0, 0])
 
         expr = max(self.A, axis=0)
-        self.A.value = np.matrix([[1, 2], [4, 3]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), np.matrix([[0, 0], [1, 0], [0, 0], [0, 1]]))
+        self.A.value = np.array([[1, 2], [4, 3]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), np.array([[0, 0], [1, 0], [0, 0], [0, 1]]))
 
         expr = max(self.A, axis=1)
-        self.A.value = np.matrix([[1, 2], [4, 3]])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), np.matrix([[0, 0], [0, 1], [1, 0], [0, 0]]))
+        self.A.value = np.array([[1, 2], [4, 3]])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), np.array([[0, 0], [0, 1], [1, 0], [0, 0]]))
 
     def test_sigma_max(self):
         """Test sigma_max.
         """
         expr = sigma_max(self.A)
         self.A.value = [[1, 0], [0, 2]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [0, 0, 0, 1])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 0, 0, 1])
 
         self.A.value = [[1, 0], [0, 1]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [1, 0, 0, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 0, 0])
 
     def test_sum_largest(self):
         """Test sum_largest.
@@ -269,10 +269,10 @@ class TestGrad(BaseTest):
         expr = sum_largest(self.A, 2)
 
         self.A.value = [[4, 3], [2, 1]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [1, 0, 1, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 1, 0])
 
         self.A.value = [[1, 2], [3, 0.5]]
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), [0, 1, 1, 0])
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 1, 1, 0])
 
     def test_abs(self):
         """Test abs.
@@ -280,7 +280,7 @@ class TestGrad(BaseTest):
         expr = abs(self.A)
         self.A.value = [[1, 2], [-1, 0]]
         val = np.zeros((4, 4)) + np.diag([1, 1, -1, 0])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_linearize(self):
         """Test linearize method.
@@ -336,7 +336,7 @@ class TestGrad(BaseTest):
         expr = log(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) + np.diag([1/3, 1/4])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = log(self.x)
         self.x.value = [-1e-9, 4]
@@ -345,7 +345,7 @@ class TestGrad(BaseTest):
         expr = log(self.A)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag([1, 1/2, 1/3, 1/4])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_log1p(self):
         """Test domain for log1p.
@@ -363,7 +363,7 @@ class TestGrad(BaseTest):
         expr = log1p(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) + np.diag([1/4, 1/5])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = log1p(self.x)
         self.x.value = [-1e-9-1, 4]
@@ -372,7 +372,7 @@ class TestGrad(BaseTest):
         expr = log1p(self.A)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag([1/2, 1/3, 1/4, 1/5])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_entr(self):
         """Test domain for entr.
@@ -390,7 +390,7 @@ class TestGrad(BaseTest):
         expr = entr(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) + np.diag(-(np.log([3, 4]) + 1))
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = entr(self.x)
         self.x.value = [-1e-9, 4]
@@ -399,7 +399,7 @@ class TestGrad(BaseTest):
         expr = entr(self.A)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag(-(np.log([1, 2, 3, 4]) + 1))
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_exp(self):
         """Test domain for exp.
@@ -417,17 +417,17 @@ class TestGrad(BaseTest):
         expr = exp(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) + np.diag(np.exp([3, 4]))
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = exp(self.x)
         self.x.value = [-1e-9, 4]
         val = np.zeros((2, 2)) + np.diag(np.exp([-1e-9, 4]))
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = exp(self.A)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag(np.exp([1, 2, 3, 4]))
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_logistic(self):
         """Test domain for logistic.
@@ -445,17 +445,17 @@ class TestGrad(BaseTest):
         expr = logistic(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) + np.diag(np.exp([3, 4])/(1+np.exp([3, 4])))
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = logistic(self.x)
         self.x.value = [-1e-9, 4]
         val = np.zeros((2, 2)) + np.diag(np.exp([-1e-9, 4])/(1+np.exp([-1e-9, 4])))
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = logistic(self.A)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag(np.exp([1, 2, 3, 4])/(1+np.exp([1, 2, 3, 4])))
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_huber(self):
         """Test domain for huber.
@@ -474,17 +474,17 @@ class TestGrad(BaseTest):
         expr = huber(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) + np.diag([2, 2])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = huber(self.x)
         self.x.value = [-1e-9, 4]
         val = np.zeros((2, 2)) + np.diag([0, 2])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = huber(self.A, M=3)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag([2, 4, 6, 6])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
     def test_kl_div(self):
         """Test domain for kl_div.
@@ -511,9 +511,9 @@ class TestGrad(BaseTest):
         self.x.value = [3, 4]
         y.value = [5, 8]
         val = np.zeros((2, 2)) + np.diag(np.log([3, 4]) - np.log([5, 8]))
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
         val = np.zeros((2, 2)) + np.diag([1 - 3/5, 1 - 4/8])
-        self.assertItemsAlmostEqual(expr.grad[y].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[y].toarray(), val)
 
         expr = kl_div(self.x, y)
         self.x.value = [-1e-9, 4]
@@ -526,9 +526,9 @@ class TestGrad(BaseTest):
         self.B.value = [[5, 1], [3.5, 2.3]]
         div = (self.A.value/self.B.value).ravel(order='F')
         val = np.zeros((4, 4)) + np.diag(np.log(div))
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
         val = np.zeros((4, 4)) + np.diag(1 - div)
-        self.assertItemsAlmostEqual(expr.grad[self.B].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.B].toarray(), val)
 
     def test_maximum(self):
         """Test domain for maximum.
@@ -555,26 +555,26 @@ class TestGrad(BaseTest):
         self.x.value = [3, 4]
         y.value = [5, -5]
         val = np.zeros((2, 2)) + np.diag([0, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
         val = np.zeros((2, 2)) + np.diag([1, 0])
-        self.assertItemsAlmostEqual(expr.grad[y].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[y].toarray(), val)
 
         expr = maximum(self.x, y)
         self.x.value = [-1e-9, 4]
         y.value = [1, 4]
         val = np.zeros((2, 2)) + np.diag([0, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
         val = np.zeros((2, 2)) + np.diag([1, 0])
-        self.assertItemsAlmostEqual(expr.grad[y].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[y].toarray(), val)
 
         expr = maximum(self.A, self.B)
         self.A.value = [[1, 2], [3, 4]]
         self.B.value = [[5, 1], [3, 2.3]]
         div = (self.A.value/self.B.value).ravel(order='F')
         val = np.zeros((4, 4)) + np.diag([0, 1, 1, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
         val = np.zeros((4, 4)) + np.diag([1, 0, 0, 0])
-        self.assertItemsAlmostEqual(expr.grad[self.B].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.B].toarray(), val)
 
     def test_minimum(self):
         """Test domain for minimum.
@@ -601,26 +601,26 @@ class TestGrad(BaseTest):
         self.x.value = [3, 4]
         y.value = [5, -5]
         val = np.zeros((2, 2)) + np.diag([1, 0])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
         val = np.zeros((2, 2)) + np.diag([0, 1])
-        self.assertItemsAlmostEqual(expr.grad[y].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[y].toarray(), val)
 
         expr = minimum(self.x, y)
         self.x.value = [-1e-9, 4]
         y.value = [1, 4]
         val = np.zeros((2, 2)) + np.diag([1, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
         val = np.zeros((2, 2)) + np.diag([0, 0])
-        self.assertItemsAlmostEqual(expr.grad[y].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[y].toarray(), val)
 
         expr = minimum(self.A, self.B)
         self.A.value = [[1, 2], [3, 4]]
         self.B.value = [[5, 1], [3, 2.3]]
         div = (self.A.value/self.B.value).ravel(order='F')
         val = np.zeros((4, 4)) + np.diag([1, 0, 1, 0])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
         val = np.zeros((4, 4)) + np.diag([0, 1, 0, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.B].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.B].toarray(), val)
 
     def test_power(self):
         """Test domain for power.
@@ -637,24 +637,24 @@ class TestGrad(BaseTest):
 
         expr = (self.x)**3
         self.x.value = [3, 4]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(),
-                                    np.matrix("27 0; 0 48"))
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(),
+                                    np.array([[27, 0], [0, 48]]))
 
         expr = (self.x)**3
         self.x.value = [-1e-9, 4]
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), np.matrix("0 0; 0 48"))
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), np.array([[0, 0], [0, 48]]))
 
         expr = (self.A)**2
         self.A.value = [[1, -2], [3, 4]]
         val = np.zeros((4, 4)) + np.diag([2, -4, 6, 8])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
         # Constant.
         expr = (self.a)**0
         self.assertAlmostEqual(expr.grad[self.a], 0)
 
         expr = (self.x)**0
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), np.zeros((2, 2)))
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), np.zeros((2, 2)))
 
     def test_partial_problem(self):
         """Test grad for partial minimization/maximization problems.
@@ -679,7 +679,7 @@ class TestGrad(BaseTest):
             self.x.value = [10, 10]
             grad = expr.grad
             self.assertAlmostEqual(grad[self.a], obj.args[0].grad[self.a])
-            self.assertItemsAlmostEqual(grad[self.x].todense(), [0, 0, 0, 0])
+            self.assertItemsAlmostEqual(grad[self.x].toarray(), [0, 0, 0, 0])
 
             # Optimize over x.
             expr = partial_optimize(prob, opt_vars=[self.x])
@@ -694,7 +694,7 @@ class TestGrad(BaseTest):
             expr = partial_optimize(prob, opt_vars=[self.a])
             self.x.value = [0, 0]
             grad = expr.grad
-            self.assertItemsAlmostEqual(grad[self.x].todense(), dual_val)
+            self.assertItemsAlmostEqual(grad[self.x].toarray(), dual_val)
 
             # Optimize over x and a.
             expr = partial_optimize(prob, opt_vars=[self.x, self.a])
@@ -719,18 +719,18 @@ class TestGrad(BaseTest):
         expr = -(self.x)
         self.x.value = [3, 4]
         val = np.zeros((2, 2)) - np.diag([1, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = -(self.A)
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 4)) - np.diag([1, 1, 1, 1])
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
         expr = self.A[0, 1]
         self.A.value = [[1, 2], [3, 4]]
         val = np.zeros((4, 1))
         val[2] = 1
-        self.assertItemsAlmostEqual(expr.grad[self.A].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
         z = Variable(3)
         expr = hstack([self.x, z])
@@ -738,20 +738,20 @@ class TestGrad(BaseTest):
         z.value = [1, 2, 3]
         val = np.zeros((2, 5))
         val[:, 0:2] = np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         val = np.zeros((3, 5))
         val[:, 2:] = np.eye(3)
-        self.assertItemsAlmostEqual(expr.grad[z].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[z].toarray(), val)
 
         # cumsum
         expr = cumsum(self.x)
         self.x.value = [1, 2]
         val = np.ones((2, 2))
         val[1, 0] = 0
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
         expr = cumsum(self.x[:, None], axis=1)
         self.x.value = [1, 2]
         val = np.eye(2)
-        self.assertItemsAlmostEqual(expr.grad[self.x].todense(), val)
+        self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -175,7 +175,7 @@ class TestInterfaces(BaseTest):
         mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
         self.assertEqual(interface.index(mat, (0, 1)), 3)
         mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
-        assert not (mat - np.matrix("2 4; 4 6")).any()
+        assert not (mat - np.array([[2, 4], [4, 6]])).any()
         # Sign
         self.sign_for_intf(interface)
 
@@ -212,7 +212,7 @@ class TestInterfaces(BaseTest):
         mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
         self.assertEqual(interface.index(mat, (0, 1)), 3)
         mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
-        assert not (mat - np.matrix("2 4; 4 6")).any()
+        assert not (mat - np.array([[2, 4], [4, 6]])).any()
         # scalar value
         mat = sp.eye(1)
         self.assertEqual(intf.scalar_value(mat), 1.0)

--- a/cvxpy/tests/test_linear_cone.py
+++ b/cvxpy/tests/test_linear_cone.py
@@ -156,7 +156,7 @@ class TestLinearCone(BaseTest):
             self.assertItemsAlmostEqual(inv_sltn.primal_vars[self.x.id],
                                         self.x.value)
 
-            A = Constant(numpy.matrix([[3, 5], [1, 2]]).T).value
+            A = Constant(numpy.array([[3, 5], [1, 2]]).T).value
             I = Constant([[1, 0], [0, 1]])
             p = Problem(Minimize(c.T*self.x + self.a),
                         [A*self.x >= [-1, 1],

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -86,13 +86,13 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(self.x == v, (2,))
         self.assertExpression(v == self.x, (2,))
         # Matrix
-        A = numpy.matrix(numpy.arange(8).reshape((4, 2)))
+        A = numpy.arange(8).reshape((4, 2))
         self.assertExpression(A*self.x, (4,))
-        self.assertExpression((A.T*A) * self.x, (2,))
+        self.assertExpression((A.T.dot(A)) * self.x, (2,))
         if PY35:
             self.assertExpression(self.x.__rmatmul__(A), (4,))
         # PSD inequalities.
-        A = numpy.matrix(numpy.ones((2, 2)))
+        A = numpy.ones((2, 2))
         self.assertExpression(A << self.A, (2, 2))
         self.assertExpression(A >> self.A, (2, 2))
 
@@ -144,7 +144,7 @@ class TestMatrices(unittest.TestCase):
     def test_scipy_sparse(self):
         """Test scipy sparse matrices."""
         # Constants.
-        A = numpy.matrix(numpy.arange(8).reshape((4, 2)))
+        A = numpy.arange(8).reshape((4, 2))
         A = sp.csc_matrix(A)
         A = sp.eye(2).tocsc()
         key = (slice(0, 1, None), slice(None, None, None))
@@ -156,7 +156,7 @@ class TestMatrices(unittest.TestCase):
 
         # Linear ops.
         var = Variable((4, 2))
-        A = numpy.matrix(numpy.arange(8).reshape((4, 2)))
+        A = numpy.arange(8).reshape((4, 2))
         A = sp.csc_matrix(A)
         B = sp.hstack([A, A])
         self.assertExpression(var + A, (4, 2))

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -88,7 +88,7 @@ class TestMIPVariable(BaseTest):
         self.assertAlmostEqual(self.x_bool.value, 0, places=4)
 
         # Matrix Bool in objective.
-        C = np.matrix([[0, 1, 0], [1, 1, 1]]).T
+        C = np.array([[0, 1, 0], [1, 1, 1]]).T
         obj = cvx.Minimize(cvx.sum_squares(self.A_bool - C))
         p = cvx.Problem(obj,[])
         result = p.solve(solver=solver)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -628,13 +628,13 @@ class TestProblem(BaseTest):
 
     # Test vector LP problems.
     def test_vector_lp(self):
-        c = Constant(numpy.matrix([1, 2]).T).value
+        c = Constant(numpy.array([[1, 2]]).T).value
         p = Problem(cvx.Minimize(c.T*self.x), [self.x[:,None] >= c])
         result = p.solve()
         self.assertAlmostEqual(result, 5)
         self.assertItemsAlmostEqual(self.x.value, [1, 2])
 
-        A = Constant(numpy.matrix([[3, 5], [1, 2]]).T).value
+        A = Constant(numpy.array([[3, 5], [1, 2]]).T).value
         I = Constant([[1, 0], [0, 1]])
         p = Problem(cvx.Minimize(c.T*self.x + self.a),
                     [A*self.x >= [-1, 1],
@@ -666,7 +666,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.A.value, T)
 
         T = Constant(numpy.ones((2, 3))*2).value
-        c = Constant(numpy.matrix([3, 4]).T).value
+        c = Constant(numpy.array([[3, 4]]).T).value
         p = Problem(cvx.Minimize(1), [self.A >= T*self.C,
                                   self.A == self.B, self.C == T.T])
         result = p.solve(solver=cvx.ECOS)
@@ -897,7 +897,7 @@ class TestProblem(BaseTest):
                 self.assertAlmostEqual(p.constraints[2].dual_value, 0, places=acc)
 
                 T = numpy.ones((2, 3))*2
-                c = numpy.matrix([3, 4]).T
+                c = numpy.array([[3, 4]]).T
                 p = Problem(cvx.Minimize(1),
                             [self.A >= T*self.C,
                             self.A == self.B,
@@ -1049,7 +1049,7 @@ class TestProblem(BaseTest):
         result = p.solve()
         self.assertAlmostEqual(result, 0)
 
-        c = numpy.matrix([1, -1]).T
+        c = numpy.array([[1, -1]]).T
         p = Problem(cvx.Minimize(c.T * cvx.vstack([cvx.square(a), cvx.sqrt(b)])),
                     [a == 2,
                      b == 16])
@@ -1093,7 +1093,7 @@ class TestProblem(BaseTest):
         result = p.solve()
         self.assertAlmostEqual(result, 13)
 
-        c = numpy.matrix([1, -1]).T
+        c = numpy.array([[1, -1]]).T
         p = Problem(cvx.Minimize(c.T * cvx.hstack([cvx.square(a).T, cvx.sqrt(b).T]).T),
                     [a == 2,
                      b == 16])
@@ -1110,13 +1110,13 @@ class TestProblem(BaseTest):
 
     # Test variable transpose.
     def test_transpose(self):
-        p = Problem(cvx.Minimize(cvx.sum(self.x)), [self.x[None,:] >= numpy.matrix([1, 2])])
+        p = Problem(cvx.Minimize(cvx.sum(self.x)), [self.x[None,:] >= numpy.array([[1, 2]])])
         result = p.solve()
         self.assertAlmostEqual(result, 3)
         self.assertItemsAlmostEqual(self.x.value, [1, 2])
 
         p = Problem(cvx.Minimize(cvx.sum(self.C)),
-                    [numpy.matrix([1, 1])*self.C.T >= numpy.matrix([0, 1, 2])])
+                    [numpy.array([[1, 1]])*self.C.T >= numpy.array([[0, 1, 2]])])
         result = p.solve()
         value = self.C.value
 
@@ -1136,17 +1136,17 @@ class TestProblem(BaseTest):
         result = p.solve()
         self.assertAlmostEqual(result, -2)
 
-        c = numpy.matrix([1, -1]).T
+        c = numpy.array([[1, -1]]).T
         p = Problem(cvx.Minimize(cvx.maximum(c.T, 2, 2 + c.T)[0,1]))
         result = p.solve()
         self.assertAlmostEqual(result, 2)
 
-        c = numpy.matrix([[1, -1, 2], [1, -1, 2]]).T
+        c = numpy.array([[1, -1, 2], [1, -1, 2]]).T
         p = Problem(cvx.Minimize(cvx.sum(cvx.maximum(c, 2, 2 + c).T[:, 0])))
         result = p.solve()
         self.assertAlmostEqual(result, 6)
 
-        c = numpy.matrix([[1, -1, 2], [1, -1, 2]]).T
+        c = numpy.array([[1, -1, 2], [1, -1, 2]]).T
         p = Problem(cvx.Minimize(cvx.sum(cvx.square(c.T).T[:, 0])))
         result = p.solve()
         self.assertAlmostEqual(result, 6)
@@ -1160,7 +1160,7 @@ class TestProblem(BaseTest):
     def test_multiplication_on_left(self):
         """Test multiplication on the left by a non-constant.
         """
-        c = numpy.matrix([1, 2]).T
+        c = numpy.array([[1, 2]]).T
         p = Problem(cvx.Minimize(c.T*self.A*c), [self.A >= 2])
         result = p.solve()
         self.assertAlmostEqual(result, 18)
@@ -1292,7 +1292,7 @@ class TestProblem(BaseTest):
         p = Problem(obj, [self.x == 5])
         result = p.solve()
         self.assertAlmostEqual(result, 10)
-        self.assertItemsAlmostEqual(expr.value.todense(), [5, 10])
+        self.assertItemsAlmostEqual(expr.value.toarray(), [5, 10])
 
         # Test promotion.
         c = [[1, -1], [2, -2]]
@@ -1323,14 +1323,14 @@ class TestProblem(BaseTest):
 
         # Test vector to matrix.
         x = Variable(4)
-        mat = numpy.matrix([[1, -1], [2, -2]]).T
-        vec = numpy.matrix([1, 2, 3, 4]).T
-        vec_mat = numpy.matrix([[1, 2], [3, 4]]).T
+        mat = numpy.array([[1, -1], [2, -2]]).T
+        vec = numpy.array([[1, 2, 3, 4]]).T
+        vec_mat = numpy.array([[1, 2], [3, 4]]).T
         expr = cvx.reshape(x, (2, 2))
         obj = cvx.Minimize(cvx.sum(mat*expr))
         prob = Problem(obj, [x[:,None] == vec])
         result = prob.solve()
-        self.assertAlmostEqual(result, numpy.sum(mat*vec_mat))
+        self.assertAlmostEqual(result, numpy.sum(mat.dot(vec_mat)))
 
         # Test on matrix to vector.
         c = [1, 2, 3, 4]
@@ -1345,8 +1345,8 @@ class TestProblem(BaseTest):
 
         # Test matrix to matrix.
         expr = cvx.reshape(self.C, (2, 3))
-        mat = numpy.matrix([[1, -1], [2, -2]])
-        C_mat = numpy.matrix([[1, 4], [2, 5], [3, 6]])
+        mat = numpy.array([[1, -1], [2, -2]])
+        C_mat = numpy.array([[1, 4], [2, 5], [3, 6]])
         obj = cvx.Minimize(cvx.sum(mat*expr))
         prob = Problem(obj, [self.C == C_mat])
         result = prob.solve()
@@ -1355,7 +1355,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(expr.value, C_mat)
 
         # Test promoted expressions.
-        c = numpy.matrix([[1, -1], [2, -2]]).T
+        c = numpy.array([[1, -1], [2, -2]]).T
         expr = cvx.reshape(c*self.a, (1, 4))
         obj = cvx.Minimize(expr*[1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])

--- a/cvxpy/tests/test_qp.py
+++ b/cvxpy/tests/test_qp.py
@@ -205,10 +205,10 @@ class TestQp(BaseTest):
             self.assertItemsAlmostEqual(z, var.value, places=4)
 
     def quad_form_bound(self, solver):
-        P = np.matrix([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
-        q = np.matrix([[-22], [-14.5], [13]])
+        P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
+        q = np.array([[-22], [-14.5], [13]])
         r = 1
-        y_star = np.matrix([[1], [0.5], [-1]])
+        y_star = np.array([[1], [0.5], [-1]])
         p = Problem(Minimize(0.5*QuadForm(self.y, P) + q.T*self.y + r),
                     [self.y >= -1, self.y <= 1])
         self.solve_QP(p, solver)
@@ -220,15 +220,15 @@ class TestQp(BaseTest):
         # Number of examples to use
         n = 100
         # Specify the true value of the variable
-        true_coeffs = np.matrix('2; -2; 0.5')
+        true_coeffs = np.array([[2, -2, 0.5]]).T
         # Generate data
         x_data = np.random.rand(n) * 5
-        x_data = np.asmatrix(x_data)
+        x_data = np.atleast_2d(x_data)
         x_data_expanded = np.vstack([np.power(x_data, i)
                                      for i in range(1, 4)])
-        x_data_expanded = np.asmatrix(x_data_expanded)
-        y_data = x_data_expanded.T * true_coeffs + 0.5 * np.random.rand(n, 1)
-        y_data = np.asmatrix(y_data)
+        x_data_expanded = np.atleast_2d(x_data_expanded)
+        y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
+        y_data = np.atleast_2d(y_data)
 
         line = self.offset + x_data * self.slope
         residuals = line.T - y_data

--- a/cvxpy/tests/test_quadratic.py
+++ b/cvxpy/tests/test_quadratic.py
@@ -108,7 +108,7 @@ class TestExpressions(BaseTest):
     def test_quadratic_form(self):
         x = Variable(5)
         P = np.eye(5) - 2*np.ones((5, 5))
-        q = np.asmatrix(np.ones((5, 1)))
+        q = np.ones((5, 1))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             s = x.T*P*x + q.T*x

--- a/cvxpy/tests/test_scs.py
+++ b/cvxpy/tests/test_scs.py
@@ -88,19 +88,19 @@ class TestSCS(BaseTest):
         """Test complex matrices.
         """
         # Complex-valued matrix
-        K = np.matrix(np.random.rand(2,2) + 1j * np.random.rand(2,2) ) #  example matrix
+        K = np.array(np.random.rand(2, 2) + 1j * np.random.rand(2, 2))  # example matrix
         n1 = la.svdvals(K).sum()  # trace norm of K
 
         # Dual Problem
-        X = cvx.Variable((2,2), complex=True)
-        Y = cvx.Variable((2,2), complex=True)
-        Z = cvx.Variable((2,2))
+        X = cvx.Variable((2, 2), complex=True)
+        Y = cvx.Variable((2, 2), complex=True)
+        Z = cvx.Variable((2, 2))
         # X, Y >= 0 so trace is real
         objective = cvx.Minimize(
             cvx.real(0.5 * cvx.trace(X) + 0.5 * cvx.trace(Y))
         )
         constraints = [
-            cvx.bmat([[X, -K.H], [-K, Y]]) >> 0,
+            cvx.bmat([[X, -K.conj().T], [-K, Y]]) >> 0,
             X >> 0,
             Y >> 0,
         ]

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -27,7 +27,7 @@ class TestSemidefiniteVariable(BaseTest):
     def setUp(self):
         self.X = Variable((2, 2), PSD=True)
         self.Y = Variable((2, 2))
-        self.F = np.matrix([[1, 0], [0, -1]])
+        self.F = np.array([[1, 0], [0, -1]])
 
     def test_symm(self):
         """Test that results are symmetric.

--- a/cvxpy/tests/test_solvers.py
+++ b/cvxpy/tests/test_solvers.py
@@ -321,7 +321,7 @@ class TestSolvers(BaseTest):
             h = cvx.Parameter(2)
             c = cvx.Parameter(2)
 
-            A.value = np.matrix([[1, 0], [0, 0]])
+            A.value = np.array([[1, 0], [0, 0]])
             b.value = np.array([1, 0])
             h.value = np.array([2, 2])
             c.value = np.array([1, 1])
@@ -338,7 +338,7 @@ class TestSolvers(BaseTest):
             orig_x = self.x.value
 
             # Change A and b from the original values
-            A.value = np.matrix([[0, 0], [0, 1]])   # <----- Changed
+            A.value = np.array([[0, 0], [0, 1]])   # <----- Changed
             b.value = np.array([0, 1])              # <----- Changed
             h.value = np.array([2, 2])
             c.value = np.array([1, 1])
@@ -349,7 +349,7 @@ class TestSolvers(BaseTest):
             self.assertItemsAlmostEqual(self.x.value, [2, 1])
 
             # Change h from the original values
-            A.value = np.matrix([[1, 0], [0, 0]])
+            A.value = np.array([[1, 0], [0, 0]])
             b.value = np.array([1, 0])
             h.value = np.array([1, 1])              # <----- Changed
             c.value = np.array([1, 1])
@@ -360,7 +360,7 @@ class TestSolvers(BaseTest):
             self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
             # Change c from the original values
-            A.value = np.matrix([[1, 0], [0, 0]])
+            A.value = np.array([[1, 0], [0, 0]])
             b.value = np.array([1, 0])
             h.value = np.array([2, 2])
             c.value = np.array([2, 1])              # <----- Changed
@@ -750,7 +750,7 @@ class TestSolvers(BaseTest):
             h = cvx.Parameter(2)
             c = cvx.Parameter(2)
 
-            A.value = np.matrix([[1, 0], [0, 0]])
+            A.value = np.array([[1, 0], [0, 0]])
             b.value = np.array([1, 0])
             h.value = np.array([2, 2])
             c.value = np.array([1, 1])
@@ -767,7 +767,7 @@ class TestSolvers(BaseTest):
             orig_x = self.x.value
 
             # Change A and b from the original values
-            A.value = np.matrix([[0, 0], [0, 1]])   # <----- Changed
+            A.value = np.array([[0, 0], [0, 1]])   # <----- Changed
             b.value = np.array([0, 1])              # <----- Changed
             h.value = np.array([2, 2])
             c.value = np.array([1, 1])
@@ -778,7 +778,7 @@ class TestSolvers(BaseTest):
             self.assertItemsAlmostEqual(self.x.value, [2, 1])
 
             # Change h from the original values
-            A.value = np.matrix([[1, 0], [0, 0]])
+            A.value = np.array([[1, 0], [0, 0]])
             b.value = np.array([1, 0])
             h.value = np.array([1, 1])              # <----- Changed
             c.value = np.array([1, 1])
@@ -789,7 +789,7 @@ class TestSolvers(BaseTest):
             self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
             # Change c from the original values
-            A.value = np.matrix([[1, 0], [0, 0]])
+            A.value = np.array([[1, 0], [0, 0]])
             b.value = np.array([1, 0])
             h.value = np.array([2, 2])
             c.value = np.array([2, 1])              # <----- Changed

--- a/cvxpy/tests/test_super_scs.py
+++ b/cvxpy/tests/test_super_scs.py
@@ -93,7 +93,7 @@ class TestSCS(BaseTest):
         """
         if cvx.SUPER_SCS in cvx.installed_solvers():
             # Complex-valued matrix
-            K = np.matrix(np.random.rand(2,2) + 1j * np.random.rand(2,2) ) #  example matrix
+            K = np.array(np.random.rand(2,2) + 1j * np.random.rand(2,2) ) #  example matrix
             n1 = la.svdvals(K).sum()  # trace norm of K
             # Dual Problem
             X = cvx.Variable((2,2), complex=True)


### PR DESCRIPTION
Trying to fix as many `DeprecationWarning` as possible.

The bulk of this PR is the deprecation of `numpy.matrix` (#567, #638).
There are also some assertion methods which need to be replaced.