### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ nosetests test_dgp.py:TestDgp.test_product
 
 Please make sure that your change doesn't cause any of the unit tests to fail.
 
-`nosetests` supresses stdout by default. To see stdout, pass the `-s` flag
+`nosetests` suppresses stdout by default. To see stdout, pass the `-s` flag
 to `nosetests`.
 
 ## Benchmarks

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -76,7 +76,7 @@ class BinaryOperator(AffAtom):
 
 
 def matmul(lh_exp, rh_exp):
-    """Matrix multipliction."""
+    """Matrix multiplication."""
     return MulExpression(lh_exp, rh_exp)
 
 

--- a/cvxpy/atoms/affine/transpose.py
+++ b/cvxpy/atoms/affine/transpose.py
@@ -84,5 +84,5 @@ class transpose(AffAtom):
             (LinOp for objective, list of constraints)
         """
         # TODO(akshakya): This will need to be updated when we add support
-        # for >2D ararys.
+        # for >2D arrays.
         return (lu.transpose(arg_objs[0]), [])

--- a/cvxpy/cvxcore/python/numpy.i
+++ b/cvxpy/cvxcore/python/numpy.i
@@ -56,7 +56,7 @@
     if (PyInstance_Check(py_obj)) return "instance"    ;
 %#endif
 
-    return "unkown type";
+    return "unknown type";
   }
 
   /* Given a NumPy typecode, return a string describing the type.

--- a/cvxpy/performance_tests/test_robustness.py
+++ b/cvxpy/performance_tests/test_robustness.py
@@ -44,7 +44,7 @@ class TestProblem(unittest.TestCase):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-    # Overriden method to handle lists and lower accuracy.
+    # Overridden method to handle lists and lower accuracy.
     def assertAlmostEqual(self, a, b, interface=intf.DEFAULT_INTF):
         try:
             a = list(a)

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -54,7 +54,7 @@ def are_args_affine(constraints):
 def group_constraints(constraints):
     """Organize the constraints into a dictionary keyed by constraint names.
 
-    Paramters
+    Parameters
     ---------
     constraints : list of constraints
 

--- a/cvxpy/tests/base_test.py
+++ b/cvxpy/tests/base_test.py
@@ -33,7 +33,7 @@ class BaseTest(unittest.TestCase):
         for i in range(len(a)):
             self.assertAlmostEqual(a[i], b[i], places)
 
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertAlmostEqual(self, a, b, places=5):
         super(BaseTest, self).assertAlmostEqual(a, b, places=places)
 

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -29,7 +29,7 @@ class TestExamples(BaseTest):
     # Find the largest Euclidean ball in the polyhedron.
     def test_chebyshev_center(self):
         # The goal is to find the largest Euclidean ball (i.e. its center and
-        # radius) that lies in a polyhedron described by linear inequalites in this
+        # radius) that lies in a polyhedron described by linear inequalities in this
         # fashion: P = {x : a_i'*x <= b_i, i=1,...,m} where x is in R^2
 
         # Generate the input data

--- a/cvxpy/tests/test_param_cone_prog.py
+++ b/cvxpy/tests/test_param_cone_prog.py
@@ -23,11 +23,11 @@ import numpy as np
 
 
 class TestParamConeProg(BaseTest):
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertItemsAlmostEqual(self, a, b, places=2):
         super(TestParamConeProg, self).assertItemsAlmostEqual(a, b, places=places)
 
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertAlmostEqual(self, a, b, places=2):
         super(TestParamConeProg, self).assertAlmostEqual(a, b, places=places)
 

