### PR TITLE
tutorial/advanced: use both "data" and "probdata" variables

### DIFF
--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -798,15 +798,15 @@ For example:
 .. code:: python
 
   problem = cp.Problem(objective, constraints)
-  data, _, _ = problem.get_problem_data(cp.SCS)
+  probdata, _, _ = problem.get_problem_data(cp.SCS)
 
   import scs
-  probdata = {
-    'A': data['A'],
-    'b': data['b'],
-    'c': data['c'],
+  data = {
+    'A': probdata['A'],
+    'b': probdata['b'],
+    'c': probdata['c'],
   }
-  cone_dims = data['dims']
+  cone_dims = probdata['dims']
   cones = {
       "f": cone_dims.zero,
       "l": cone_dims.nonpos,


### PR DESCRIPTION
Previously, "probdata" variable was constructed
but not passed to SCS. Instead, "data" was passed,
which contained more elements than required.

Now get_problem_data result is renamed to "probdata",
and "data" is constructed, so scs.solve(data, cones)
actually uses constructed dictionary.