### PR TITLE
Migrate examples from python2 to python3

### DIFF
--- a/examples/admm_example.py
+++ b/examples/admm_example.py
@@ -75,10 +75,10 @@ def main():
 
 		iters = iters + 1
 
- 	pool.close()
- 	pool.join()
-	
-	print x
+	pool.close()
+	pool.join()
+
+	print(x)
 
 if __name__ == '__main__':
 	main()

--- a/examples/admm_lasso.py
+++ b/examples/admm_lasso.py
@@ -24,6 +24,9 @@ n = 75
 np.random.seed(1)
 A = np.random.randn(m, n)
 b = np.random.randn(m, 1)
+gamma = 0.1
+
+NUM_PROCS = 4
 
 def prox(args):
     f, v = args
@@ -34,8 +37,7 @@ def prox(args):
 # Setup problem.
 rho = 1.0
 x = Variable(n)
-funcs = [sum_squares(A*x - b),
-         gamma*norm(x, 1)]
+funcs = [sum_squares(A*x - b), gamma * norm(x, 1)]
 ui = [np.zeros((n, 1)) for func in funcs]
 xbar = np.zeros((n, 1))
 pool = Pool(NUM_PROCS)
@@ -49,5 +51,5 @@ for i in range(50):
 # Compare ADMM with standard solver.
 prob = Problem(Minimize(sum(funcs)))
 result = prob.solve()
-print "ADMM best", (sum_squares(np.dot(A, xbar) - b) + gamma*norm(xbar, 1)).value
-print "ECOS best", result
+print("ADMM best", (sum_squares(np.dot(A, xbar) - b) + gamma * norm(xbar, 1)).value)
+print("ECOS best", result)

--- a/examples/admm_svm_pool.py
+++ b/examples/admm_svm_pool.py
@@ -31,11 +31,11 @@ N = NUM_PROCS*SPLIT_SIZE
 n = 10
 offset = np.random.randn(n, 1)
 data = []
-for i in xrange(N/2):
+for i in range(N/2):
     data += [(1, offset + np.random.normal(1.0, 2.0, (n, 1)))]
-for i in xrange(N/2):
+for i in range(N/2):
     data += [(-1, offset + np.random.normal(-1.0, 2.0, (n, 1)))]
-data_splits = [data[i:i+SPLIT_SIZE] for i in xrange(0, N, SPLIT_SIZE)]
+data_splits = [data[i:i+SPLIT_SIZE] for i in range(0, N, SPLIT_SIZE)]
 
 # Count misclassifications.
 def get_error(w):
@@ -65,11 +65,11 @@ pool = Pool(NUM_PROCS)
 w_avg = np.zeros((n+1, 1))
 u_vals = NUM_PROCS*[np.zeros((n+1, 1))]
 for i in range(10):
-    print get_error(w_avg)
+    print(get_error(w_avg))
     prox_args = [w_avg - ui for ui in u_vals]
     w_vals = pool.map(prox, zip(fi, prox_args))
     w_avg = sum(w_vals)/len(w_vals)
     u_vals = [ui + wi - w_avg for ui, wi in zip(u_vals, w_vals)]
 
-print w_avg[:-1]
-print w_avg[-1]
+print(w_avg[:-1])
+print(w_avg[-1])

--- a/examples/admm_svm_procs.py
+++ b/examples/admm_svm_procs.py
@@ -32,12 +32,12 @@ N = NUM_PROCS*SPLIT_SIZE
 n = 11
 data = []
 offset = np.random.randn(n-1, 1)
-for i in xrange(N/2):
+for i in range(N/2):
     data += [(1, offset + np.random.normal(1.0, 4.0, (n-1, 1)))]
-for i in xrange(N/2):
+for i in range(N/2):
     data += [(-1, offset + np.random.normal(-1.0, 4.0, (n-1, 1)))]
 np.random.shuffle(data)
-data_splits = [data[i:i+SPLIT_SIZE] for i in xrange(0, N, SPLIT_SIZE)]
+data_splits = [data[i:i+SPLIT_SIZE] for i in range(0, N, SPLIT_SIZE)]
 
 # Count misclassifications.
 def get_error(x):
@@ -83,7 +83,7 @@ for i in range(NUM_PROCS):
 for i in range(MAX_ITER):
     # Gather.
     xbar = sum([pipe.recv() for pipe in pipes])/NUM_PROCS
-    print get_error(xbar)
+    print(get_error(xbar))
     # Scatter.
     [pipe.send(xbar) for pipe in pipes]
 

--- a/examples/advanced/acent.py
+++ b/examples/advanced/acent.py
@@ -51,8 +51,8 @@ x, obj = acent(A,b)
 cvxopt_x = x
 
 if isinstance(status, (float, int)):
-    print "difference in solution:", sum((cvxopt_x - cvxpy_x)**2)
-    print "difference in objective:", abs(obj - status)
+    print("difference in solution:", sum((cvxopt_x - cvxpy_x)**2))
+    print("difference in objective:", abs(obj - status))
 else:
-    print "Generated infeasible problem"
-    print "  ", status
+    print("Generated infeasible problem")
+    print("  ", status)

