### PR TITLE
Drop zero arguments in addition

### DIFF
--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -441,12 +441,16 @@ class Expression(u.Canonical):
     def __add__(self, other):
         """Expression : Sum two expressions.
         """
+        if isinstance(other, cvxtypes.constant()) and other.is_zero():
+            return self
         return cvxtypes.add_expr()([self, other])
 
     @_cast_other
     def __radd__(self, other):
         """Expression : Sum two expressions.
         """
+        if isinstance(other, cvxtypes.constant()) and other.is_zero():
+            return self
         return other + self
 
     @_cast_other

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -156,3 +156,7 @@ class TestDgp(BaseTest):
         self.assertTrue(geo_mean.is_log_log_affine())
         self.assertTrue(geo_mean.is_log_log_convex())
         self.assertTrue(geo_mean.is_log_log_concave())
+
+    def test_builtin_sum(self):
+        x = cvxpy.Variable(2, pos=True)
+        self.assertTrue(sum(x).is_log_log_convex())


### PR DESCRIPTION
Modify __add__ such that expr + 0 returns expr (similarly for 0 + expr);
this makes it possible to use Python's builtin sum when constructing LLCPs.

Fixes #883