### PR TITLE
Updated max transform function in scalarize function

### DIFF
--- a/cvxpy/transforms/scalarize.py
+++ b/cvxpy/transforms/scalarize.py
@@ -95,7 +95,7 @@ def max(objectives, weights):
       A Minimize objective.
     """
     num_objs = len(objectives)
-    expr = atoms.max_elemwise([(objectives[i]*weights[i]).args[0] for i in range(num_objs)])
+    expr = atoms.maximum(*[(objectives[i]*weights[i]).args[0] for i in range(num_objs)])
     return Minimize(expr)
 
 


### PR DESCRIPTION
when i used cp.max i encountered a bug so i tried to fix it by just using atoms.maximum instead of atoms.max_elemwise