--- a/examples/advanced/cheshire_tomography.py
+++ b/examples/advanced/cheshire_tomography.py
@@ -15,14 +15,14 @@ limitations under the License.
 """
 
 import cvxpy as cp
-import mixed_integer as mi
+from ..extensions.mixed_integer.boolean import Boolean
 import ncvx
 
 bv = [] # Boolean variables.
 for i in range(26):
 	var_row = []
 	for j in range(31):
-		var_row.append(mi.BoolVar())
+		var_row.append(Boolean())
 	bv.append(var_row)
 
 
@@ -197,10 +197,10 @@ bv[25][1] == 0,
 
 p = cp.Problem(cp.Minimize(obj), constraints)
 result = p.solve()
-print result
+print(result)
 
 result = p.solve(method="admm", iterations=5, solver="ecos")
-print result
+print(result)
 
 obj = bv[1][24].z.value[0]+bv[2][5].z.value[0]+bv[2][6].z.value[0]+bv[2][7].z.value[0]+bv[2][23].z.value[0]+bv[2][24].z.value[0]+bv[3][5].z.value[0]+bv[3][7].z.value[0]+bv[3][8].z.value[0]+bv[3][22].z.value[0]+bv[3][25].z.value[0]+bv[4][4].z.value[0]+bv[4][8].z.value[0]+bv[4][9].z.value[0]+bv[4][13].z.value[0]+bv[4][14].z.value[0]+bv[4][15].z.value[0]+bv[4][16].z.value[0]+bv[4][17].z.value[0]+bv[4][18].z.value[0]+bv[4][19].z.value[0]+bv[4][22].z.value[0]+bv[4][25].z.value[0]+bv[5][4].z.value[0]+bv[5][6].z.value[0]+bv[5][9].z.value[0]+bv[5][10].z.value[0]+bv[5][11].z.value[0]+bv[5][12].z.value[0]+bv[5][20].z.value[0]+bv[5][21].z.value[0]+bv[5][22].z.value[0]+bv[5][26].z.value[0]+bv[6][4].z.value[0]+bv[6][6].z.value[0]+bv[6][9].z.value[0]+bv[6][22].z.value[0]+bv[6][24].z.value[0]+bv[6][26].z.value[0]+bv[7][4].z.value[0]+bv[7][6].z.value[0]+bv[7][9].z.value[0]+bv[7][22].z.value[0]+bv[7][24].z.value[0]+bv[7][26].z.value[0]+bv[8][4].z.value[0]+bv[8][22].z.value[0]+bv[8][26].z.value[0]+bv[9][4].z.value[0]+bv[9][23].z.value[0]+bv[9][26].z.value[0]+bv[10][5].z.value[0]+bv[10][25].z.value[0]+bv[10][27].z.value[0]+bv[11][6].z.value[0]+bv[11][27].z.value[0]+bv[12][6].z.value[0]+bv[12][9].z.value[0]+bv[12][10].z.value[0]+bv[12][11].z.value[0]+bv[12][19].z.value[0]+bv[12][20].z.value[0]+bv[12][21].z.value[0]+bv[12][27].z.value[0]+bv[13][6].z.value[0]+bv[13][8].z.value[0]+bv[13][12].z.value[0]+bv[13][18].z.value[0]+bv[13][22].z.value[0]+bv[13][27].z.value[0]+bv[14][1].z.value[0]+bv[14][2].z.value[0]+bv[14][5].z.value[0]+bv[14][8].z.value[0]+bv[14][9].z.value[0]+bv[14][10].z.value[0]+bv[14][12].z.value[0]+bv[14][18].z.value[0]+bv[14][19].z.value[0]+bv[14][20].z.value[0]+bv[14][22].z.value[0]+bv[14][28].z.value[0]+bv[15][3].z.value[0]+bv[15][4].z.value[0]+bv[15][5].z.value[0]+bv[15][8].z.value[0]+bv[15][9].z.value[0]+bv[15][10].z.value[0]+bv[15][11].z.value[0]+bv[15][12].z.value[0]+bv[15][19].z.value[0]+bv[15][20].z.value[0]+bv[15][21].z.value[0]+bv[15][28].z.value[0]+bv[16][5].z.value[0]+bv[16][6].z.value[0]+bv[16][14].z.value[0]+bv[16][16].z.value[0]+bv[16][28].z.value[0]+bv[17][1].z.value[0]+bv[17][2].z.value[0]+bv[17][3].z.value[0]+bv[17][4].z.value[0]+bv[17][14].z.value[0]+bv[17][16].z.value[0]+bv[17][27].z.value[0]+bv[17][28].z.value[0]+bv[17][29].z.value[0]+bv[17][30].z.value[0]+bv[18][4].z.value[0]+bv[18][5].z.value[0]+bv[18][6].z.value[0]+bv[18][7].z.value[0]+bv[18][13].z.value[0]+bv[18][16].z.value[0]+bv[18][23].z.value[0]+bv[18][24].z.value[0]+bv[18][25].z.value[0]+bv[18][26].z.value[0]+bv[18][28].z.value[0]+bv[19][4].z.value[0]+bv[19][14].z.value[0]+bv[19][15].z.value[0]+bv[19][28].z.value[0]+bv[20][5].z.value[0]+bv[20][9].z.value[0]+bv[20][10].z.value[0]+bv[20][22].z.value[0]+bv[20][23].z.value[0]+bv[20][24].z.value[0]+bv[20][25].z.value[0]+bv[20][26].z.value[0]+bv[20][27].z.value[0]+bv[20][28].z.value[0]+bv[20][29].z.value[0]+bv[20][30].z.value[0]+bv[21][6].z.value[0]+bv[21][10].z.value[0]+bv[21][11].z.value[0]+bv[21][12].z.value[0]+bv[21][13].z.value[0]+bv[21][14].z.value[0]+bv[21][27].z.value[0]+bv[22][7].z.value[0]+bv[22][8].z.value[0]+bv[22][12].z.value[0]+bv[22][13].z.value[0]+bv[22][14].z.value[0]+bv[22][15].z.value[0]+bv[22][16].z.value[0]+bv[22][17].z.value[0]+bv[22][18].z.value[0]+bv[22][19].z.value[0]+bv[22][20].z.value[0]+bv[22][21].z.value[0]+bv[22][22].z.value[0]+bv[22][26].z.value[0]+bv[23][9].z.value[0]+bv[23][10].z.value[0]+bv[23][13].z.value[0]+bv[23][14].z.value[0]+bv[23][15].z.value[0]+bv[23][16].z.value[0]+bv[23][17].z.value[0]+bv[23][18].z.value[0]+bv[23][19].z.value[0]+bv[23][24].z.value[0]+bv[23][25].z.value[0]+bv[24][11].z.value[0]+bv[24][21].z.value[0]+bv[24][22].z.value[0]+bv[24][23].z.value[0]+bv[25][12].z.value[0]+bv[25][13].z.value[0]+bv[25][14].z.value[0]+bv[25][15].z.value[0]+bv[25][16].z.value[0]+bv[25][17].z.value[0]+bv[25][18].z.value[0]+bv[25][19].z.value[0]+bv[25][20].z.value[0]+bv[25][21].z.value[0]
 
@@ -369,6 +369,6 @@ bv[23][1].z.value[0]+bv[24][2].z.value[0]+bv[25][3].z.value[0] == 0,
 bv[24][1].z.value[0]+bv[25][2].z.value[0] == 0,
 bv[25][1].z.value[0] == 0,
 ]
-print len(constraints)
-print len(constraints) - sum(constraints)
-print obj
+print(len(constraints))
+print(len(constraints) - sum(constraints))
+print(obj)

--- a/examples/advanced/circuits.py
+++ b/examples/advanced/circuits.py
@@ -32,7 +32,7 @@ class Ground(Node):
     """ A node at 0 volts. """
     def constraints(self):
         return [self.voltage == 0] + super(Ground, self).constraints()
-    
+
 class Device(object):
     __metaclass__ = abc.ABCMeta
     """ A device on a circuit. """
@@ -113,4 +113,4 @@ for obj in nodes + devices:
     constraints += obj.constraints()
 Problem(Minimize(0), constraints).solve()
 for node in nodes:
-    print node.voltage.value
+    print(node.voltage.value)

--- a/examples/advanced/image_processing.py
+++ b/examples/advanced/image_processing.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 from cvxpy import *
-from itertools import izip, imap
 import cvxopt
 import pylab
 import math
@@ -51,11 +50,11 @@ img_gradx, img_grady = grad(img,'x'), grad(img,'y')
 # filter them (remove ones with small magnitude)
 
 def denoise(gradx, grady, thresh):
-    for dx, dy in izip(gradx, grady):
+    for dx, dy in zip(gradx, grady):
          if math.sqrt(dx*dx + dy*dy) >= thresh: yield (dx,dy)
          else: yield (0.0,0.0)
 
-denoise_gradx, denoise_grady = izip(*denoise(img_gradx, img_grady, 0.2))
+denoise_gradx, denoise_grady = zip(*denoise(img_gradx, img_grady, 0.2))
 
 # function to get boundary of image
 def boundary(img):
@@ -67,8 +66,8 @@ def boundary(img):
 
 # now, reconstruct the image by solving a constrained least-squares problem
 new_img = Variable(n,n)
-gradx_obj = imap(square, (fx - gx for fx, gx in izip(grad(new_img,'x'),denoise_gradx)))
-grady_obj = imap(square, (fy - gy for fy, gy in izip(grad(new_img,'y'),denoise_grady)))
+gradx_obj = map(square, (fx - gx for fx, gx in zip(grad(new_img,'x'),denoise_gradx)))
+grady_obj = map(square, (fy - gy for fy, gy in zip(grad(new_img,'y'),denoise_grady)))
 
 p = Problem(
     Minimize(sum(gradx_obj) + sum(grady_obj)),
@@ -80,4 +79,4 @@ plt = pylab.imshow(new_img.value)
 plt.set_cmap('gray')
 pylab.show()
 
-print new_img.value
+print(new_img.value)

--- a/examples/advanced/numpy_test.py
+++ b/examples/advanced/numpy_test.py
@@ -17,8 +17,8 @@ limitations under the License.
 import numpy
 import abc
 class Meta(object):
-    def __subclasscheck__(cls, subclass):
-        print "hello"
+    def __subclasscheck__(self, subclass):
+        print("hello")
 
     def __array_finalize__(self, obj):
         return 1
@@ -28,11 +28,11 @@ class Test(numpy.ndarray):
         pass
 
     def __coerce__(self, other):
-        print other
+        print(other)
         return (self,self)
 
     def __radd__(self, other):
-        print other
+        print(other)
 
     def __getattribute__(self, name):
         import pdb; pdb.set_trace()
@@ -41,10 +41,10 @@ class Test(numpy.ndarray):
         else:
             raise AttributeError("'Test' object has no attribute 'affa'")
 
-print issubclass(Test, Meta)
-print issubclass(Meta, numpy.ndarray)
-print issubclass(Test, numpy.ndarray)
-print issubclass(numpy.ndarray, Test)
+print(issubclass(Test, Meta))
+print(issubclass(Meta, numpy.ndarray))
+print(issubclass(Test, numpy.ndarray))
+print(issubclass(numpy.ndarray, Test))
 
 a = numpy.arange(2)
 t = Test(1)

--- a/examples/advanced/optimal_control.py
+++ b/examples/advanced/optimal_control.py
@@ -39,4 +39,4 @@ for i in range(T):
 obj = sum(s.cost for s in stages)
 constraints = [stages[-1].x == x_final]
 map(constraints.append, (s.constraint for s in stages))
-print Problem(Minimize(obj), constraints).solve()
+print(Problem(Minimize(obj), constraints).solve())

--- a/examples/advanced/test.py
+++ b/examples/advanced/test.py
@@ -48,14 +48,14 @@ import numpy as np
 
 class MyMeta(type):
     def __getitem__(self, key):
-        print key
+        print(key)
         return 2
 
     def __len__(self):
         return 1
 
     def __contains__(self, obj):
-        print "hello"
+        print("hello")
         return 0
 
 
@@ -67,7 +67,7 @@ class Exp(object):
         return 1
 
     def __rmul__(self, other):
-        print 1
+        print(1)
 
     __array_priority__ = 100
 
@@ -87,13 +87,13 @@ class Bar1(object):
     def __ge__(self, rhs): return 5
 
     def __array_prepare__(self):
-        print "hello"
+        print("hello")
         return self
     def __array_wrap__(self):
         return self
 
     def __array__(self):
-        print "Afafaf"
+        print("Afafaf")
         arr = np.array([self], dtype="object")
         return arr
 
@@ -102,7 +102,7 @@ class Bar1(object):
 def override(name):
     if name == "equal":
         def ufunc(x, y):
-            print y
+            print(y)
             if isinstance(y, Bar1) or \
                isinstance(y, np.ndarray) and isinstance(y[0], Bar1):
                 return NotImplemented
@@ -110,7 +110,7 @@ def override(name):
         return ufunc
     else:
         def ufunc(x, y):
-            print y
+            print(y)
             if isinstance(y, Bar1):
                 return NotImplemented
             return getattr(np, name)(x, y)
@@ -125,6 +125,6 @@ np.set_numeric_ops(
 )
 
 b = Bar1()
-print a == b
-print a <= b
-print a + b
+print(a == b)
+print(a <= b)
+print(a + b)

--- a/examples/chebyshev.py
+++ b/examples/chebyshev.py
@@ -66,8 +66,8 @@ p = Problem(objective, constraints)
 # The optimal objective is returned by p.solve().
 result = p.solve()
 # The optimal value
-print radius.value
-print center.value
+print(radius.value)
+print(center.value)
 # Convert to 1D array.
 center_val = np.asarray(center.value[:,0])
 

--- a/examples/communications/maximise_minimum_SINR_BV4.20.py
+++ b/examples/communications/maximise_minimum_SINR_BV4.20.py
@@ -37,7 +37,7 @@ def maxmin_sinr(G,P_max,P_received,sigma,Group,Group_max,detail=False,epsilon = 
   '''
 Boyd and Vandenberghe, Convex Optimization, exercise 4.20 page 196
 Power assignment in a wireless communication system.
-  
+
 We consider n transmitters with powers p1,...,pn ≥ 0, transmitting to
 n receivers. These powers are the optimization variables in the problem.
 We let G ∈ ℝ(n*n) denote the matrix of path gains from the

--- a/examples/consensus_admm.py
+++ b/examples/consensus_admm.py
@@ -24,6 +24,9 @@ n = 75
 np.random.seed(1)
 A = np.random.randn(m, n)
 b = np.random.randn(m, 1)
+gamma = 0.1
+
+NUM_PROCS = 4
 
 def prox(args):
     f, v = args
@@ -56,5 +59,5 @@ for i in range(50):
 # Compare ADMM with standard solver.
 prob = Problem(Minimize(sum(funcs)))
 result = prob.solve()
-print "ADMM best", (sum_squares(np.dot(A, xbar) - b) + gamma*norm(xbar, 1)).value
-print "ECOS best", result
+print("ADMM best", (sum_squares(np.dot(A, xbar) - b) + gamma*norm(xbar, 1)).value)
+print("ECOS best", result)

--- a/examples/deadzone.py
+++ b/examples/deadzone.py
@@ -49,12 +49,12 @@ objective = Minimize( sum(maximum( abs(A*x -b) - 1 , 0 )) )
 p = Problem(objective, [])
 
 # Solve it
-print 'Computing the optimal solution of the deadzone approximation problem:'
+print ('Computing the optimal solution of the deadzone approximation problem:')
 p.solve()
 
-print 'Optimal vector:'
-print x.value
+print ('Optimal vector:')
+print (x.value)
 
-print 'Residual vector:'
-print A*x.value - b
+print ('Residual vector:')
+print (A*x.value - b)
 

--- a/examples/ex_5_33.py
+++ b/examples/ex_5_33.py
@@ -49,7 +49,7 @@ A = cvxopt.matrix([ -2, 7, 1,
 					-1, 4, -4,
 					1, 5, 5,
 					2, -5, -1 ], (m,n))
-					
+
 b = cvxopt.matrix([-4, 3, 9, 0, -11, 5], (m,1))
 d = cvxopt.matrix([-10, -13, -27, -10, -7, 14], (m,1))
 epsilon = Parameter()
@@ -71,10 +71,10 @@ e_values = np.linspace(-1,1,41)
 # x_values = [get_p(value) for value in e_values]
 
 # Solve in parallel
-print 'Computing p*(epsilon) for -1 <= epsilon <= 1 ...'
+print('Computing p*(epsilon) for -1 <= epsilon <= 1 ...')
 pool = Pool(processes = 4)
 p_values = pool.map(get_p, e_values)
-print 'Done!'
+print('Done!')
 
 # Plots
 plot(e_values, p_values)

--- a/examples/expr_trees/helloworld.py
+++ b/examples/expr_trees/helloworld.py
@@ -49,4 +49,4 @@ constraints = [x >= 0]
 prob = Problem(Minimize(obj), constraints)
 result = prob.solve(solver=SCS, verbose=True)
 
-print norm(signal - x.value, 1).value
+print(norm(signal - x.value, 1).value)

--- a/examples/expr_trees/inpainting.py
+++ b/examples/expr_trees/inpainting.py
@@ -22,7 +22,7 @@ l = misc.ascent()
 l = l.astype(np.float64, copy=False)
 l = l/np.max(l) #rescale pixels into [0,1]
 
-plt.imshow(l, cmap=plt.cm.gray)
+plt.imshow(l, cmap=plt.gray)
 #plt.show()
 
 from PIL import Image, ImageDraw
@@ -48,12 +48,11 @@ del draw
 err = np.asarray(im,dtype=np.bool)
 r = l.copy()
 r[err] = 1.0
-plt.imshow(r, cmap=plt.cm.gray)
+plt.imshow(r, cmap=plt.gray)
 
-import itertools
 idx2pair = np.nonzero(err)
 idx2pair = zip(idx2pair[0].tolist(), idx2pair[1].tolist())
-pair2idx = dict(itertools.izip(idx2pair, xrange(len(idx2pair))))
+pair2idx = dict(zip(idx2pair, range(len(idx2pair))))
 idx2pair = np.array(idx2pair) #convert back to numpy array
 
 import scipy.sparse as sp

--- a/examples/expr_trees/portfolio.py
+++ b/examples/expr_trees/portfolio.py
@@ -39,25 +39,25 @@ constraints_longonly = [sum(x) == 1, x >= 0]
 prob = Problem(objective, constraints_longonly)
 #constraints_totalshort = [sum(x) == 1, one.T * max(-x, 0) <= 0.5]
 import time
-print "starting problems"
+print("starting problems")
 
 start = time.clock()
 prob.solve(verbose=True, solver=SCS)
 elapsed = (time.clock() - start)
-print "SCS time:", elapsed
-print prob.value
+print("SCS time:", elapsed)
+print(prob.value)
 
 start = time.clock()
 prob.solve(verbose=True, solver=ECOS)
 elapsed = (time.clock() - start)
-print "ECOS time:", elapsed
-print prob.value
+print("ECOS time:", elapsed)
+print(prob.value)
 
 start = time.clock()
 prob.solve(verbose=True, solver=CVXOPT)
 elapsed = (time.clock() - start)
-print "CVXOPT time:", elapsed
-print prob.value
+print("CVXOPT time:", elapsed)
+print(prob.value)
 
 # Results:
 # n = 500, total 0.647 (SCS)

--- a/examples/expr_trees/portfolio_profiler.py
+++ b/examples/expr_trees/portfolio_profiler.py
@@ -37,7 +37,7 @@ D.data = np.random.randn(len(D.data))**2
 # Z = np.cov(vals)
 Z = np.random.normal(size=(m, m))
 Z = Z.T.dot(Z)
-print Z.shape
+print(Z.shape)
 
 x = Variable(n)
 y = x.__rmul__(F)
@@ -51,23 +51,23 @@ constraints_longonly = [sum(x) == 1, x >= 0]
 prob = Problem(objective, constraints_longonly)
 #constraints_totalshort = [sum(x) == 1, one.T * max(-x, 0) <= 0.5]
 import time
-print "starting problems"
+print("starting problems")
 
 start = time.clock()
 prob.solve(verbose=True, solver=SCS)
 elapsed = (time.clock() - start)
-print "SCS time:", elapsed
-print prob.value
+print("SCS time:", elapsed)
+print(prob.value)
 
 start = time.clock()
 prob.solve(verbose=True, solver=ECOS)
 elapsed = (time.clock() - start)
-print "ECOS time:", elapsed
-print prob.value
+print("ECOS time:", elapsed)
+print(prob.value)
 
 start = time.clock()
 prob.solve(verbose=True, solver=CVXOPT)
 elapsed = (time.clock() - start)
-print "CVXOPT time:", elapsed
-print prob.value
+print("CVXOPT time:", elapsed)
+print(prob.value)
 

--- a/examples/extensions/feature_selection.py
+++ b/examples/extensions/feature_selection.py
@@ -28,9 +28,9 @@ N = 50
 M = 40
 n = 10
 data = []
-for i in xrange(N):
+for i in range(N):
     data += [(1, np.random.normal(1.0, 2.0, (n, 1)))]
-for i in xrange(M):
+for i in range(M):
     data += [(-1, np.random.normal(-1.0, 2.0, (n, 1)))]
 
 # Construct problem.
@@ -52,6 +52,6 @@ for label, sample in data:
     if not label*(a.value.T*sample - b.value)[0] >= 0:
         error += 1
 
-print "%s misclassifications" % error
-print a.value
-print b.value
+print("%s misclassifications" % error)
+print(a.value)
+print(b.value)

--- a/examples/extensions/integer_ls.py
+++ b/examples/extensions/integer_ls.py
@@ -25,8 +25,8 @@ z = cvxopt.matrix([3, 7, 9])
 
 p = Problem(Minimize(sum_squares(A*x - z))).solve(method="branch and bound")
 
-print x.value
-print p
+print(x.value)
+print(p)
 
 # even a simple problem like this introduces too many variables
 # y = Boolean()

--- a/examples/extensions/kmeans.py
+++ b/examples/extensions/kmeans.py
@@ -32,11 +32,12 @@ from sklearn.preprocessing import scale
 np.random.seed(42)
 
 digits = load_digits()
-data = scale(digits.data)
+data, target = tuple(digits)
+data = scale(data)
 
 n_samples, n_features = data.shape
-n_digits = len(np.unique(digits.target))
-labels = digits.target
+n_digits = len(np.unique(target))
+labels = target
 
 sample_size = 300
 
@@ -101,7 +102,6 @@ plt.figure(1)
 plt.clf()
 plt.imshow(Z, interpolation='nearest',
            extent=(xx.min(), xx.max(), yy.min(), yy.max()),
-           cmap=plt.cm.Paired,
            aspect='auto', origin='lower')
 
 plt.plot(reduced_data[:, 0], reduced_data[:, 1], 'k.', markersize=2)

--- a/examples/extensions/mixed_integer/admm_problem.py
+++ b/examples/extensions/mixed_integer/admm_problem.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from noncvx_variable import NonCvxVariable
+from .noncvx_variable import NonCvxVariable
 import cvxpy as cvx
 from cvxpy import settings as s
 import numpy as np
@@ -31,12 +31,11 @@ def admm(self, rho=0.5, iterations=5, *args, **kwargs):
         obj = obj + (rho/2)*cvx.sum(cvx.square(var - var.z + var.u))
     prob = cvx.Problem(cvx.Minimize(obj), self.constraints)
     # ADMM loop
-    for i in range(iterations):
+    for _ in range(iterations):
         result = prob.solve(*args, **kwargs)
-        print "relaxation", result
-        for idx, var in enumerate(noncvx_vars):
+        print("relaxation", result)
+        for var in noncvx_vars:
             var.z.value = var.round(var.value + var.u.value)
-            # print idx, var.z.value, var.value, var.u.value
             var.u.value += var.value - var.z.value
     return polish(self, noncvx_vars, *args, **kwargs)
 
@@ -53,15 +52,15 @@ def admm2(self, rho=0.5, iterations=5, *args, **kwargs):
     prob = cvx.Problem(cvx.Minimize(obj), self.constraints)
     # ADMM loop
     best_so_far = np.inf
-    for i in range(iterations):
-        result = prob.solve(*args, **kwargs)
+    for _ in range(iterations):
+        _ = prob.solve(*args, **kwargs)
         for var in noncvx_vars:
             var.z.value = var.round(var.value + var.u.value)
             var.u.value += var.value - var.z.value
         polished_opt = polish(self, noncvx_vars, *args, **kwargs)
         if polished_opt < best_so_far:
             best_so_far = polished_opt
-            print best_so_far
+            print(best_so_far)
     return best_so_far
 
 def polish(prob, noncvx_vars, *args, **kwargs):

--- a/examples/extensions/mixed_integer/assign.py
+++ b/examples/extensions/mixed_integer/assign.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from boolean import Boolean
+from .boolean import Boolean
 import cvxpy.lin_ops.lin_utils as lu
 from munkres import Munkres
 import numpy as np

--- a/examples/extensions/mixed_integer/boolean.py
+++ b/examples/extensions/mixed_integer/boolean.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from noncvx_variable import NonCvxVariable
+from .noncvx_variable import NonCvxVariable
 import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 

--- a/examples/extensions/mixed_integer/card.py
+++ b/examples/extensions/mixed_integer/card.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from noncvx_variable import NonCvxVariable
+from .noncvx_variable import NonCvxVariable
 import cvxpy.interface.matrix_utilities as intf
 from itertools import product
 
@@ -27,7 +27,7 @@ class Card(NonCvxVariable):
 
     # All values except k-largest (by magnitude) set to zero.
     def _round(self, matrix):
-        indices = product(xrange(self.size[0]), xrange(self.size[1]))
+        indices = product(range(self.size[0]), range(self.size[1]))
         v_ind = sorted(indices, key=lambda ind: -abs(matrix[ind]))
         for ind in v_ind[self.k:]:
            matrix[ind] = 0
@@ -37,7 +37,7 @@ class Card(NonCvxVariable):
     # zeros in the matrix.
     def _fix(self, matrix):
         constraints = []
-        rows,cols = intf.size(matrix)
+        rows,cols = intf.shape(matrix)
         for i in range(rows):
             for j in range(cols):
                 if matrix[i, j] == 0:

--- a/examples/extensions/mixed_integer/choose.py
+++ b/examples/extensions/mixed_integer/choose.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from boolean import Boolean
+from .boolean import Boolean
 import cvxopt
 import numpy as np
 from itertools import product
@@ -32,7 +32,7 @@ class Choose(Boolean):
 
     # The k-largest values are set to 1. The remainder are set to 0.
     def _round(self, matrix):
-        indices = product(xrange(self.size[0]), xrange(self.size[1]))
+        indices = product(range(self.size[0]), range(self.size[1]))
         v_ind = sorted(indices, key=lambda ind: -matrix[ind])
         for ind in v_ind[0:self.k]:
             matrix[ind] = 1

--- a/examples/extensions/mixed_integer/integer.py
+++ b/examples/extensions/mixed_integer/integer.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from noncvx_variable import NonCvxVariable
+from .noncvx_variable import NonCvxVariable
 
 class Integer(NonCvxVariable):
     """ An integer variable. """

--- a/examples/extensions/mixed_integer/noncvx_variable.py
+++ b/examples/extensions/mixed_integer/noncvx_variable.py
@@ -35,7 +35,7 @@ class NonCvxVariable(cvxpy.Variable):
 
     # Verify that the matrix has the same dimensions as the variable.
     def validate_matrix(self, matrix):
-        if self.size != intf.size(matrix):
+        if self.size != intf.shape(matrix):
             raise Exception(("The argument's dimensions must match "
                              "the variable's dimensions."))
 
@@ -47,7 +47,7 @@ class NonCvxVariable(cvxpy.Variable):
     # Project the matrix into the space defined by the non-convex constraint.
     # Returns the updated matrix.
     @abc.abstractmethod
-    def _round(matrix):
+    def _round(self, matrix):
         return NotImplemented
 
     # Wrapper to validate matrix and update curvature.

--- a/examples/extensions/mixed_integer/tests/test_vars.py
+++ b/examples/extensions/mixed_integer/tests/test_vars.py
@@ -41,8 +41,8 @@ class TestVars(unittest.TestCase):
         p = Problem(Minimize(sum(1-x) + sum(x)), [x == Boolean(5,4)])
         result = p.solve(method="admm", solver=CVXOPT)
         self.assertAlmostEqual(result, 20)
-        for i in xrange(x.size[0]):
-            for j in xrange(x.size[1]):
+        for i in range(x.size[0]):
+            for j in range(x.size[1]):
                 v = x.value[i, j]
                 self.assertAlmostEqual(v*(1-v), 0)
 
@@ -59,8 +59,8 @@ class TestVars(unittest.TestCase):
                     [x == Choose(5,4,k=4)])
         result = p.solve(method="admm", solver=CVXOPT)
         self.assertAlmostEqual(result, 20)
-        for i in xrange(x.size[0]):
-            for j in xrange(x.size[1]):
+        for i in range(x.size[0]):
+            for j in range(x.size[1]):
                 v = x.value[i, j]
                 self.assertAlmostEqual(v*(1-v), 0)
         self.assertAlmostEqual(x.value.sum(), 4)
@@ -84,8 +84,8 @@ class TestVars(unittest.TestCase):
                     [x == c, x == b])
         result = p.solve(method="admm", solver=CVXOPT)
         self.assertAlmostEqual(result, 20)
-        for i in xrange(x.size[0]):
-            for j in xrange(x.size[1]):
+        for i in range(x.size[0]):
+            for j in range(x.size[1]):
                 v = x.value[i, j]
                 self.assertAlmostEqual(v*(1-v), 0)
 

--- a/examples/extensions/sudoku.py
+++ b/examples/extensions/sudoku.py
@@ -49,20 +49,20 @@ known =[(0,6), (0,7), (1,4), (1,5), (1,8), (2,0), (2,2), (2,7), (2,8),
 
 def row(x,r):
     m, n = x.size
-    for i in xrange(m):
-        for j in xrange(n):
+    for i in range(m):
+        for j in range(n):
             if i == r: yield x[i,j]
 
 def col(x,c):
     m, n = x.size
-    for i in xrange(m):
-        for j in xrange(n):
+    for i in range(m):
+        for j in range(n):
             if j == c: yield x[i,j]
 
 def block(x,b):
     m, n = x.size
-    for i in xrange(m):
-        for j in xrange(n):
+    for i in range(m):
+        for j in range(n):
             # 0 block is r = 0,1, c = 0,1
             # 1 block is r = 0,1, c = 2,3
             # 2 block is r = 2,3, c = 0,1
@@ -94,4 +94,4 @@ A = np.zeros((n, n))
 for i, num in enumerate(numbers):
     A += i * num.value
 
-print np.sum(A - solution)
+print(np.sum(A - solution))

--- a/examples/extensions/sudoku_admm.py
+++ b/examples/extensions/sudoku_admm.py
@@ -45,20 +45,20 @@ known =[(0,6), (0,7), (1,4), (1,5), (1,8), (2,0), (2,2), (2,7), (2,8),
 
 def row(x,r):
     m, n = x.size
-    for i in xrange(m):
-        for j in xrange(n):
+    for i in range(m):
+        for j in range(n):
             if i == r: yield x[i,j]
 
 def col(x,c):
     m, n = x.size
-    for i in xrange(m):
-        for j in xrange(n):
+    for i in range(m):
+        for j in range(n):
             if j == c: yield x[i,j]
 
 def block(x,b):
     m, n = x.size
-    for i in xrange(m):
-        for j in xrange(n):
+    for i in range(m):
+        for j in range(n):
             # 0 block is r = 0,1, c = 0,1
             # 1 block is r = 0,1, c = 2,3
             # 2 block is r = 2,3, c = 0,1
@@ -79,4 +79,4 @@ for i in range(n):
 # attempt to solve
 p = Problem(Minimize(sum(abs(numbers-solution))), constraints)
 p.solve(method="admm2", rho=0.5, iterations=25)
-print sum(numbers.value - solution)
+print(sum(numbers.value - solution))

--- a/examples/extensions/three_sat.py
+++ b/examples/extensions/three_sat.py
@@ -50,7 +50,7 @@ for i in range(VARIABLES*CLAUSES_PER_VARIABLE):
         if result:
             break
     clauses.append( (clause_vars, negated) )
-print "Generated %d clauses." % len(clauses)
+print("Generated %d clauses." % len(clauses))
 
 # The 3-SAT variables.
 vars = [Boolean() for i in range(VARIABLES)]
@@ -72,10 +72,10 @@ best_rho = 0
 for i in range(MAX_ITER):
     p = Problem(Minimize(0), constraints)
     rho = random.random()
-    print rho
+    print(rho)
     result = p.solve(method="admm", rho=rho,
                      iterations=2, solver=ECOS)
-    print result
+    print(result)
 
     # Store the result.
     values = [vars[i].value for i in range(VARIABLES)]
@@ -98,4 +98,4 @@ for i in range(MAX_ITER):
     if best_match == len(clauses): break
 
 percent_satisfied = 100*best_match/len(clauses)
-print "%s%% of the clauses were satisfied." % percent_satisfied
+print("%s%% of the clauses were satisfied." % percent_satisfied)

--- a/examples/extensions/tsp.py
+++ b/examples/extensions/tsp.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from cvxpy import *
 from mixed_integer import *
+from ncvx import Boolean
 import numpy as np
 
 # Traveling salesman problem.
@@ -22,29 +23,29 @@ cost = 0
 for i in range(n-1):
     x_diff = ordered_x[i+1] - ordered_x[i]
     y_diff = ordered_y[i+1] - ordered_y[i]
-    cost += norm(vstack(x_diff, y_diff))
+    cost += norm(vstack([x_diff, y_diff]))
 prob = Problem(Minimize(cost))
 result = prob.solve(method="admm", iterations=MAX_ITER,
                     solver=ECOS, verbose=False)#, tau=1.1, tau_max=100)
-print "all constraints hold:", np.all([c.value for c in prob.constraints])
-print "final value", result
+print("all constraints hold:", np.all([c.value for c in prob.constraints]))
+print("final value", result)
 
 # print prob.solve(method="polish")
 # print np.around(positions.value)
 
-assignment = Bool(n, n)
+assignment = Boolean(n, n)
 ordered_x = assignment*x
 ordered_y = assignment*y
 cost = 0
 for i in range(n-1):
     x_diff = ordered_x[i+1] - ordered_x[i]
     y_diff = ordered_y[i+1] - ordered_y[i]
-    cost += norm(vstack(x_diff, y_diff))
+    cost += norm(vstack([x_diff, y_diff]))
 prob = Problem(Minimize(cost),
         [assignment*np.ones((n, 1)) == 1,
          np.ones((1, n))*assignment == 1])
 prob.solve(solver=GUROBI, verbose=False, TimeLimit=10)
-print "gurobi solution", prob.value
+print("gurobi solution", prob.value)
 # print positions.value
 
 # Randomly guess permutations.
@@ -59,5 +60,5 @@ for k in range(RESTARTS*MAX_ITER):
     if cost.value < best:
         best = cost.value
     # print positions.value
-print "%% better = ", (total/(RESTARTS*MAX_ITER))
-print "best = ", best
+print("%% better = ", (total/(RESTARTS*MAX_ITER)))
+print("best = ", best)

--- a/examples/floor_packing.py
+++ b/examples/floor_packing.py
@@ -96,7 +96,7 @@ class FloorPlan(object):
                             box.width <= box.ASPECT_RATIO*box.height]
             # Enforce minimum area
             constraints += [
-            geo_mean(vstack(box.width, box.height)) >= math.sqrt(box.min_area)
+            geo_mean(vstack([box.width, box.height])) >= math.sqrt(box.min_area)
             ]
 
         # Enforce the relative ordering of the boxes.

--- a/examples/flows/commodity_flow.py
+++ b/examples/flows/commodity_flow.py
@@ -46,7 +46,7 @@ class MultiNode(Node):
     # The total accumulation of flow.
     def accumulation(self):
         return sum(f for f in self.edge_flows)
-    
+
     def constraints(self):
         return [abs(self.accumulation()) <= self.capacity]
 
@@ -88,8 +88,8 @@ if __name__ == "__main__":
         constraints += o.constraints()
     p = Problem(objective, constraints)
     result = p.solve()
-    print "Objective value = %s" % result
+    print("Objective value = %s" % result)
     # Show how the flow for each commodity.
     for i,s in enumerate(sinks):
         accumulation = sum(f.value[i] for f in s.edge_flows)
-        print "Accumulation of commodity %s = %s" % (i, accumulation)
+        print("Accumulation of commodity %s = %s" % (i, accumulation))

--- a/examples/flows/incidence_matrix.py
+++ b/examples/flows/incidence_matrix.py
@@ -47,8 +47,8 @@ flows = Variable(E)
 source = Variable()
 sink = Variable()
 p = Problem(Maximize(source),
-            [A*vstack(flows,source,sink) == 0,
+            [A*vstack([flows,source,sink]) == 0,
              0 <= flows,
              flows <= c])
 result = p.solve()
-print result
+print(result)

--- a/examples/flows/leaky_edges.py
+++ b/examples/flows/leaky_edges.py
@@ -15,8 +15,8 @@ limitations under the License.
 """
 
 from cvxpy import *
