### PR TITLE
Keep zeros

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -24,7 +24,7 @@ from cvxpy.problems.objective import Maximize, Minimize
 import cvxpy.interface.scipy_wrapper
 from cvxpy.error import DCPError, DPPError, DGPError, SolverError, disable_warnings, enable_warnings, warnings_enabled
 from cvxpy.settings import (CVXOPT, GLPK, GLPK_MI, CBC, CPLEX, OSQP, NAG,
-                            ECOS, ECOS_BB, SUPER_SCS, SCS, GUROBI, MOSEK, XPRESS,
+                            ECOS, ECOS_BB, SUPER_SCS, SCS, DIFFCP, GUROBI, MOSEK, XPRESS,
                             OPTIMAL, UNBOUNDED, INFEASIBLE, SOLVER_ERROR, ROBUST_KKTSOLVER,
                             OPTIMAL_INACCURATE, UNBOUNDED_INACCURATE, INFEASIBLE_INACCURATE)
 from cvxpy.transforms import linearize, partial_optimize

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -81,7 +81,9 @@ def A_mapping_nonzero_rows(problem_data_tensor, var_length):
     A_nrows = problem_data_tensor.shape[0] // (var_length + 1)
     A_ncols = var_length
     A_mapping = problem_data_tensor_csc[:A_nrows*A_ncols, :-1]
-    A_mapping_nonzero_rows, _ = nonzero_csc_matrix(A_mapping)
+    # don't call nonzero_csc_matrix, because here we don't want to
+    # count explicit zeros
+    A_mapping_nonzero_rows, _ = A_mapping.nonzero()
     return A_mapping_nonzero_rows
 
 

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -61,15 +61,21 @@ def get_parameter_vector(param_size,
 def nonzero_csc_matrix(A):
     # this function returns (rows, cols) corresponding to nonzero entries in
     # A; an entry that is explicitly set to zero is treated as nonzero
-    assert np.nan not in A.data
-    zero_indices = (A.data == 0)
+    assert not np.isnan(A.data).any()
+
     # scipy drops rows, cols with explicit zeros; use nan as a sentinel
     # to prevent them from being dropped
+    zero_indices = (A.data == 0)
     A.data[zero_indices] = np.nan
+
+    # A.nonzero() returns (rows, cols) sorted in C-style order,
+    # but (when A is a csc matrix) A.data is stored in Fortran-order, hence
+    # the sorting below
     A_rows, A_cols = A.nonzero()
     ind = np.argsort(A_cols, kind='mergesort')
     A_rows = A_rows[ind]
     A_cols = A_cols[ind]
+
     A.data[zero_indices] = 0
     return A_rows, A_cols
 
@@ -84,7 +90,7 @@ def A_mapping_nonzero_rows(problem_data_tensor, var_length):
     # don't call nonzero_csc_matrix, because here we don't want to
     # count explicit zeros
     A_mapping_nonzero_rows, _ = A_mapping.nonzero()
-    return A_mapping_nonzero_rows
+    return np.unique(A_mapping_nonzero_rows)
 
 
 def get_matrix_and_offset_from_tensor(problem_data_tensor, param_vec,

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -53,6 +53,7 @@ class ParamConeProg(object):
         self.c = c
         self.x = x
         self.A = A
+        self._A_mapping_nonzero = None
         self.constraints = constraints
         self.constr_size = sum([c.size for c in constraints])
         self.parameters = parameters
@@ -94,8 +95,12 @@ class ParamConeProg(object):
         c, d = canonInterface.get_matrix_and_offset_from_tensor(
             self.c, param_vec, self.x.size)
         c = c.toarray().flatten()
+        if keep_zeros and self._A_mapping_nonzero is None:
+            self._A_mapping_nonzero = canonInterface.A_mapping_nonzero_rows(
+                self.A, self.x.size)
         A, b = canonInterface.get_matrix_and_offset_from_tensor(
-            self.A, param_vec, self.x.size, keep_zeros=keep_zeros)
+            self.A, param_vec, self.x.size,
+            nonzero_rows=self._A_mapping_nonzero)
         return c, d, A, np.atleast_1d(b)
 
     def apply_param_jac(self, delc, delA, delb, active_params=None):

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -71,13 +71,16 @@ class ParamConeProg(object):
         return self.x.attributes['boolean'] or \
             self.x.attributes['integer']
 
-    def apply_parameters(self, id_to_param_value=None, zero_offset=False):
+    def apply_parameters(self, id_to_param_value=None, zero_offset=False,
+                         keep_zeros=False):
         """Returns A, b after applying parameters (and reshaping).
 
         Args:
           id_to_param_value: (optional) dict mapping parameter ids to values
           zero_offset: (optional) if True, zero out the constant offset in the
                        parameter vector
+          keep_zeros: (optional) if True, store explicit zeros in A where
+                        parameters are affected
         """
         def param_value(idx):
             return (np.array(self.id_to_param[idx].value) if id_to_param_value
@@ -92,7 +95,7 @@ class ParamConeProg(object):
             self.c, param_vec, self.x.size)
         c = c.toarray().flatten()
         A, b = canonInterface.get_matrix_and_offset_from_tensor(
-            self.A, param_vec, self.x.size)
+            self.A, param_vec, self.x.size, keep_zeros=keep_zeros)
         return c, d, A, np.atleast_1d(b)
 
     def apply_param_jac(self, delc, delA, delb, active_params=None):

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -37,6 +37,20 @@ class DIFFCP(scs_conif.SCS):
         if patch_version < 7:
             raise ImportError("diffcp >= 1.0.7 is required")
 
