### PR TITLE
Fix license in cvxcore.i (#834)

### DIFF
--- a/cvxpy/cvxcore/python/cvxcore.i
+++ b/cvxpy/cvxcore/python/cvxcore.i
@@ -1,18 +1,16 @@
-"""
-Copyright 2017 Steven Diamond
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-"""
+//   Copyright 2017 Steven Diamond
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 %module cvxcore
 

--- a/cvxpy/cvxcore/python/cvxcore.i
+++ b/cvxpy/cvxcore/python/cvxcore.i
@@ -1,17 +1,18 @@
-//    This file is part of cvxcore.
-//
-//    cvxcore is free software: you can redistribute it and/or modify
-//    it under the terms of the GNU General Public License as published by
-//    the Free Software Foundation, either version 3 of the License, or
-//    (at your option) any later version.
-//
-//    cvxcore is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//    GNU General Public License for more details.
-//
-//    You should have received a copy of the GNU General Public License
-//    along with cvxcore.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Copyright 2017 Steven Diamond
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
 
 %module cvxcore
 


### PR DESCRIPTION
This should be the correct license paragraph as it is taken from the corresponding [cvxcore init file](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/cvxcore/python/__init__.py)