-import create_graph as g
-from max_flow import Node, Edge
+from .create_graph import FILE, NODE_COUNT_KEY, EDGES_KEY
+from .max_flow import Node, Edge
 import pickle
 
 # Max-flow with different kinds of edges.
@@ -52,12 +52,12 @@ class LeakyUndirected(Edge):
 
 if __name__ == "__main__":
     # Read a graph from a file.
-    f = open(g.FILE, 'r')
+    f = open(FILE, 'r')
     data = pickle.load(f)
     f.close()
 
     # Construct nodes.
-    node_count = data[g.NODE_COUNT_KEY]
+    node_count = data[NODE_COUNT_KEY]
     nodes = [Node() for i in range(node_count)]
     # Add source.
     nodes[0].accumulation = Variable()
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     # Construct edges.
     edges = []
-    for n1,n2,capacity in data[g.EDGES_KEY]:
+    for n1,n2,capacity in data[EDGES_KEY]:
         edges.append(LeakyUndirected(capacity))
         edges[-1].connect(nodes[n1], nodes[n2])
 
@@ -76,4 +76,4 @@ if __name__ == "__main__":
         constraints += o.constraints()
     p = Problem(Maximize(nodes[-1].accumulation), constraints)
     result = p.solve()
-    print result
+    print(result)

