### PR TITLE
Minor optimization for Gurobi

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -93,7 +93,7 @@ class GUROBI(QpSolver):
     def solve_via_data(self, data, warm_start, verbose, solver_opts, solver_cache=None):
         import gurobipy as grb
         # N.B. Here we assume that the matrices in data are in csc format
-        P = data[s.P].tocoo()       # Convert matrix to coo format
+        P = data[s.P]
         q = data[s.Q]
         A = data[s.A].tocsr()       # Convert A matrix to csr format
         b = data[s.B]
@@ -161,9 +161,11 @@ class GUROBI(QpSolver):
         # Define objective
         obj = grb.QuadExpr()
         if hasattr(model, '_v811_setMObjective'):
+            P = P.tocoo()
             model._v811_setMObjective(0.5 * P, q)
         else:
             if P.count_nonzero():  # If there are any nonzero elms in P
+                P = P.tocoo()
                 obj.addTerms(0.5*P.data, vars=list(x[P.row]),
                              vars2=list(x[P.col]))
             obj.add(grb.LinExpr(q, x))  # Add linear part
@@ -172,7 +174,6 @@ class GUROBI(QpSolver):
 
         # Set verbosity and other parameters
         model.setParam("OutputFlag", verbose)
-        # TODO user option to not compute duals.
         model.setParam("QCPDual", True)
 
         for key, value in solver_opts.items():


### PR DESCRIPTION
We can avoid the `tocoo()` conversion on the quadratic part in the Gurobi path if there are no quadratic terms. Avoids an unnecessary allocation of a potentially big matrix of zeros.