### PR TITLE
support functions (transform, and atom)

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -27,6 +27,6 @@ from cvxpy.settings import (CVXOPT, GLPK, GLPK_MI, CBC, CPLEX, OSQP, NAG,
                             ECOS, ECOS_BB, SUPER_SCS, SCS, DIFFCP, GUROBI, MOSEK, XPRESS,
                             OPTIMAL, UNBOUNDED, INFEASIBLE, SOLVER_ERROR, ROBUST_KKTSOLVER,
                             OPTIMAL_INACCURATE, UNBOUNDED_INACCURATE, INFEASIBLE_INACCURATE)
-from cvxpy.transforms import linearize, partial_optimize
+from cvxpy.transforms import linearize, partial_optimize, suppfunc
 from cvxpy.reductions import *
 from cvxpy.reductions.solvers.defines import installed_solvers

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -10,14 +10,14 @@ class SuppFuncAtom(Atom):
     def __init__(self, y, A, b, K_sels, x, cons):
         self.id = lu.get_id()
         eta = Variable(shape=(b.size,))
-        self.args = [Atom.cast_to_const(y), Atom.cast_to_const(A), Atom.cast_to_const(b),
-                     Atom.cast_to_const(eta)]
-        horrible = self.args[2]
-        horrible.__dict__['K_sels'] = K_sels
+        self.args = [Atom.cast_to_const(y), Atom.cast_to_const(eta)]
+        self._A = A
+        self._b = b
+        self._K_sels = K_sels
         self._x = x
         self._xcons = cons
-        self.validate_arguments()
         self._shape = tuple()
+        self.validate_arguments()
         pass
 
     def validate_arguments(self):
@@ -27,14 +27,14 @@ class SuppFuncAtom(Atom):
             raise ValueError("Arguments to SuppFuncAtom must be affine.")
 
     def variables(self):
-        varlist = self.args[0].variables() + self.args[3].variables()
+        varlist = self.args[0].variables() + self.args[1].variables()
         return varlist
 
     def parameters(self):
         return []
 
     def constants(self):
-        return [self.args[1], self.args[2]]
+        return []
 
     def shape_from_args(self):
         return self._shape

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -23,7 +23,6 @@ class SuppFuncAtom(Atom):
         self._eta = None  # store for debugging purposes
         self._shape = tuple()
         self.validate_arguments()
-        pass
 
     def validate_arguments(self):
         if self.args[0].is_complex():

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -1,0 +1,132 @@
+import cvxpy.lin_ops.lin_utils as lu
+from cvxpy.atoms.atom import Atom
+from cvxpy.expressions.variable import Variable
+import scipy.sparse as sp
+import numpy as np
+
+
+class SuppFuncAtom(Atom):
+
+    def __init__(self, y, A, b, K_sels, x, cons):
+        self.id = lu.get_id()
+        eta = Variable(shape=(b.size,))
+        self.args = [Atom.cast_to_const(y), Atom.cast_to_const(A), Atom.cast_to_const(b),
+                     Atom.cast_to_const(eta)]
+        horrible = self.args[2]
+        horrible.__dict__['K_sels'] = K_sels
+        self._x = x
+        self._xcons = cons
+        self.validate_arguments()
+        self._shape = tuple()
+        pass
+
+    def validate_arguments(self):
+        if self.args[0].is_complex():
+            raise ValueError("Arguments to SuppFuncAtom cannot be complex.")
+        if not self.args[0].is_affine():
+            raise ValueError("Arguments to SuppFuncAtom must be affine.")
+
+    def variables(self):
+        varlist = self.args[0].variables() + self.args[3].variables()
+        return varlist
+
+    def parameters(self):
+        return []
+
+    def constants(self):
+        return [self.args[1], self.args[2]]
+
+    def shape_from_args(self):
+        return self._shape
+
+    def sign_from_args(self):
+        return (False, False)
+
+    def is_nonneg(self):
+        return False
+
+    def is_nonpos(self):
+        return False
+
+    def is_imag(self):
+        return False
+
+    def is_complex(self):
+        return False
+
+    def is_atom_convex(self):
+        return True
+
+    def is_atom_concave(self):
+        return False
+
+    def is_atom_log_log_convex(self):
+        return False
+
+    def is_atom_log_log_concave(self):
+        return False
+
+    def is_atom_quasiconvex(self):
+        return True
+
+    def is_atom_quasiconcave(self):
+        return False
+
+    def is_incr(self, idx):
+        return False
+
+    def is_decr(self, idx):
+        return False
+
+    def is_convex(self):
+        # The argument "y" is restricted to being affine.
+        return True
+
+    def is_concave(self):
+        return False
+
+    def is_log_log_convex(self):
+        return False
+
+    def is_log_log_concave(self):
+        return False
+
+    def is_quasiconvex(self):
+        # The argument "y" is restricted to being affine.
+        return True
+
+    def is_quasiconcave(self):
+        return False
+
+    def _value_impl(self):
+        from cvxpy.problems.problem import Problem
+        from cvxpy.problems.objective import Maximize
+        y_val = self.args[0].value.round(decimals=9).ravel(order='F')
+        x_flat = self._x.flatten()
+        cons = self._xcons
+        prob = Problem(Maximize(y_val @ x_flat), cons)
+        val = prob.solve(solver='SCS', eps=1e-6)
+        return val
+
+    def _grad(self, values):
+        # the implementation of _grad from log_det.py was used
+        # as a reference for this implementation.
+        y0 = self.args[0].value  # save for later
+        y = values[0]  # ignore all other values
+        self.args[0].value = y
+        self._value_impl()  # dead-store
+        self.args[0].value = y0  # put this value back
+        gradval = self._x.value
+        if np.any(np.isnan(gradval)):
+            # If we evaluated the support function successfully, then
+            # this means the support function is not finite at this input.
+            return [None]
+        else:
+            gradmat = sp.csc_matrix(gradval.ravel(order='F')).T
+            return [gradmat]
+
+    def __lt__(self, other):
+        raise NotImplementedError("Strict inequalities are not allowed.")
+
+    def __gt__(self, other):
+        raise NotImplementedError("Strict inequalities are not allowed.")

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.atoms import *
+from cvxpy.atoms.suppfunc import SuppFuncAtom
 from cvxpy.atoms.affine.binary_operators import MulExpression, multiply
 from cvxpy.atoms.affine.index import special_index
 from cvxpy.transforms.indicator import indicator