--- a/examples/flows/max_flow.py
+++ b/examples/flows/max_flow.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from cvxpy import *
-import create_graph as g
+from .create_graph import FILE, NODE_COUNT_KEY, EDGES_KEY
 import pickle
 
 # An object oriented max-flow problem.
@@ -46,12 +46,12 @@ class Node(object):
 
 if __name__ == "__main__":
     # Read a graph from a file.
-    f = open(g.FILE, 'r')
+    f = open(FILE, 'r')
     data = pickle.load(f)
     f.close()
 
     # Construct nodes.
-    node_count = data[g.NODE_COUNT_KEY]
+    node_count = data[NODE_COUNT_KEY]
     nodes = [Node() for i in range(node_count)]
     # Add source.
     nodes[0].accumulation = Variable()
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     # Construct edges.
     edges = []
-    for n1,n2,capacity in data[g.EDGES_KEY]:
+    for n1,n2,capacity in data[EDGES_KEY]:
         edges.append(Edge(capacity))
         edges[-1].connect(nodes[n1], nodes[n2])
     # Construct the problem.
@@ -69,4 +69,4 @@ if __name__ == "__main__":
         constraints += o.constraints()
     p = Problem(Maximize(nodes[-1].accumulation), constraints)
     result = p.solve()
-    print result
+    print(result)

