### PR TITLE
DQCP: Fix detection of monotone real functions

### DIFF
--- a/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
+++ b/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from cvxpy import problems
+from cvxpy.atoms.max import max as max_atom
+from cvxpy.atoms.min import min as min_atom
 from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.atoms.elementwise.minimum import minimum
 from cvxpy.constraints import Inequality
@@ -167,7 +169,7 @@ class Dqcp2Dcp(Canonicalization):
                 if lhs.is_incr(idx):
                     return self._canonicalize_constraint(expr <= rhs)
                 return self._canonicalize_constraint(expr >= rhs)
-            elif isinstance(lhs, maximum):
+            elif isinstance(lhs, (maximum, max_atom)):
                 # Lower maximum.
                 return [c for arg in lhs.args
                         for c in self._canonicalize_constraint(arg <= rhs)]
@@ -188,7 +190,7 @@ class Dqcp2Dcp(Canonicalization):
             if rhs.is_incr(idx):
                 return self._canonicalize_constraint(lhs <= expr)
             return self._canonicalize_constraint(lhs >= expr)
-        elif isinstance(rhs, minimum):
+        elif isinstance(rhs, (minimum, min_atom)):
             # Lower minimum.
             return [c for arg in rhs.args
                     for c in self._canonicalize_constraint(lhs <= arg)]

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -568,3 +568,28 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(SOLVER, qcp=True)
         np.testing.assert_almost_equal(x.value, 2)
         np.testing.assert_almost_equal(problem.objective.value, 7)
+
+    def test_max(self):
+        x = cp.Variable(2, pos=True)
+        obj = cp.max((1 - 2*cp.sqrt(x) + x) / x)
+        problem = cp.Problem(cp.Minimize(obj), [x[0] <= 0.5, x[1] <= 0.9])
+        self.assertTrue(problem.is_dqcp())
+        problem.solve(SOLVER, qcp=True)
+        self.assertAlmostEqual(problem.objective.value, 0.1715, places=3)
+
+    def test_min(self):
+        x = cp.Variable(2)
+        expr = cp.min(cp.ceil(x))
+        problem = cp.Problem(cp.Maximize(expr),
+                             [x[0] >= 11.9, x[0] <= 15.8, x[1] >= 17.4])
+        self.assertTrue(problem.is_dqcp())
+        problem.solve(SOLVER, qcp=True)
+        self.assertAlmostEqual(problem.objective.value, 16.0)
+        self.assertLess(x[0].value, 16.0)
+        self.assertGreater(x[0].value, 14.9)
+        self.assertGreater(x[1].value, 17.3)
+
+    def test_sum_of_qccv_not_dqcp(self):
+        t = cp.Variable(5, pos=True)
+        expr = cp.sum(cp.square(t) / t)
+        self.assertFalse(expr.is_dqcp())


### PR DESCRIPTION
Fixes a bug in DQCP analysis in analyzing monotone real functions; DQCP
analysis previously did not check whether the argument of a scalar function
was also scalar. This bug caused DQCP analysis to be too permissive, incorrectly
labeling things as DQCP and causing the reduction to fail in surprising ways.

As an extension, this change adds the vector atoms cp.max and cp.min to the
DQCP atom library, letting users take the max or min of quasiconvex or
quasiconcave expressions. Previously, only the elementwise cp.maximum and
cp.minimum atoms were allowed.

Fixes #904