### PR TITLE
install scs from conda-forge

### DIFF
--- a/continuous_integration/AppVeyor/configure_conda_and_install_cvxpy.ps1
+++ b/continuous_integration/AppVeyor/configure_conda_and_install_cvxpy.ps1
@@ -4,6 +4,6 @@ conda create -n testenv --yes python=$env:PYTHON_VERSION mkl=2018.0.3 pip nose n
 conda activate testenv
 "python=$env:PYTHON_VERSION" | Out-File C:\conda\envs\testenv\conda-meta\pinned -encoding ascii
 conda install --yes lapack ecos multiprocess
-pip install scs<=2.0
+conda install -c conda-forge --yes scs
 conda install -c anaconda --yes flake8
 python setup.py install


### PR DESCRIPTION
Installing SCS from conda-forge instead of from pip seems to fix the appveyor build.

https://ci.appveyor.com/project/StevenDiamond/cvxpy/builds/28230656

Related: #788