### PR TITLE
Remove extra verb from the operators subsection at the atomic functions section

### DIFF
--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -11,7 +11,7 @@ Operators
 ---------
 
 The infix operators ``+, -, *, /`` are treated as functions. ``+`` and
-``-`` are affine functions. The expression ``expr1*expr2`` is are affine in
+``-`` are affine functions. The expression ``expr1*expr2`` is affine in
 CVXPY when one of the expressions is constant, and ``expr1/expr2`` is affine
 when ``expr2`` is a scalar constant.
 


### PR DESCRIPTION
At https://www.cvxpy.org/tutorial/functions/index.html#operators, there is an extra `are`.