--- a/examples/fmmc.py
+++ b/examples/fmmc.py
@@ -47,7 +47,7 @@ def FMMC(g,verbose=False):
       if i!=j: constraints.append(P[i,j]==0)
   prob=cvxpy.Problem(objective,constraints)
   prob.solve()
-  if verbose: print 'status: %s.'%prob.status,'optimal value=%.6f'%prob.value
+  if verbose: print('status: %s.'%prob.status,'optimal value=%.6f'%prob.value)
   return prob.status,prob.value,P.value
 
 def print_result(P,n,eps=1e-8):
@@ -55,24 +55,24 @@ def print_result(P,n,eps=1e-8):
     for i in range(n):
       x=row[0,i]
       if abs(x)<eps: x=0.0
-      print '%8.4f'%x,
+      print('%8.4f'%x)
     print
 
 def examples_p674():
-  print 'SIAM Rev. 46 examples p.674: Figure 1 and Table 1'
-  print '(a) line graph L(4)'
+  print('SIAM Rev. 46 examples p.674: Figure 1 and Table 1')
+  print('(a) line graph L(4)')
   g={0:(1,),1:(0,2,),2:(1,3,),3:(2,)}
   status,value,P=FMMC(g,verbose=True)
   print_result(P,len(g))
-  print '(b) triangle+one edge'
+  print('(b) triangle+one edge')
   g={0:(1,),1:(0,2,3,),2:(1,3,),3:(1,2,)}
   status,value,P=FMMC(g,verbose=True)
   print_result(P,len(g))
