### PR TITLE
Make cvxpy deterministic

### DIFF
--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -19,6 +19,7 @@ from .. import utilities as u
 from .. import interface as intf
 from ..expressions.constants import Constant, CallbackParam
 from ..expressions.expression import Expression
+from cvxpy.utilities.deterministic import unique_list
 import abc
 import numpy as np
 from fastcache import clru_cache
@@ -384,4 +385,4 @@ class Atom(Expression):
         atom_list = []
         for arg in self.args:
             atom_list += arg.atoms()
-        return list(set(atom_list + [type(self)]))
+        return unique_list(atom_list + [type(self)])

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -21,6 +21,7 @@ from cvxpy.reductions.solvers.solving_chain import construct_solving_chain
 from cvxpy.reductions.solvers.intermediate_chain import construct_intermediate_chain
 from cvxpy.interface.matrix_utilities import scalar_value
 from cvxpy.reductions.solvers import defines as slv_def
+from cvxpy.utilities.deterministic import unique_list
 
 # TODO(akshayka): This is a hack. Fix this if possible.
 # Only need to import cvxpy.transform.get_separable_problems, but this creates
@@ -167,6 +168,7 @@ class Problem(u.Canonical):
         vars_ = self.objective.variables()
         for constr in self.constraints:
             vars_ += constr.variables()
+        # NB. This should preserve the variable order
         seen = set()
         # never use list as a variable name
         return [seen.add(obj.id) or obj for obj in vars_ if obj.id not in seen]
@@ -182,7 +184,7 @@ class Problem(u.Canonical):
         params = self.objective.parameters()
         for constr in self.constraints:
             params += constr.parameters()
-        return list(set(params))
+        return unique_list(params)
 
     def constants(self):
         """Accessor method for parameters.
@@ -213,7 +215,7 @@ class Problem(u.Canonical):
         atoms = self.objective.atoms()
         for constr in self.constraints:
             atoms += constr.atoms()
-        return list(set(atoms))
+        return unique_list(atoms)
 
     @property
     def size_metrics(self):
@@ -668,7 +670,7 @@ class Problem(u.Canonical):
         elif not isinstance(other, Problem):
             return NotImplemented
         return Problem(self.objective + other.objective,
-                       list(set(self.constraints + other.constraints)))
+                       unique_list(self.constraints + other.constraints))
 
     def __radd__(self, other):
         if other == 0:
@@ -680,7 +682,7 @@ class Problem(u.Canonical):
         if not isinstance(other, Problem):
             return NotImplemented
         return Problem(self.objective - other.objective,
-                       list(set(self.constraints + other.constraints)))
+                       unique_list(self.constraints + other.constraints))
 
     def __rsub__(self, other):
         if other == 0:

--- a/cvxpy/problems/xpress_problem.py
+++ b/cvxpy/problems/xpress_problem.py
@@ -19,6 +19,7 @@ import cvxpy.settings as s
 from collections import namedtuple
 
 from cvxpy.problems.problem import Problem
+from cvxpy.utilities.deterministic import unique_list
 
 # Used in self._cached_data to check if problem's objective or constraints have
 # changed.
@@ -91,13 +92,13 @@ class XpressProblem (Problem):
         elif not isinstance(other, XpressProblem):
             return NotImplemented
         return XpressProblem(self.objective + other.objective,
-                             list(set(self.constraints + other.constraints)))
+                             unique_list(self.constraints + other.constraints))
 
     def __sub__(self, other):
         if not isinstance(other, XpressProblem):
             return NotImplemented
         return XpressProblem(self.objective - other.objective,
-                             list(set(self.constraints + other.constraints)))
+                             unique_list(self.constraints + other.constraints))
 
     def __mul__(self, other):
         if not isinstance(other, (int, float)):

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import abc
 from cvxpy.utilities import performance_utils as pu
+from cvxpy.utilities.deterministic import unique_list
 
 
 class Canonical(object):
@@ -47,13 +48,12 @@ class Canonical(object):
         """Returns all the variables present in the arguments.
         """
         # Remove duplicates.
-        return list(set(var for arg in self.args for var in arg.variables()))
+        return unique_list(var for arg in self.args for var in arg.variables())
 
     def parameters(self):
         """Returns all the parameters present in the arguments.
         """
-        return list(
-          set(param for arg in self.args for param in arg.parameters()))
+        return unique_list(param for arg in self.args for param in arg.parameters())
 
     def constants(self):
         """Returns all the constants present in the arguments.
@@ -115,4 +115,4 @@ class Canonical(object):
         list
         """
         # Remove duplicates.
-        return list(set(atom for arg in self.args for atom in arg.atoms()))
+        return unique_list(atom for arg in self.args for atom in arg.atoms())

--- a/cvxpy/utilities/deterministic.py
+++ b/cvxpy/utilities/deterministic.py
@@ -7,4 +7,3 @@ def unique_list(duplicates_list):
               if x not in used and
               (used.add(x) or True)]
     return unique
-

--- a/cvxpy/utilities/deterministic.py
+++ b/cvxpy/utilities/deterministic.py
@@ -1,0 +1,10 @@
+def unique_list(duplicates_list):
+    """Return unique list preserving the order.
+    https://stackoverflow.com/a/37163210/9753175
+    """
+    used = set()
+    unique = [x for x in duplicates_list
+              if x not in used and
+              (used.add(x) or True)]
+    return unique
+


### PR DESCRIPTION
I have been trying to make CVXPY behavior deterministic. I know that for Python 3.6+ the insertion order in dictionaries should be preserved. However, operations like `set` [do not preserve ordering](https://stackoverflow.com/a/54545521/9753175). I replaced the operations to compute the unique elements in a list with something that should preserve the ordering.

With the changes I propose here, I can get a deterministic behavior with MOSEK but not with GUROBI. You can try the mwe in https://github.com/cvxgrp/cvxpy/issues/624#issuecomment-479962141. I guess it is related to the QP canonicalization but I am not really sure.

Any idea why? It would be great to have this problem solved at least for Python 3.6+.

Fixes https://github.com/cvxgrp/cvxpy/issues/624