### PR TITLE
Missing status code in cvxopt STATUS_MAP

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -56,6 +56,7 @@ class CVXOPT(ECOS):
                   "infeasible": s.INFEASIBLE,
                   "primal infeasible": s.INFEASIBLE,
                   "LP relaxation is primal infeasible": s.INFEASIBLE,
+                  "LP relaxation is dual infeasible": s.UNBOUNDED,
                   "unbounded": s.UNBOUNDED,
                   "dual infeasible": s.UNBOUNDED,
                   "unknown": s.SOLVER_ERROR,


### PR DESCRIPTION
Missing status code for "LP relaxation is dual infeasible" from CVXOPT: https://github.com/cvxopt/cvxopt/blob/master/src/C/glpk.c#L462