-  print '(c) bipartite 2+3'
+  print('(c) bipartite 2+3')
   g={0:(1,3,4,),1:(0,2,),2:(1,3,4,),3:(0,2,),4:(0,2,)}
   status,value,P=FMMC(g,verbose=True)
   print_result(P,len(g))
-  print '(d) square+central point'
+  print('(d) square+central point')
   g={0:(1,2,4,),1:(0,3,4,),2:(0,3,4,),3:(1,2,4,),4:(0,1,2,3,4,)}
   status,value,P=FMMC(g,verbose=True)
   print_result(P,len(g))

--- a/examples/geometry/convex_sets.py
+++ b/examples/geometry/convex_sets.py
@@ -106,9 +106,9 @@ class ConvexHull(ConvexSet):
     # The convex hull of a list of values.
     def __init__(self, values):
         values = map(self.cast_to_const, values)
-        rows, cols = values[0].size
+        rows, cols = next(values).size
         def constr_func(aff_obj):
-            theta = [lu.create_var((1, 1)) for i in xrange(len(values))]
+            theta = [lu.create_var((1, 1)) for i in range(len(values))]
             convex_objs = []
             for val, theta_var in zip(values, theta):
                 val_aff = val.canonical_form[0]

--- a/examples/geometry/separating_polyhedra.py
+++ b/examples/geometry/separating_polyhedra.py
@@ -17,7 +17,7 @@ limitations under the License.
 # Finds the separating hyperplane between two polyhedra.
 # Data from Section 8.2.2: Separating polyhedra in 2D in http://cvxr.com/cvx/examples/
 