+    def apply(self, problem):
+        problem, data, inv_data = self._prepare_data_and_inv_data(problem)
+
+        # Apply parameter values.
+        # Obtain A, b such that Ax + s = b, s \in cones.
+        #
+        # Keep zeros in A that are affected by parameters
+        c, d, A, b = problem.apply_parameters(keep_zeros=True)
+        data[s.C] = c
+        inv_data[s.OFFSET] = d
+        data[s.A] = -A
+        data[s.B] = b
+        return data, inv_data
+
     def solve_via_data(self, data, warm_start, verbose, solver_opts,
                        solver_cache=None):
         """Returns the result of the call to the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -140,14 +140,7 @@ class SCS(ConicSolver):
 
         return scaled_lower_tri @ symm_matrix
 
-    def apply(self, problem):
-        """Returns a new problem and data for inverting the new solution.
-
-        Returns
-        -------
-        tuple
-            (dict of arguments needed for the solver, inverse data)
-        """
+    def _prepare_data_and_inv_data(self, problem):
         data = {}
         inv_data = {self.VAR_ID: problem.x.id}
 
@@ -171,13 +164,20 @@ class SCS(ConicSolver):
         if not problem.formatted:
             problem = self.format_constraints(problem, self.EXP_CONE_ORDER)
         data[s.PARAM_PROB] = problem
+        return problem, data, inv_data
+
+    def apply(self, problem):
+        """Returns a new problem and data for inverting the new solution.
+
+        Returns
+        -------
+        tuple
+            (dict of arguments needed for the solver, inverse data)
+        """
+        problem, data, inv_data = self._prepare_data_and_inv_data(problem)
 
         # Apply parameter values.
         # Obtain A, b such that Ax + s = b, s \in cones.
-        #
-        # Note that scs mandates that the cones MUST be ordered with
-        # zero cones first, then non-nonnegative orthant, then SOC,
-        # then PSD, then exponential.
         c, d, A, b = problem.apply_parameters()
         data[s.C] = c
         inv_data[s.OFFSET] = d

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -1,4 +1,5 @@
 import cvxpy as cp
+import cvxpy.settings as s
 from cvxpy.tests.base_test import BaseTest
 
 import numpy as np
@@ -300,3 +301,12 @@ class TestBackward(BaseTest):
                                     "When requires_grad is True, the "
                                     "only supported solver is SCS.*"):
             problem.solve(cp.ECOS, requires_grad=True)
+
+    def test_zero_in_problem_data(self):
+        x = cp.Variable()
+        param = cp.Parameter()
+        param.value = 0.0
+        problem = cp.Problem(cp.Minimize(x), [param * x >= 0])
+        data, _, _ = problem.get_problem_data(cp.DIFFCP)
+        A = data[s.A]
+        self.assertIn(0.0, A.data)


### PR DESCRIPTION
When differentiating, keep zero entries in problem data that are affected by parameters