@@ -38,6 +39,7 @@ from cvxpy.reductions.dcp2cone.atom_canonicalizers.pnorm_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.sigma_max_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.quad_form_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.quad_over_lin_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.suppfunc_canon import suppfunc_canon
 
 from cvxpy.reductions.utilities import special_index_canon
 
@@ -80,4 +82,5 @@ CANON_METHODS = {
     power : power_canon,
     indicator : indicator_canon,
     special_index : special_index_canon,
+    SuppFuncAtom : suppfunc_canon
 }

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
@@ -1,0 +1,99 @@
+from cvxpy import hstack, SOC, sum
+from cvxpy.constraints.exponential import ExpCone
+import numpy as np
+from scipy.sparse import csc_matrix
+
+
+def scspsdvec2mat(vec):
+    n = int(np.sqrt(vec.size * 2))
+    rows, cols = np.triu_indices(n)
+    mats = []
+    for i in range(vec.size):
+        r, c = rows[i], cols[i]
+        mat = np.zeros(shape=(n, n))
+        if r == c:
+            mat[r, r] = 1
+        else:
+            mat[r, c] = 1 / np.sqrt(2)
+            mat[c, r] = 1 / np.sqrt(2)
+        mat = vec[i] * mat
+        mats.append(mat)
+    V = sum(mats)
+    return V
+
+
+def selector_matrix(selector, inshape):
+    """
+    :param selector: a vector of nonnegative integer indices.
+    :param inshape: an integer > np.max(selector)
+
+    :return: A csc-format sparse matrix ``mat``, where for some cvxpy expression ``x``,
+    ``expr1 = x[selector]`` and ``expr2 = mat @ x`` are equivalent in a symbolic sense.
+
+    This function is necessary, because special-indexing like "x[selector]" doesn't
+    have a graph_implementation function, and the usual CVXPY rewriting system to handle
+    such indexing can't be relied at this point in the compilation process.
+    """
+    vals = np.ones(selector.size)
+    rows = np.arange(selector.size)
+    mat = csc_matrix((vals, (rows, selector)), shape=(selector.size, inshape))
+    return mat
+
+
+def suppfunc_canon(expr, args):
+    y = args[0].flatten()
+    # ^ That's the user-supplied argument to the support function.
+    A, b = args[1], args[2]
+    K_sels = b.K_sels
+    # ^ That defines the set "X" associated with this support function.
+    eta = args[3]
+    # ^ Variable, of shape (b.size,). It's the main part of the duality
+    # trick for representing the epigraph of this support function.
+    n = A.shape[1]
+    n0 = y.size
+    if n > n0:
+        # The description of the set "X" used in this support
+        # function included n - n0 > 0 auxiliary variables.
+        # We can pretend these variables were user-defined
+        # by appending a suitable number of zeros to y.
+        y_lift = hstack([y, np.zeros(shape=(n - n0,))])
+    else:
+        y_lift = y
+    local_cons = [A.T @ eta + y_lift == 0]
+    # now, the main conic constraints on eta.
+    #   nonneg, exp, soc, psd
+    nonnegsel = K_sels['nonneg']
+    if nonnegsel.size > 0:
+        selector = selector_matrix(nonnegsel, eta.size)
+        temp_expr = selector @ eta
+        local_cons.append(temp_expr >= 0)
+    socsels = K_sels['soc']
+    for socsel in socsels:
+        selector = selector_matrix(np.array([socsel[0]]), eta.size)
+        tempsca = selector @ eta
+        selector = selector_matrix(socsel[1:], eta.size)
+        tempvec = selector @ eta
+        soccon = SOC(tempsca, tempvec)
+        local_cons.append(soccon)
+    psdsels = K_sels['psd']
+    for psdsel in psdsels:
+        selector = selector_matrix(psdsel, eta.size)
+        curvec = selector @ eta
+        curmat = scspsdvec2mat(curvec)
+        local_cons.append(curmat >> 0)
+    expsel = K_sels['exp']
+    if expsel.size > 0:
+        matexpsel = np.reshape(expsel, (-1, 3))
+        selector = selector_matrix(matexpsel[:, 0], eta.size)
+        curr_u = selector @ eta
+        selector = selector_matrix(matexpsel[:, 1], eta.size)
+        curr_v = selector @ eta
+        selector = selector_matrix(matexpsel[:, 2], eta.size)
+        curr_w = selector @ eta
+        # (curr_u, curr_v, curr_w) needs to belong to the dual
+        # exponential cone, as used by the SCS solver. We map
+        # this to a primal exponential cone as follows.
+        ec = ExpCone(-curr_v, -curr_u, np.exp(1) * curr_w)
+        local_cons.append(ec)
+    epigraph = b @ eta
+    return epigraph, local_cons

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
@@ -1,4 +1,4 @@
-from cvxpy import hstack, SOC, sum, Variable
+from cvxpy import hstack, SOC, Variable
 from cvxpy.constraints.exponential import ExpCone
 from cvxpy.reductions.solvers.conic_solvers.scs_conif import scs_psdvec_to_psdmat
 import numpy as np

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
@@ -1,75 +1,19 @@
 from cvxpy import hstack, SOC, sum, Variable
 from cvxpy.constraints.exponential import ExpCone
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import scs_psdvec_to_psdmat
 import numpy as np