-import convex_sets as cs
+from .convex_sets import Polyhedron, sep_hyp
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -28,12 +28,12 @@ A2 = np.matrix("1 0; -1 0; 0 1; 0 -1")
 b1 = 2*np.ones((m,1))
 b2 = np.matrix("5; -3; 4; -2")
 
-poly1 = cs.Polyhedron(A1, b1)
-poly2 = cs.Polyhedron(A2, b2)
+poly1 = Polyhedron(A1, b1)
+poly2 = Polyhedron(A2, b2)
 
 # Separating hyperplane.
-normal,offset = cs.sep_hyp(poly1, poly2)
-print normal, offset
+normal,offset = sep_hyp(poly1, poly2)
+print(normal, offset)
 
 # Plotting
 t = np.linspace(-3,6,100);

--- a/examples/geometry/tests.py
+++ b/examples/geometry/tests.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Problems involving polyhedra.
 
-import convex_sets as cs
+from .convex_sets import ConvexHull, Polyhedron, intersect, is_empty, dist, proj, contains
 import numpy as np
 
 n = 2
@@ -26,28 +26,28 @@ A2 = np.matrix("1 0; -1 0; 0 1; 0 -1")
 b1 = 2*np.ones((m,1))
 b2 = np.matrix("5; -3; 4; -2")
 
-poly1 = cs.Polyhedron(A1, b1)
-poly2 = cs.Polyhedron(A2, b2)
+poly1 = Polyhedron(A1, b1)
+poly2 = Polyhedron(A2, b2)
 
-assert cs.contains(poly1, [1,1])
+assert contains(poly1, [1,1])
 # TODO distance should be an expression, i.e. norm2(poly1 - poly2)
-print cs.dist(poly1, poly2)
-elem = cs.proj(poly1, poly2)
-assert cs.contains(poly1, elem)
-assert cs.dist(poly1, elem) < 1e-6
+print(dist(poly1, poly2))
+elem = proj(poly1, poly2)
+assert contains(poly1, elem)
+assert dist(poly1, elem) < 1e-6
 
-hull = cs.ConvexHull([b1, b2])
-print cs.contains(hull, b1)
-print cs.contains(hull, 0.3*b1 + 0.7*b2)
+hull = ConvexHull([b1, b2])
+print(contains(hull, b1))
+print(contains(hull, 0.3*b1 + 0.7*b2))
 
-print cs.dist(poly1, 5*hull[0:2] + 2)
-print cs.dist(poly1, np.matrix("1 5; -1 3")*poly2 + [1,5])
-d1 = cs.dist(poly1, np.matrix("1 0; 0 1")*poly2 + [1,5])
-d2 = cs.dist(poly2, poly1 - [1,5])
+print(dist(poly1, 5*hull[0:2] + 2))
+print(dist(poly1, np.matrix("1 5; -1 3") * poly2 + [1,5]))
+d1 = dist(poly1, np.matrix("1 0; 0 1")*poly2 + [1,5])
+d2 = dist(poly2, poly1 - [1,5])
 assert abs(d1 - d2) < 1e-6
 
 poly_hull = hull[0:2] + poly1 + poly2
-assert cs.dist(poly_hull, poly1) > 0
-intersection = cs.intersect(poly_hull, poly1)
-assert cs.is_empty(intersection)
-assert not cs.is_empty(poly1)
+assert dist(poly_hull, poly1) > 0
+intersection = intersect(poly_hull, poly1)
+assert is_empty(intersection)
+assert not is_empty(poly1)

--- a/examples/lasso.py
+++ b/examples/lasso.py
@@ -47,4 +47,4 @@ par_x = pool.map(get_x, gammas)
 
 for v1,v2 in zip(x_values, par_x):
     if np.linalg.norm(v1 - v2) > 1e-5:
-        print "error"
+        print("error")

