### PR TITLE
improve SDP-atom canonicalization efficiency (#877)

### DIFF
--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -13,14 +13,29 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.affine.reshape import reshape
 import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
+from scipy.sparse import csc_matrix
 
 
 class upper_tri(AffAtom):
-    """The vectorized strictly upper triagonal entries.
+    """The vectorized strictly upper-triagonal entries.
+
+    The vectorization is performed by concatenating (partial) rows.
+    For example, if
+    ```
+    A = np.array([[10, 11, 12, 13],
+                  [14, 15, 16, 17],
+                  [18, 19, 20, 21],
+                  [22, 23, 24, 25]])
+    ```
+    then we have
+    ```
+    upper_tri(A).value == np.array([11, 12, 13, 16, 17, 21])
+    ```
     """
 
     def __init__(self, expr):
@@ -81,3 +96,37 @@ class upper_tri(AffAtom):
             (LinOp for objective, list of constraints)
         """
         return (lu.upper_tri(arg_objs[0]), [])
+
+
+def vec_to_upper_tri(expr, strict=False):
+    expr = Expression.cast_to_const(expr)
+    ell = expr.shape[0]
+    if strict:
+        # n * (n-1)/2 == ell
+        n = ((8 * ell + 1) ** 0.5 + 1) // 2
+    else:
+        # n * (n+1)/2 == ell
+        n = ((8 * ell + 1) ** 0.5 - 1) // 2
+    n = int(n)
+    # form a matrix P, of shape (n**2, ell).
+    #       the i-th block of n rows of P gives the entries of the i-th row
+    #       of the upper-triangular matrix associated with expr.
+    # compute expr2 = P @ expr
+    # compute expr3 = reshape(expr2, shape=(n, n)).T
+    #   expr3 is the matrix formed by reading length-n blocks of expr2,
+    #   and letting each block form a row of expr3.
+    P_rows = []
+    P_row = 0
+    for mat_row in range(n):
+        entries_in_row = n - mat_row
+        if strict:
+            entries_in_row -= 1
+        P_row += n - entries_in_row  # these are zeros
+        P_rows.extend(range(P_row, P_row + entries_in_row))
+        P_row += entries_in_row
+    P_cols = np.arange(ell)
+    P_vals = np.ones(P_cols.size)
+    P = csc_matrix((P_vals, (P_rows, P_cols)), shape=(n**2, ell))
+    expr2 = P @ expr
+    expr3 = reshape(expr2, (n, n)).T
+    return expr3

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/lambda_max_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/lambda_max_canon.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.diag import diag_vec
+from cvxpy.atoms.affine.upper_tri import upper_tri
 from cvxpy.constraints.psd import PSD
 from cvxpy.expressions.variable import Variable
 
@@ -27,5 +28,9 @@ def lambda_max_canon(expr, args):
     prom_t = promote(t, (n,))
     # Constrain I*t - A to be PSD; note that this expression must be symmetric.
     tmp_expr = diag_vec(prom_t) - A
-    constr = [tmp_expr == tmp_expr.T, PSD(tmp_expr)]
+    constr = [PSD(tmp_expr)]
+    if not A.is_symmetric():
+        ut = upper_tri(A)
+        lt = upper_tri(A.T)
+        constr.append(ut == lt)
     return t, constr

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/matrix_frac_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/matrix_frac_canon.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import reshape, trace, bmat
+from cvxpy.atoms import reshape, trace, bmat, upper_tri
 from cvxpy.expressions.variable import Variable
 from cvxpy.constraints.psd import PSD
 
@@ -31,4 +31,8 @@ def matrix_frac_canon(expr, args):
               [X.T, T]])
     # ^ a matrix with Schur complement T - X.T*P^-1*X.
     constraints = [PSD(M)]
+    if not P.is_symmetric():
+        ut = upper_tri(P)
+        lt = upper_tri(P.T)
+        constraints.append(ut == lt)
     return trace(T), constraints

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -573,6 +573,28 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Argument to upper_tri must be a square matrix.")
 
+    def test_vec_to_upper_tri(self):
+        from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
+        x = Variable(shape=(3,))
+        X = vec_to_upper_tri(x)
+        x.value = np.array([1, 2, 3])
+        actual = X.value
+        expect = np.array([[1, 2], [0, 3]])
+        assert np.allclose(actual, expect)
+        y = Variable(shape=(1,))
+        y.value = np.array([4])
+        Y = vec_to_upper_tri(y, strict=True)
+        actual = Y.value
+        expect = np.array([[0, 4], [0, 0]])
+        assert np.allclose(actual, expect)
+        A_expect = np.array([[0, 11, 12, 13],
+                             [0, 0, 16, 17],
+                             [0, 0, 0, 21],
+                             [0, 0, 0, 0]])
+        a = np.array([11, 12, 13, 16, 17, 21])
+        A_actual = vec_to_upper_tri(a, strict=True).value
+        assert np.allclose(A_actual, A_expect)
+
     def test_huber(self):
         # Valid.
         cp.huber(self.x, 1)

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -333,14 +333,14 @@ class TestComplex(BaseTest):
             value = cvx.lambda_max(P).value
             X = Variable(P.shape, complex=True)
             prob = Problem(cvx.Minimize(cvx.lambda_max(X)), [X == P])
-            result = prob.solve(solver=cvx.SCS, eps=1e-5)
+            result = prob.solve(solver=cvx.SCS, eps=1e-6)
             self.assertAlmostEqual(result, value, places=2)
 
             eigs = np.linalg.eigvals(P).real
             value = cvx.sum_largest(eigs, 2).value
             X = Variable(P.shape, complex=True)
             prob = Problem(cvx.Minimize(cvx.lambda_sum_largest(X, 2)), [X == P])
-            result = prob.solve(solver=cvx.SCS, eps=1e-8, verbose=True)
+            result = prob.solve(solver=cvx.SCS, eps=1e-8)
             self.assertAlmostEqual(result, value, places=3)
             self.assertItemsAlmostEqual(X.value, P, places=3)
 


### PR DESCRIPTION
This PR addresses the issues mentioned in #877. Fewer variables and fewer equality constraints are introduced in the compilation process. The bmat atom is used more often.

The only questionable part of this PR is the introduction of a ``vec_to_upper_tri`` function in ``upper_tri.py``. If you want me to make this function an actual *atom*, or to write documentation for it, let me know. Tests for this function have been added to ``test_atoms.py``.

I did not write additional tests for any of the existing atoms (``normNuc``, ``lambda_max``, ``sigma_max``, ``matrix_frac``).  