-from scipy.sparse import csc_matrix
-
-
-def scs_psdvec_to_psdmat(vec, indices):
-    """
-    Return "V" so that "vec[indices] belongs to the SCS-standard PSD cone"
-    can be written in natural cvxpy syntax as "V >> 0".
-
-    Parameters
-    ----------
-    vec : cvxpy.expressions.expression.Expression
-        Must have ``vec.is_affine() == True``.
-    indices : ndarray
-        Contains nonnegative integers, which can index into ``vec``.
-
-    """
-    n = int(np.sqrt(indices.size * 2))
-    rows, cols = np.triu_indices(n)
-    mats = []
-    for i, idx in enumerate(indices):
-        r, c = rows[i], cols[i]
-        mat = np.zeros(shape=(n, n))
-        if r == c:
-            mat[r, r] = 1
-        else:
-            mat[r, c] = 1 / np.sqrt(2)
-            mat[c, r] = 1 / np.sqrt(2)
-        mat = vec[idx] * mat
-        mats.append(mat)
-    V = sum(mats)
-    return V
-
-
-def selector_matrix(selector, inshape):
-    """
-    Parameters
-    ----------
-    selector : ndarray
-        Contains nonnegative integers.
-    inshape : int
-        Must be greater than np.max(selector).
-
-    Returns
-    -------
-    A csc-format sparse matrix ``mat``, where for some cvxpy expression ``x``,
-    ``expr1 = x[selector]`` and ``expr2 = mat @ x`` are symbolically equivalent.
-
-    Notes
-    -----
-    This function is necessary, because special-indexing like "x[selector]" doesn't
-    have a graph_implementation function, and the usual CVXPY rewriting system to handle
-    such indexing can't be relied at this point in the compilation process.
-    """
-    vals = np.ones(selector.size)
-    rows = np.arange(selector.size)
-    mat = csc_matrix((vals, (rows, selector)), shape=(selector.size, inshape))
-    return mat
 
 
 def suppfunc_canon(expr, args):
     y = args[0].flatten()
-    parent = expr._parent
     # ^ That's the user-supplied argument to the support function.
+    parent = expr._parent
     A, b, K_sels = parent.conic_repr_of_set()
     # ^ That defines the set "X" associated with this support function.
     eta = Variable(shape=(b.size,))
     expr._eta = eta