--- a/examples/machine_learning/lasso_regression.py
+++ b/examples/machine_learning/lasso_regression.py
@@ -49,8 +49,8 @@ def plot_regularization_path(lambd_values, beta_values):
     plt.xscale("log")
     plt.title("Regularization Path")
     plt.show()
-    
-    
+
+
 if __name__ == "__main__":
     m = 100
     n = 20

--- a/examples/matrix_games_LP.py
+++ b/examples/matrix_games_LP.py
@@ -65,20 +65,20 @@ p1 = Problem(objective1, constraints1)
 p2 = Problem(objective2, constraints2)
 
 # Optimal strategy for Player 1
-print 'Computing the optimal strategy for player 1 ... '
+print('Computing the optimal strategy for player 1 ... ')
 result1 = p1.solve()
-print 'Done!'
+print('Done!')
 
 # Optimal strategy for Player 2
-print 'Computing the optimal strategy for player 2 ... '
+print('Computing the optimal strategy for player 2 ... ')
 result2 = p2.solve()
-print 'Done!'
+print('Done!')
 
 # Displaying results
-print '------------------------------------------------------------------------'
-print 'The optimal strategies for players 1 and 2 are respectively: '
-print x.value, y.value
-print 'The expected payoffs for player 1 and player 2 respectively are: '
-print result1, result2
-print 'They are equal as expected!'
+print('------------------------------------------------------------------------')
+print('The optimal strategies for players 1 and 2 are respectively: ')
+print(x.value, y.value)
+print('The expected payoffs for player 1 and player 2 respectively are: ')
+print(result1, result2)
+print('They are equal as expected!')
 ## ISSUE: THEY AREN'T EXACTLY EQUAL FOR SOME REASON!

--- a/examples/mpi_consensus_admm.py
+++ b/examples/mpi_consensus_admm.py
@@ -26,6 +26,7 @@ import operator as op
 import numpy as np
 from numpy.random import randn
 import dill
+from functools import reduce
 
 # Initialize the problem.
 n = 1000
@@ -74,4 +75,4 @@ for i in range(10):
         pool.map(apply_f, zip(functions, len(functions)*[xbar]))
     )
     xbar = total/len(functions)
-    print i
+    print(i)

--- a/examples/norm_approx.py
+++ b/examples/norm_approx.py
@@ -58,7 +58,7 @@ q = p/(p-1)
 x = Variable(n)
 objective1 = Minimize( norm ( A*x - b , p) )
 p1 = Problem(objective1, [])
-print 'Computing the optimal solution of problem 1... '
+print('Computing the optimal solution of problem 1... ')
 opt1 = p1.solve()
 
 # Reformulation 1
@@ -66,14 +66,14 @@ x = Variable(n)
 y = Variable(m)
 objective2 = Minimize ( norm( y, p ) )
 p2 = Problem(objective2, [ A*x - b == y ])
-print 'Computing the optimal solution of problem 2... '
+print('Computing the optimal solution of problem 2... ')
 opt2 = p2.solve()
 
 # Dual of reformulation 1
 nu = Variable(m)
 objective3 = Maximize( b.T * nu )
 p3 = Problem(objective3, [ norm( nu, q) <= 1, A.T*nu == 0 ])
-print 'Computing the optimal solution of problem 3... '
+print('Computing the optimal solution of problem 3... ')
 opt3 = p3.solve()
 
 # Reformulation 2
@@ -81,18 +81,18 @@ x = Variable(n)
 y = Variable(m)
 objective4 = Minimize( 0.5*square( norm(y, p) ) )
 p4 = Problem(objective4, [ A*x - b == y ] )
-print 'Computing the optimal solution of problem 4... '
+print('Computing the optimal solution of problem 4... ')
 opt4 = math.sqrt(2*p4.solve())
 
 # Dual of reformulation 2
 nu = Variable(m)
 objective5 = Maximize( -0.5*square( norm(nu,q) ) + b.T*nu )
 p5 = Problem(objective5, [ A.T*nu==0 ])
-print 'Computing the optimal solution of problem 5... '
+print('Computing the optimal solution of problem 5... ')
 opt5 = math.sqrt(2*p5.solve())
 
 # Display results
-print '------------------------------------------------------------------------'
-print 'The optimal residual values for problems 1,2,3,4 and 5 are respectively:'
-print opt1, opt2, opt3, opt4, opt5
-print 'They are equal as expected!'
+print('------------------------------------------------------------------------')
+print('The optimal residual values for problems 1,2,3,4 and 5 are respectively:')
+print(opt1, opt2, opt3, opt4, opt5)
+print('They are equal as expected!')

--- a/examples/qcqp.py
+++ b/examples/qcqp.py
@@ -46,7 +46,7 @@ P0 = cvxopt.normal(n, n)
 eye = cvxopt.spmatrix(1.0, range(n), range(n))
 P0 = P0.T * P0 + eps * eye
 
-print P0
+print(P0)
 
 P1 = cvxopt.normal(n, n)
 P1 = P1.T*P1
@@ -81,7 +81,7 @@ primal_result = p.solve()
 if p.status is OPTIMAL:
     # Note that since our data is random, we may need to run this program multiple times to get a feasible primal
     # When feasible, we can print out the following values
-    print x.value # solution
+    print (x.value) # solution
     lam1 = constraints[0].dual_value
     lam2 = constraints[1].dual_value
     lam3 = constraints[2].dual_value
@@ -93,5 +93,5 @@ if p.status is OPTIMAL:
     dual_result = -0.5*q_lam.T*P_lam*q_lam + r_lam
     # ISSUE: dual result is matrix for some reason
 
-    print 'Our duality gap is:'
+    print ('Our duality gap is:')
     print (primal_result - dual_result)

--- a/examples/relax_and_round.py
+++ b/examples/relax_and_round.py
@@ -94,7 +94,7 @@ numpy.random.seed(1)
 # Min sum_squares(A*x + B*z - c)
 # z boolean.
 def example(n, get_vals=False):
-    print "n = %d #################" % n
+    print ("n = %d #################" % n)
     m = 2*n
     A = numpy.matrix(numpy.random.randn(m, n))
     B = numpy.matrix(numpy.random.randn(m, n))
@@ -111,13 +111,13 @@ def example(n, get_vals=False):
     obj = sum_squares(A*x + B*z - c)
     prob = Problem(Minimize(obj))
     relaxation = cvx_relax(prob)
-    print "relaxation", relaxation.solve()
+    print ("relaxation", relaxation.solve())
     rel_z = z.value
     rounded = round_and_fix(relaxation)
     rounded.solve()
-    print "relax and round", rounded.value
+    print ("relax and round", rounded.value)
     truth, true_z = branch_and_bound(n, A, B, c)
-    print "true optimum", truth
+    print ("true optimum", truth)
     if get_vals:
         return (rel_z, z.value, true_z)
     return (relaxation.value, rounded.value, truth)
@@ -142,7 +142,7 @@ truth = []
 vals = range(1, 36)
 for n in vals:
     results = example(n)
-    results = map(lambda x: numpy.around(x, 3), results)
+    results = list(map(lambda x: numpy.around(x, 3), results))
     relaxed.append(results[0])
     rounded.append(results[1])
     truth.append(results[2])


### PR DESCRIPTION
Most of examples are in python2 (print, imap, izip, xrange) and quite outdated with the current state of `cvxpy` (still use `BoolVar()` instead of `Boolean()`, `vstack` with 2 variables instead of a list).

The goal of this PR is to update the examples to python3 and the latest version of `cvxpy`.