--- a/cvxpy/tests/test_scs.py
+++ b/cvxpy/tests/test_scs.py
@@ -31,11 +31,11 @@ class TestSCS(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertItemsAlmostEqual(self, a, b, places=2):
         super(TestSCS, self).assertItemsAlmostEqual(a, b, places=places)
 
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertAlmostEqual(self, a, b, places=2):
         super(TestSCS, self).assertAlmostEqual(a, b, places=places)
 

--- a/cvxpy/tests/test_super_scs.py
+++ b/cvxpy/tests/test_super_scs.py
@@ -31,11 +31,11 @@ class TestSCS(BaseTest):
         self.B = cvx.Variable((2, 2), name='B')
         self.C = cvx.Variable((3, 2), name='C')
 
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertItemsAlmostEqual(self, a, b, places=2):
         super(TestSCS, self).assertItemsAlmostEqual(a, b, places=places)
 
-    # Overriden method to assume lower accuracy.
+    # Overridden method to assume lower accuracy.
     def assertAlmostEqual(self, a, b, places=2):
         super(TestSCS, self).assertAlmostEqual(a, b, places=places)
 

--- a/cvxpy/utilities/shape.py
+++ b/cvxpy/utilities/shape.py
@@ -73,9 +73,9 @@ def mul_shapes_promote(lh_shape, rh_shape):
     Parameters
     ----------
     lh_shape : tuple
-        The left-hand shape of a multiplciation operation.
+        The left-hand shape of a multiplication operation.
     rh_shape : tuple
-        The right-hand shape of a multiplciation operation.
+        The right-hand shape of a multiplication operation.
 
     Returns
     -------
@@ -120,9 +120,9 @@ def mul_shapes(lh_shape, rh_shape):
     Parameters
     ----------
     lh_shape : tuple
-        The left-hand shape of a multiplciation operation.
+        The left-hand shape of a multiplication operation.
     rh_shape :  tuple
-        The right-hand shape of a multiplciation operation.
+        The right-hand shape of a multiplication operation.
 
     Returns
     -------

--- a/doc/source/examples/applications/ant_array_min_beamwidth.rst
+++ b/doc/source/examples/applications/ant_array_min_beamwidth.rst
@@ -189,7 +189,7 @@ Solve using bisection algorithm
         #
     
         # As of this writing (2014/05/14) cvxpy does not do complex valued math,
-        # so the real and complex values must be stored seperately as reals
+        # so the real and complex values must be stored separately as reals
         # and operated on as follows:
         #     Let any vector or matrix be represented as a+bj, or A+Bj.
         #     Vectors are stored [a; b] and matrices as [A -B; B A]:

--- a/doc/source/examples/applications/censored_data.rst
+++ b/doc/source/examples/applications/censored_data.rst
@@ -150,7 +150,7 @@ how this new regression does.
 We can see that the fit for the uncensored portion is now vastly
 improved. Even the fit for the censored data is now relatively unbiased
 i.e. the fitted values (red points) are now centered around the
-uncensored obsevations (cyan points).
+uncensored observations (cyan points).
 
 The one glaring issue with this arrangement is that we are now
 predicting many observations to be *below* :math:`D` (orange) even

--- a/doc/source/examples/applications/interdiction.rst
+++ b/doc/source/examples/applications/interdiction.rst
@@ -69,7 +69,7 @@ that path. That is,
    P(c, \mathcal{P}) = \log \left( \prod_{j \in \mathcal{P}} p_j \right) = \sum_{j \in \mathcal{P}} \log(p_j) = \sum_{j \in \mathcal{P}} c_j.
 
 Define :math:`P(c, \mathcal{P}) = -\infty` if :math:`\mathcal{P}` is not
-a valid path from source to sink. We do this to implicity encode the
+a valid path from source to sink. We do this to implicitly encode the
 constraint that the smuggler's path must be valid.
 
 Min/max game

--- a/doc/source/examples/applications/robust_kalman.rst
+++ b/doc/source/examples/applications/robust_kalman.rst
@@ -226,7 +226,7 @@ Problem Data
 
 We generate the data for the vehicle tracking problem. We'll have
 :math:`N=1000`, :math:`w_t` a standard Gaussian, and :math:`v_t` a
-standard Guassian, except :math:`20\%` of the points will be outliers
+standard Gaussian, except :math:`20\%` of the points will be outliers
 with :math:`\sigma = 20`.
 
 Below, we set the problem parameters and define the matrices :math:`A`,

--- a/doc/source/examples/dgp/power_control.rst
+++ b/doc/source/examples/dgp/power_control.rst
@@ -11,7 +11,7 @@ example library (Almir Mutapcic).*
 
 This example formulates and solves a power control problem for
 communication systems, in which the goal is to minimize the total
-transmitter power across n trasmitters, each trasmitting positive power
+transmitter power across n transmitters, each trasmitting positive power
 levels :math:`P_1`, :math:`P_2`, :math:`\ldots`, :math:`P_n` to
 :math:`n` receivers, labeled :math:`1, \ldots, n`, with receiver
 :math:`i` receiving signal from transmitter :math:`i`.

--- a/doc/source/examples/machine_learning/lasso_regression.rst
+++ b/doc/source/examples/machine_learning/lasso_regression.rst
@@ -4,7 +4,7 @@ Machine Learning: Lasso Regression
 
 Lasso regression is, like ridge regression, a **shrinkage** method. It
 differs from ridge regression in its choice of penalty: lasso imposes an
-:math:`\ell_1` **penalty** on the paramters :math:`\beta`. That is,
+:math:`\ell_1` **penalty** on the parameters :math:`\beta`. That is,
 lasso finds an assignment to :math:`\beta` that minimizes the function
 
 .. math:: f(\beta) = \|X\beta - Y\|_2^2 + \lambda \|\beta\|_1,

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -33,7 +33,7 @@ More generally, ``expr[i:j:k]`` selects every kth
 element of ``expr``, starting at ``i`` and ending at ``j-1``.
 If ``expr`` is a matrix, then ``expr[i:j:k]`` selects rows,
 while ``expr[i:j:k, r:s:t]`` selects both rows and columns.
-Indexing drops dimensions while slicing preserves dimenions.
+Indexing drops dimensions while slicing preserves dimensions.
 For example,
 
 .. code:: python

--- a/examples/chebyshev.py
+++ b/examples/chebyshev.py
@@ -35,7 +35,7 @@ from cvxpy import *
 # (a figure is generated)
 #
 # The goal is to find the largest Euclidean ball (i.e. its center and
-# radius) that lies in a polyhedron described by linear inequalites in this
+# radius) that lies in a polyhedron described by linear inequalities in this
 # fashion: P = { x : a_i'*x <= b_i, i=1,...,m } where x is in R^2
 
 # Create the problem

--- a/examples/communications/maximise_minimum_SINR_BV4.20.py
+++ b/examples/communications/maximise_minimum_SINR_BV4.20.py
@@ -151,7 +151,7 @@ if __name__=='__main__':
   print(maxmin_sinr.__doc__)
   # print all arrays to have 3 significant figures after the decimal place
   np.set_printoptions(precision=3)
-  # in this case we will use a gain matrix with a signal weight of 0.6 and an inteference weight of 0.1
+  # in this case we will use a gain matrix with a signal weight of 0.6 and an interference weight of 0.1
   G = np.array([[0.6,0.1,0.1,0.1,0.1],
                 [0.1,0.6,0.1,0.1,0.1],
                 [0.1,0.1,0.6,0.1,0.1],

--- a/examples/communications/optimal_power_Gaussian_channel_BV4.62.py
+++ b/examples/communications/optimal_power_Gaussian_channel_BV4.62.py
@@ -25,7 +25,7 @@ import cvxpy as cvx
 Input parameters   
   n: number of receivers
   a_val: Positive bit rate coefficient for each receiver
-  b_val: Positive signal to noise ratio cofficient for each receiver
+  b_val: Positive signal to noise ratio coefficient for each receiver
   P_tot: Total power available to all channels
   W_tot: Total bandwidth available to all channels
 '''

--- a/examples/extensions/mixed_integer/tests/test_vars.py
+++ b/examples/extensions/mixed_integer/tests/test_vars.py
@@ -25,7 +25,7 @@ class TestVars(unittest.TestCase):
     def setUp(self):
         pass
 
-    # Overriden method to handle lists and lower accuracy.
+    # Overridden method to handle lists and lower accuracy.
     def assertAlmostEqual(self, a, b):
         try:
             a = list(a)

--- a/examples/notebooks/WWW/ant_array_min_beamwidth.ipynb
+++ b/examples/notebooks/WWW/ant_array_min_beamwidth.ipynb
@@ -220,7 +220,7 @@
     "    #\n",
     "\n",
     "    # As of this writing (2014/05/14) cvxpy does not do complex valued math,\n",
-    "    # so the real and complex values must be stored seperately as reals\n",
+    "    # so the real and complex values must be stored separately as reals\n",
     "    # and operated on as follows:\n",
     "    #     Let any vector or matrix be represented as a+bj, or A+Bj.\n",
     "    #     Vectors are stored [a; b] and matrices as [A -B; B A]:\n",

--- a/examples/notebooks/WWW/interdiction.ipynb
+++ b/examples/notebooks/WWW/interdiction.ipynb
@@ -51,7 +51,7 @@
     "P(c, \\mathcal{P}) = \\log \\left( \\prod_{j \\in \\mathcal{P}} p_j \\right) = \\sum_{j \\in \\mathcal{P}} \\log(p_j) = \\sum_{j \\in \\mathcal{P}} c_j.\n",
     "$$\n",
     "\n",
-    "Define $P(c, \\mathcal{P}) = -\\infty$ if $\\mathcal{P}$ is not a valid path from source to sink. We do this to implicity encode the constraint that the smuggler's path must be valid.\n",
+    "Define $P(c, \\mathcal{P}) = -\\infty$ if $\\mathcal{P}$ is not a valid path from source to sink. We do this to implicitly encode the constraint that the smuggler's path must be valid.\n",
     "\n",
     "# Min/max game\n",
     "\n",

--- a/examples/notebooks/dgp/dgp_fundamentals.ipynb
+++ b/examples/notebooks/dgp/dgp_fundamentals.ipynb
@@ -187,7 +187,7 @@
    "source": [
     "# 2. Log-log curvature ruleset\n",
     "\n",
-    "CVXPY has a library of atomic functions with known log-log curvature and monotonicty. It uses this information to\n",
+    "CVXPY has a library of atomic functions with known log-log curvature and monotonicity. It uses this information to\n",
     "tag every `Expression`, i.e., every composition of atomic functions, with a log-log curvature. In particular, \n",
     "\n",
     "A function $f(expr_1,expr_2,...,expr_n)$ is log-log convex if  $f$ is a log-log convex function and for each expri one of the following conditions holds:\n",


### PR DESCRIPTION
Should be non-semantic. I will highlight upfront that this touches the Eigen subdirectory; let me know if this should be reverted.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.

`flake8 cvxpy` shows no errors/warnings.