### PR TITLE
OSQP takes max_iter instead of max_iters as an argument

### DIFF
--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -624,7 +624,7 @@ Here is the complete list of solver options.
 
 `OSQP`_ options:
 
-``'max_iters'``
+``'max_iter'``
     maximum number of iterations (default: 10,000).
 
 ``'eps_abs'``


### PR DESCRIPTION
Fixes a syntax error in the OSQP solver's argument list