### PR TITLE
Allow warm-start in diffcp

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -77,15 +77,15 @@ class DIFFCP(scs_conif.SCS):
         cones = scs_conif.dims_to_solver_dict(data[ConicSolver.DIMS])
         # Default to eps = 1e-4 instead of 1e-3.
         solver_opts['eps'] = solver_opts.get('eps', 1e-4)
-        warm_start_dict = None
+        warm_start_tuple = None
         if warm_start and solver_cache is not None and \
                 self.name() in solver_cache:
-            warm_start_dict = (solver_cache[self.name()]["x"],
-                               solver_cache[self.name()]["y"],
-                               solver_cache[self.name()]["s"])
+            warm_start_tuple = (solver_cache[self.name()]["x"],
+                                solver_cache[self.name()]["y"],
+                                solver_cache[self.name()]["s"])
         results = diffcp.solve_and_derivative_internal(
             A, b, c, cones, verbose=verbose,
-            warm_start=warm_start_dict,
+            warm_start=warm_start_tuple,
             raise_on_error=False,
             **solver_opts)
         if solver_cache is not None:

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -77,12 +77,15 @@ class DIFFCP(scs_conif.SCS):
         cones = scs_conif.dims_to_solver_dict(data[ConicSolver.DIMS])
         # Default to eps = 1e-4 instead of 1e-3.
         solver_opts['eps'] = solver_opts.get('eps', 1e-4)
-        # Ignore True/False warm_start. Warm-start only with values
-        if type(warm_start) == bool:
-            warm_start = None
+        warm_start_dict = None
+        if warm_start and solver_cache is not None and \
+           self.name() in solver_cache:
+               warm_start_dict = (solver_cache[self.name()]["x"],
+                                  solver_cache[self.name()]["y"],
+                                  solver_cache[self.name()]["s"])
         results = diffcp.solve_and_derivative_internal(
             A, b, c, cones, verbose=verbose,
-            warm_start=warm_start,
+            warm_start=warm_start_dict,
             raise_on_error=False,
             **solver_opts)
         if solver_cache is not None:

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -77,8 +77,13 @@ class DIFFCP(scs_conif.SCS):
         cones = scs_conif.dims_to_solver_dict(data[ConicSolver.DIMS])
         # Default to eps = 1e-4 instead of 1e-3.
         solver_opts['eps'] = solver_opts.get('eps', 1e-4)
+        # Ignore True/False warm_start. Warm-start only with values
+        if type(warm_start) == bool:
+            warm_start = None
         results = diffcp.solve_and_derivative_internal(
-            A, b, c, cones, verbose=verbose, raise_on_error=False,
+            A, b, c, cones, verbose=verbose,
+            warm_start=warm_start,
+            raise_on_error=False,
             **solver_opts)
         if solver_cache is not None:
             solver_cache[self.name()] = results

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -79,10 +79,10 @@ class DIFFCP(scs_conif.SCS):
         solver_opts['eps'] = solver_opts.get('eps', 1e-4)
         warm_start_dict = None
         if warm_start and solver_cache is not None and \
-           self.name() in solver_cache:
-               warm_start_dict = (solver_cache[self.name()]["x"],
-                                  solver_cache[self.name()]["y"],
-                                  solver_cache[self.name()]["s"])
+                self.name() in solver_cache:
+            warm_start_dict = (solver_cache[self.name()]["x"],
+                               solver_cache[self.name()]["y"],
+                               solver_cache[self.name()]["s"])
         results = diffcp.solve_and_derivative_internal(
             A, b, c, cones, verbose=verbose,
             warm_start=warm_start_dict,

--- a/cvxpy/tests/test_scs.py
+++ b/cvxpy/tests/test_scs.py
@@ -203,11 +203,8 @@ class TestSCS(BaseTest):
         obj = cp.Minimize(cp.sum(cp.exp(x)))
         prob = cp.Problem(obj, [cp.sum(x) == 1])
         result = prob.solve(solver=cp.DIFFCP, eps=1e-4)
-        time = prob.solver_stats.solve_time
         result2 = prob.solve(solver=cp.DIFFCP, warm_start=True, eps=1e-4)
-        time2 = prob.solver_stats.solve_time
         self.assertAlmostEqual(result2, result, places=2)
-        print(time > time2)
 
     def test_psd_constraint(self):
         """Test PSD constraint.

--- a/cvxpy/tests/test_scs.py
+++ b/cvxpy/tests/test_scs.py
@@ -196,6 +196,19 @@ class TestSCS(BaseTest):
         self.assertAlmostEqual(result2, result, places=2)
         print(time > time2)
 
+    def test_warm_start_diffcp(self):
+        """Test warm starting in diffcp.
+        """
+        x = cp.Variable(10)
+        obj = cp.Minimize(cp.sum(cp.exp(x)))
+        prob = cp.Problem(obj, [cp.sum(x) == 1])
+        result = prob.solve(solver=cp.DIFFCP, eps=1e-4)
+        time = prob.solver_stats.solve_time
+        result2 = prob.solve(solver=cp.DIFFCP, warm_start=True, eps=1e-4)
+        time2 = prob.solver_stats.solve_time
+        self.assertAlmostEqual(result2, result, places=2)
+        print(time > time2)
+
     def test_psd_constraint(self):
         """Test PSD constraint.
         """


### PR DESCRIPTION
This PR allows to warm-start SCS in diffcp. Note that the `warm_start` option in diffcp now conflicts with the standard cvxpy `warm_start` option which is True/False.

Also, it would be good to check the type of the `warm_start` entry in diffcp to avoid errors:
https://github.com/cvxgrp/diffcp/blob/2e0d3f7337e19509bd312272ed59be1f93104ff2/diffcp/cone_program.py#L248-L251