### PR TITLE
Copy swig import helper from branch 1.1

### DIFF
--- a/continuous_integration/Travis/install_dependencies.sh
+++ b/continuous_integration/Travis/install_dependencies.sh
@@ -27,6 +27,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         echo "python=$PYTHON_VERSION" >> $PIN_FILE
         conda install -c conda-forge --yes lapack
         conda install -c conda-forge --yes ecos scs multiprocess
+        conda install -c oxfordcontrol --yes osqp
         conda install -c default --yes flake8
 
         # Install GLPK.
@@ -49,6 +50,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         touch $PIN_FILE
         echo "python=$PYTHON_VERSION.*" >> $PIN_FILE
         conda install -c conda-forge --yes ecos scs multiprocess
+        conda install -c oxfordcontrol --yes osqp
         conda install -c default --yes flake8=3.5.0
     fi
 

--- a/continuous_integration/Travis/test_script.sh
+++ b/continuous_integration/Travis/test_script.sh
@@ -11,6 +11,8 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python setup.py install
 python -c "import cvxpy; print(cvxpy.installed_solvers())"
+python $(dirname ${BASH_SOURCE[0]})/../osqp_version.py
+
 if [[ "$COVERAGE" == "true" ]]; then
     export WITH_COVERAGE="--with-coverage"
 else

--- a/continuous_integration/osqp_version.py
+++ b/continuous_integration/osqp_version.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""
+Print the library version of OSQP and compare to pkg_resource
+"""
+import ctypes
+import pkg_resources
+import osqp
+
+
+dl = ctypes.CDLL(osqp._osqp.__file__)
+dl.osqp_version.restype = ctypes.c_char_p
+print("dynamic library version:", dl.osqp_version().decode())
+print("pkg_resources version:  ", pkg_resources.get_distribution("osqp").version)

--- a/cvxpy/cvxcore/python/cvxcore.py
+++ b/cvxpy/cvxcore/python/cvxcore.py
@@ -3,13 +3,19 @@
 #
 # Do not make changes to this file unless you know what you are doing--modify
 # the SWIG interface file instead.
-
-
-
-
-
-from sys import version_info
-if version_info >= (2, 6, 0):
+from sys import version_info as _swig_python_version_info
+if _swig_python_version_info >= (2, 7, 0):
+    def swig_import_helper():
+        import importlib
+        pkg = __name__.rpartition('.')[0]
+        mname = '.'.join((pkg, '_cvxcore')).lstrip('.')
+        try:
+            return importlib.import_module(mname)
+        except ImportError:
+            return importlib.import_module('_cvxcore')
+    _cvxcore = swig_import_helper()
+    del swig_import_helper
+elif _swig_python_version_info >= (2, 6, 0):
     def swig_import_helper():
         from os.path import dirname
         import imp
@@ -19,17 +25,18 @@ if version_info >= (2, 6, 0):
         except ImportError:
             import _cvxcore
             return _cvxcore
-        if fp is not None:
-            try:
-                _mod = imp.load_module('_cvxcore', fp, pathname, description)
-            finally:
+        try:
+            _mod = imp.load_module('_cvxcore', fp, pathname, description)
+        finally:
+            if fp is not None:
                 fp.close()
-            return _mod
+        return _mod
     _cvxcore = swig_import_helper()
     del swig_import_helper
 else:
     import _cvxcore
-del version_info
+del _swig_python_version_info
+
 try:
     _swig_property = property
 except NameError:


### PR DESCRIPTION
 this avoids the warning that `imp` has been deprecated in Python 3.4