-    # ^ Variable, of shape (b.size,). It's the main part of the duality
-    # trick for representing the epigraph of this support function.
+    # ^ The main part of the duality trick for representing the epigraph
+    # of this support function.
     n = A.shape[1]
     n0 = y.size
     if n > n0:
@@ -81,19 +25,16 @@ def suppfunc_canon(expr, args):
     else:
         y_lift = y
     local_cons = [A.T @ eta + y_lift == 0]
-    # now, the main conic constraints on eta.
+    # now, the conic constraints on eta.
     #   nonneg, exp, soc, psd
     nonnegsel = K_sels['nonneg']
     if nonnegsel.size > 0:
-        selector = selector_matrix(nonnegsel, eta.size)
-        temp_expr = selector @ eta
+        temp_expr = eta[nonnegsel]
         local_cons.append(temp_expr >= 0)
     socsels = K_sels['soc']
     for socsel in socsels:
-        selector = selector_matrix(np.array([socsel[0]]), eta.size)
-        tempsca = selector @ eta
-        selector = selector_matrix(socsel[1:], eta.size)
-        tempvec = selector @ eta
+        tempsca = eta[socsel[0]]
+        tempvec = eta[socsel[1:]]
         soccon = SOC(tempsca, tempvec)
         local_cons.append(soccon)
     psdsels = K_sels['psd']
@@ -103,12 +44,9 @@ def suppfunc_canon(expr, args):
     expsel = K_sels['exp']
     if expsel.size > 0:
         matexpsel = np.reshape(expsel, (-1, 3))
-        selector = selector_matrix(matexpsel[:, 0], eta.size)
-        curr_u = selector @ eta
-        selector = selector_matrix(matexpsel[:, 1], eta.size)
-        curr_v = selector @ eta
-        selector = selector_matrix(matexpsel[:, 2], eta.size)
-        curr_w = selector @ eta
+        curr_u = eta[matexpsel[:, 0]]
+        curr_v = eta[matexpsel[:, 1]]
+        curr_w = eta[matexpsel[:, 2]]
         # (curr_u, curr_v, curr_w) needs to belong to the dual
         # exponential cone, as used by the SCS solver. We map
         # this to a primal exponential cone as follows.

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
@@ -43,10 +43,9 @@ def selector_matrix(selector, inshape):
 def suppfunc_canon(expr, args):
     y = args[0].flatten()
     # ^ That's the user-supplied argument to the support function.
-    A, b = args[1], args[2]
-    K_sels = b.K_sels
+    A, b, K_sels = expr._A, expr._b, expr._K_sels
     # ^ That defines the set "X" associated with this support function.
-    eta = args[3]
+    eta = args[1]
     # ^ Variable, of shape (b.size,). It's the main part of the duality
     # trick for representing the epigraph of this support function.
     n = A.shape[1]

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -68,6 +68,36 @@ def tri_to_full(lower_tri, n):
     return np.reshape(full, n*n, order="F")
 
 
+def scs_psdvec_to_psdmat(vec, indices):
+    """
+    Return "V" so that "vec[indices] belongs to the SCS-standard PSD cone"
+    can be written in natural cvxpy syntax as "V >> 0".
+
+    Parameters
+    ----------
+    vec : cvxpy.expressions.expression.Expression
+        Must have ``vec.is_affine() == True``.
+    indices : ndarray
+        Contains nonnegative integers, which can index into ``vec``.
+
+    """
+    n = int(np.sqrt(indices.size * 2))
+    rows, cols = np.triu_indices(n)
+    mats = []
+    for i, idx in enumerate(indices):
+        r, c = rows[i], cols[i]
+        mat = np.zeros(shape=(n, n))
+        if r == c:
+            mat[r, r] = 1
+        else:
+            mat[r, c] = 1 / np.sqrt(2)
+            mat[c, r] = 1 / np.sqrt(2)
+        mat = vec[idx] * mat
+        mats.append(mat)
+    V = sum(mats)
+    return V
+
+
 class SCS(ConicSolver):
     """An interface for the SCS solver.
     """

--- a/cvxpy/tests/test_mosek_conif.py
+++ b/cvxpy/tests/test_mosek_conif.py
@@ -124,16 +124,16 @@ class TestMosek(BaseTest):
                 x = cvx.Variable(shape=(3, 1))
                 constraints = [cvx.sum(x) <= 1.0, cvx.sum(x) >= 0.1, x >= 0.01,
                                cvx.kl_div(x[1], x[0]) + x[1] - x[0] + x[2] <= 0]
-                obj = cvx.Minimize(3 * x[0] + 2 * x[1] + x[0])
+                obj = cvx.Minimize(3 * x[0] + 2 * x[1] + x[2])
                 prob = cvx.Problem(obj, constraints)
                 prob.solve(solver=cvx.MOSEK)
                 val_mosek = prob.value
                 x_mosek = x.value.flatten().tolist()
