### PR TITLE
Don't get extract dual from gurobi if it's not available

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -101,7 +101,7 @@ class GUROBI(SCS):
         if status in s.SOLUTION_PRESENT:
             opt_val = solution['value'] + inverse_data[s.OFFSET]
             primal_vars = {inverse_data[GUROBI.VAR_ID]: solution['primal']}
-            if not inverse_data['is_mip']:
+            if "eq_dual" in solution and not inverse_data['is_mip']:
                 eq_dual = utilities.get_dual_values(
                     solution['eq_dual'],
                     utilities.extract_dual_value,


### PR DESCRIPTION
Passing `QCPDual=False` to Problem.solve(solver="GUROBI") instructs gurobi not to calculate the dual values, but cvxpy will still try to extract they from the solution leading to a KeyError. At least with my models, they don't actually seem to be used at all, and just skipping their extraction here appears to work fine. This can save a couple minutes of compute.