-                duals_mosek = [c.dual_value.flatten().tolist() for c in constraints]
+                duals_mosek = [np.array(c.dual_value).ravel().tolist() for c in constraints]
                 prob.solve(solver=cvx.ECOS)
                 val_ecos = prob.value
                 x_ecos = x.value.flatten().tolist()
-                duals_ecos = [c.dual_value.flatten().tolist() for c in constraints]
+                duals_ecos = [np.array(c.dual_value).ravel().tolist() for c in constraints]
 
                 # verify results
                 self.assertAlmostEqual(val_mosek, val_ecos)

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -200,3 +200,12 @@ class TestSupportFunctions(BaseTest):
             assert False
         except SolverError:
             pass
+
+    def test_invalid_vararg(self):
+        x = cvx.Variable(shape=(2,2), symmetric=True)
+        try:
+            sigma = cvx.suppfunc(x, [])
+            assert False
+        except ValueError as e:
+            assert 'attributes' in e.args[0]
+        pass

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -193,9 +193,9 @@ class TestSupportFunctions(BaseTest):
         pass
 
     def test_invalid_variable(self):
-        x = cvx.Variable(shape=(2,2), symmetric=True)
+        x = cvx.Variable(shape=(2, 2), symmetric=True)
         try:
-            sigma = cvx.suppfunc(x, [])
+            cvx.suppfunc(x, [])  # dead-store
             assert False
         except ValueError as e:
             assert 'attributes' in e.args[0]
@@ -206,7 +206,7 @@ class TestSupportFunctions(BaseTest):
         a = cvx.Parameter(shape=(3,))
         cons = [a @ x == 1]
         try:
-            sigma = cvx.suppfunc(x, cons)
+            cvx.suppfunc(x, cons)  # dead-store
             assert False
         except ValueError as e:
             assert 'Parameter' in e.args[0]

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -1,0 +1,202 @@
+"""
+Copyright 2019, the cvxpy developers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import cvxpy as cvx
+import numpy as np
+from cvxpy.tests.base_test import BaseTest
+from cvxpy.error import SolverError
+
+
+"""
+Known issues:
+
+The support function must be declared w.r.t. a Variable
+with no attributes. I.e., no PSD=True, no nonneg=True,
+no symmetric=True.
+
+"""
+
+
+class TestSupportFunctions(BaseTest):
+    """
+    Test the implementation of support function atoms.
+
+    Relevant source code includes:
+        cvxpy.atoms.suppfunc
+        cvxpy.transforms.suppfunc
+        cvxpy.reductions.dcp2cone.atom_canonicalizers.suppfunc_canon
+    """
+
+    def test_Rn(self):
+        np.random.seed(0)
+        n = 5
+        x = cvx.Variable(shape=(n,))
+        sigma = cvx.suppfunc(x, [])
+        a = np.random.randn(n,)
+        y = cvx.Variable(shape=(n,))
+        cons = [sigma(y - a) <= 0]  # "<= num" for any num >= 0 is valid.
+        objective = cvx.Minimize(a @ y)
+        prob = cvx.Problem(objective, cons)
+        prob.solve(solver='ECOS')
+        actual = prob.value
+        expected = np.dot(a, a)
+        assert abs(actual - expected) <= 1e-6
+        actual = y.value
+        expected = a
+        assert np.linalg.norm(actual - expected, ord=2) <= 1e-6
+        viol = cons[0].violation()
+        assert viol <= 1e-8
+
+    def test_vector1norm(self):
+        n = 3
+        np.random.seed(1)
+        a = np.random.randn(n,)
+        x = cvx.Variable(shape=(n,))
+        sigma = cvx.suppfunc(x, [cvx.norm(x - a, 1) <= 1])
+        y = np.random.randn(n,)
+        y_var = cvx.Variable(shape=(n,))
+        prob = cvx.Problem(cvx.Minimize(sigma(y_var)), [y == y_var])
+        prob.solve(solver='ECOS')
+        actual = prob.value
+        expected = a @ y + np.linalg.norm(y, ord=np.inf)
+        assert abs(actual - expected) <= 1e-6
+        assert abs(prob.objective.expr.value - prob.value) <= 1e-6
+
+    def test_vector2norm(self):
+        n = 3
+        np.random.seed(1)
+        a = np.random.randn(n,)
+        x = cvx.Variable(shape=(n,))
+        sigma = cvx.suppfunc(x, [cvx.norm(x - a, 2) <= 1])
+        y = np.random.randn(n,)
+        y_var = cvx.Variable(shape=(n,))
+        prob = cvx.Problem(cvx.Minimize(sigma(y_var)), [y == y_var])
+        prob.solve(solver='ECOS')
+        actual = prob.value
+        expected = a @ y + np.linalg.norm(y, ord=2)
+        assert abs(actual - expected) <= 1e-6
+        assert abs(prob.objective.expr.value - prob.value) <= 1e-6
+
+    def test_rectangular_variable(self):
+        np.random.seed(2)
+        rows, cols = 4, 2
+        a = np.random.randn(rows, cols)
+        x = cvx.Variable(shape=(rows, cols))
+        sigma = cvx.suppfunc(x, [x[:, 0] == 0])
+        y = cvx.Variable(shape=(rows, cols))
+        cons = [sigma(y - a) <= 0]
+        objective = cvx.Minimize(cvx.sum_squares(y.flatten()))
+        prob = cvx.Problem(objective, cons)
+        prob.solve(solver='ECOS')
+        expect = np.hstack([np.zeros(shape=(rows, 1)), a[:, [1]]])
+        actual = y.value
+        assert np.linalg.norm(actual - expect, ord=2) <= 1e-6
+        viol = cons[0].violation()
+        assert viol <= 1e-6
+
+    def test_psd_dualcone(self):
+        np.random.seed(5)
+        n = 3
+        X = cvx.Variable(shape=(n, n))
+        sigma = cvx.suppfunc(X, [X >> 0])
+        A = np.random.randn(n, n)
+        Y = cvx.Variable(shape=(n, n))
+        objective = cvx.Minimize(cvx.norm(A.ravel(order='F') + Y.flatten()))
+        cons = [sigma(Y) <= 0]  # Y is negative definite.
+        prob = cvx.Problem(objective, cons)
+        prob.solve(solver='SCS', eps=1e-8)
+        viol = cons[0].violation()
+        assert viol <= 1e-6
+        eigs = np.linalg.eigh(Y.value)[0]
+        assert np.max(eigs) <= 1e-6
+
+    def test_largest_singvalue(self):
+        np.random.seed(3)
+        rows, cols = 3, 4
+        A = np.random.randn(rows, cols)
+        A_sv = np.linalg.svd(A, compute_uv=False)
+        X = cvx.Variable(shape=(rows, cols))
+        sigma = cvx.suppfunc(X, [cvx.sigma_max(X) <= 1])
+        Y = cvx.Variable(shape=(rows, cols))
+        cons = [Y == A]
+        prob = cvx.Problem(cvx.Minimize(sigma(Y)), cons)
+        prob.solve(solver='SCS', eps=1e-8)
+        actual = prob.value
+        expect = np.sum(A_sv)
+        assert abs(actual - expect) <= 1e-6
+
+    def test_expcone0(self):
+        x = cvx.Variable(shape=(1,))
+        tempcons = [cvx.exp(x[0]) <= np.exp(1), cvx.exp(-x[0]) <= np.exp(1)]
+        sigma = cvx.suppfunc(x, tempcons)
+        y = cvx.Variable(shape=(1,))
+        obj_expr = y[0]
+        cons = [sigma(y) <= 1]
+        # ^ That just means -1 <= y[0] <= 1
+        prob = cvx.Problem(cvx.Minimize(obj_expr), cons)
+        prob.solve(solver='ECOS')
+        viol = cons[0].violation()
+        assert viol <= 1e-6
+        assert abs(y.value - (-1)) <= 1e-6
+
+    def test_expcone1(self):
+        x = cvx.Variable(shape=(3,))
+        tempcons = [cvx.sum(x) <= 1.0, cvx.sum(x) >= 0.1, x >= 0.01,
+                    cvx.kl_div(x[1], x[0]) + x[1] - x[0] + x[2] <= 0]
+        sigma = cvx.suppfunc(x, tempcons)
+        y = cvx.Variable(shape=(3,))
+        a = np.array([-3, -2, -1])  # this is negative of objective in mosek_conif.py example
+        expr = -sigma(y)
+        objective = cvx.Maximize(expr)
+        cons = [y == a]
+        prob = cvx.Problem(objective, cons)
+        prob.solve(solver='ECOS')
+        # Check for expected objective value
+        epi_actual = prob.value
+        direct_actual = expr.value
+        expect = 0.235348211
+        assert abs(epi_actual - expect) <= 1e-6
+        assert abs(direct_actual - expect) <= 1e-6
+
+    def test_basic_lmi(self):
+        np.random.seed(4)
+        n = 3
+        A = np.random.randn(n, n)
+        A = A.T @ A
+        X = cvx.Variable(shape=(n, n))  # will fail if you try PSD=True, or symmetric=Trues
+        sigma = cvx.suppfunc(X, [0 << X, cvx.lambda_max(X) <= 1])
+        Y = cvx.Variable(shape=(n, n))
+        cons = [Y == A]
+        expr = sigma(Y)
+        prob = cvx.Problem(cvx.Minimize(expr), cons)  # opt value of support func would be at X=I.
+        prob.solve(solver='SCS', eps=1e-8)
+        actual1 = prob.value  # computed with epigraph
+        actual2 = expr.value  # computed by evaluating support function, as a maximization problem.
+        assert abs(actual1 - actual2) <= 1e-6
+        expect = np.trace(A)
+        assert abs(actual1 - expect) <= 1e-4
+
+    def test_invalid_solver(self):
+        n = 3
+        x = cvx.Variable(shape=(n,))
+        sigma = cvx.suppfunc(x, [cvx.norm(x - np.random.randn(n,), 2) <= 1])
+        y_var = cvx.Variable(shape=(n,))
+        prob = cvx.Problem(cvx.Minimize(sigma(y_var)), [np.random.randn(n,) == y_var])
+        try:
+            prob.solve(solver='OSQP')
+            assert False
+        except SolverError:
+            pass

--- a/cvxpy/transforms/__init__.py
+++ b/cvxpy/transforms/__init__.py
@@ -21,3 +21,4 @@ from cvxpy.transforms.indicator import indicator
 from cvxpy.transforms.scalarize import (weighted_sum,
                                         targets_and_priorities,
                                         max, log_sum_exp)
+from cvxpy.transforms.suppfunc import SuppFunc as suppfunc

--- a/cvxpy/transforms/suppfunc.py
+++ b/cvxpy/transforms/suppfunc.py
@@ -113,6 +113,10 @@ class SuppFunc(object):
             raise ValueError('The first argument must be an unmodified cvxpy Variable object.')
         if any(x.attributes[attr] for attr in CONVEX_ATTRIBUTES):
             raise ValueError('The first argument cannot have any declared attributes.')
+        for con in constraints:
+            con_params = con.parameters()
+            if len(con_params) > 0:
+                raise ValueError('Convex sets described with Parameter objects are not allowed.')
         self.x = x
         self.constraints = constraints
         self._A = None

--- a/cvxpy/transforms/suppfunc.py
+++ b/cvxpy/transforms/suppfunc.py
@@ -1,0 +1,131 @@
+from cvxpy.expressions.variable import Variable
+from cvxpy.atoms.suppfunc import SuppFuncAtom
+import numpy as np
+from scipy import sparse
+
+
+def scs_coniclift(x, constraints):
+    """
+    Return (A, b, K) so that
+        {x : x satisfies constraints}
+    can be written as
+        {x : exists y where A @ [x; y] + b in K}.
+
+    Parameters
+    ----------
+    x: cvxpy.Variable
+    constraints: list of cvxpy.constraints.constraint.Constraint
+        Each Constraint object must be DCP-compatible.
+
+    Notes
+    -----
+    This function DOES NOT work when ``x`` has attributes, like ``PSD=True``,
+    ``diag=True``, ``symmetric=True``, etc...
+    """
+    from cvxpy.problems.problem import Problem
+    from cvxpy.problems.objective import Minimize
+    from cvxpy.atoms.affine.sum import sum
+    prob = Problem(Minimize(sum(x)), constraints)
+    # ^ The objective value is only used to make sure that "x"
+    # participates in the problem. So, if constraints is an
+    # empty list, then the support function is the standard
+    # support function for R^n.
+    data, chain, invdata = prob.get_problem_data(solver='SCS')
+    inv = invdata[-2]
+    x_offset = inv.var_offsets[x.id]
+    x_indices = np.arange(x_offset, x_offset + x.size)
+    A = data['A']
+    x_selector = np.zeros(shape=(A.shape[1],), dtype=bool)
+    x_selector[x_indices] = True
+    A_x = A[:, x_selector]
+    A_other = A[:, ~x_selector]
+    A = -sparse.hstack([A_x, A_other])
+    b = data['b']
+    K = data['dims']
+    return A, b, K
+
+
+def scs_cone_selectors(K):
+    """
+    Parse a ConeDims object, as returned from SCS's apply function.
+
+    Return a dictionary which gives row-wise information for the affine
+    operator returned from SCS's apply function.
+
+    Parameters
+    ----------
+    K : cvxpy.reductions.solvers.conic_solver.ConeDims
+
+    Returns
+    -------
+    selectors : dict
+        Keyed by strings, which specify cone types. Values are numpy
+        arrays, or lists of numpy arrays. The numpy arrays give row indices
+        of the affine operator (A, b) returned by SCS's apply function.
+    """
+    idx = K.zero
+    nonpos_idxs = np.arange(idx, idx + K.nonpos)
+    idx += K.nonpos
+    # ^ Called "nonpos", but its actually nonneg.
+    soc_idxs = []
+    for soc in K.soc:
+        idxs = np.arange(idx, idx + soc)
+        soc_idxs.append(idxs)
+        idx += soc
+    psd_idxs = []
+    for psd in K.psd:
+        veclen = psd * (psd + 1) // 2
+        psd_idxs.append(np.arange(idx, idx + veclen))
+        idx += veclen
+    expsize = 3 * K.exp
+    exp_idxs = np.arange(idx, idx + expsize)
+    selectors = {
+        'nonneg': nonpos_idxs,
+        'exp': exp_idxs,
+        'soc': soc_idxs,
+        'psd': psd_idxs
+    }
+    return selectors
+
+
+class SuppFunc(object):
+
+    def __init__(self, x, constraints):
+        """
+        A callable python object, representing the support function of the convex set:
+
+            S = { val : it is possible to satisfy the given constraints, when x.value = val }.
+
+        Parameters
+        ----------
+        x : cvxpy.Variable
+            This variable cannot have any attributes, such as PSD=True, nonneg=True,
+            symmetric=True, etc...
+
+        constraints : list of cvxpy.constraints.constraint.Constraint
+            Usually, these are constraints over ``x``, and some number of auxiliary
+            cvxpy Variables. It is valid to supply ``constraints=[]``.
+        """
+        if len(constraints) == 0:
+            dummy = Variable()
+            constraints.append(dummy == 1)
+        A, b, K = scs_coniclift(x, constraints)
+        K_sels = scs_cone_selectors(K)
+        self._A = A
+        self._b = b
+        self._K_sels = K_sels
+        self._x = x
+        self._constraints = constraints
+        pass
+
+    def __call__(self, y):
+        """
+        Return an atom representing
+
+            max{ cvxpy.vec(y) @ cvxpy.vec(x) : x in S }
+
+        where S is the convex set associated with this SuppFunc object.
+        """
+        sigma_at_y = SuppFuncAtom(y, self._A, self._b, self._K_sels,
+                                  self._x, self._constraints)
+        return sigma_at_y

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -177,6 +177,6 @@ class CoeffExtractor(object):
            q.shape[0] != self.x_length:
             raise RuntimeError("Resulting quadratic form does not have "
                                "appropriate dimensions")
-        if not np.isscalar(constant):
+        if not np.isscalar(constant) and constant.size > 1:
             raise RuntimeError("Constant must be a scalar")
         return P.tocsr(), q, constant


### PR DESCRIPTION
This PR focuses on the content of my accidental merge from earlier today. It also contains fixes to the MOSEK interface.

Users can get a handle on a ``SuppFunc`` object by calling ``sigma = cvxpy.suppfunc(x, constrs)``. From there, ``SuppFuncAtom`` objects are generated by evaluating the ``SuppFunc`` object. So a user could write ``sigma(y) <= 1``, and this generates a ``SuppFuncAtom`` object and a cvxpy inequality constraint in the same line of code.

It may seem odd to have two separate classes for this feature. This is necessary because cvxpy doesn't consider convex sets as first-class objects. After quite a bit of thinking, I think the best way to represent a convex set in cvxpy is with a pair ``(expr, constrs)``, where this pair stands in for ``S = {val : constraints in constrs can be satisfied, when expr.value = val}``.

From an implementation perspective, I also need to map an ``(expr, constrs)`` pair into a conic form ``S = {x : A @ [x, y] + b in K }``. I did this by having the ``SuppFunc`` class execute a call to ``get_problem_data(solver='SCS')``, and then reaching slightly back into the solver reduction chain. Due to the nature of this approach, I can't *cleanly* construct all the convex sets I'd really like to. The current implementation only allows sets ``(x, constrs)`` where ``x`` is a cvxpy Variable with no special attributes (i.e. no declared symmetry, nonnegativity, etc...). This isn't a huge limitation, but it's certainly worth mentioning.

The one thing I don't like about this implementation is how ``SuppFuncAtom`` objects maintain some of their metadata. When one of these objects is constructed, I stash an extra dictionary *inside* the ``__dict__`` field of an existing ``cvxpy.Constant`` object. I do this because the ``suppfunc_canon`` function defined within the ``dcp2cone`` folder doesn't have access to the ``SuppFuncAtom`` object in question; it only has access to the ``args`` field of that ``SuppFuncAtom`` object! I tried storing all necessary data in the ``args`` field of ``SuppFuncAtom`` objects, but it seems that strong assumptions are placed on the elements of ``args`` elsewhere in the compilation process. I don't know how to pass the necessary data through objects that satisfy the (unwritten?) assumptions on ``args``, so for now I have this hacky solution.