### PR TITLE
Deprecate ``*`` for matrix multiplication; drop Python 2.7 and 3.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ b = numpy.random.randn(m)
 
 # Construct the problem.
 x = cp.Variable(n)
-objective = cp.Minimize(cp.sum_squares(A*x - b))
+objective = cp.Minimize(cp.sum_squares(A @ x - b))
 constraints = [0 <= x, x <= 1]
 prob = cp.Problem(objective, constraints)
 
@@ -63,7 +63,7 @@ pip install cvxpy
 
 CVXPY has the following dependencies:
 
-- Python 2.7, 3.4, 3.5, 3.6, or 3.7.
+- Python 3.5, 3.6, or 3.7.
 - multiprocess
 - OSQP
 - ECOS >= 2
@@ -74,7 +74,7 @@ CVXPY has the following dependencies:
 For detailed instructions, see the [installation
 guide](https://www.cvxpy.org/install/index.html).
 
-**Python 2.7 end of life**: The CVXPY development team plans to stop supporting Python 2 later this year, starting with the release of CVXPY 1.1.
+**Python 2.7 end of life**: The CVXPY development team will stop supporting python 2.7 and python 3.4, starting when CVXPY version 1.1 is released.
 
 ## Getting started
 To get started with CVXPY, check out the following:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,23 +12,23 @@ build:
 requirements:
   build:
     - setuptools
-    - python
+    - python >= 3.5
     - osqp
     - ecos >=2
     - scs >=1.1.3
     - numpy >=1.14
-    - scipy >=0.15
+    - scipy >=1.1
     - libgcc # [not win]
     - lapack
     - mkl
 
   run:
-    - python
+    - python >= 3.5
     - osqp
     - ecos >=2
     - scs >=1.1.3
     - numpy >=1.9
-    - scipy >=0.15
+    - scipy >=1.1
     - libgcc # [not win]
     - lapack
     - mkl

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -99,7 +99,7 @@ class MulExpression(BinaryOperator):
         The right-hand side of the multiplication.
     """
 
-    OP_NAME = "*"
+    OP_NAME = "@"
     OP_FUNC = op.mul
 
     def numeric(self, values):

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -164,7 +164,7 @@ class special_index(AffAtom):
           self._select_mat, self._select_mat.size, order='F')
         identity = sp.eye(self.args[0].size).tocsc()
         lowered = reshape(
-          identity[select_vec]*vec(self.args[0]), self._shape)
+          identity[select_vec] @ vec(self.args[0]), self._shape)
         return lowered.grad
 
     def graph_implementation(self, arg_objs, shape, data=None):

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -216,7 +216,7 @@ def quad_form(x, P):
     if not P.ndim == 2 or P.shape[0] != P.shape[1] or max(x.shape, (1,))[0] != P.shape[0]:
         raise Exception("Invalid dimensions for arguments.")
     if x.is_constant():
-        return x.H * P * x
+        return x.H @ P @ x
     elif P.is_constant():
         return QuadForm(x, P)
     else:

--- a/cvxpy/expressions/cvxtypes.py
+++ b/cvxpy/expressions/cvxtypes.py
@@ -67,12 +67,12 @@ def minimize():
     return objective.Minimize
 
 
-def mul_expr():
+def matmul_expr():
     from cvxpy.atoms.affine import binary_operators
     return binary_operators.MulExpression
 
 
-def multiply_expr():
+def elmul_expr():
     from cvxpy.atoms.affine import binary_operators
     return binary_operators.multiply
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -48,11 +48,11 @@ def _cast_other(binary_op):
 
 
 __STAR_MATMUL_WARNING__ = """
-\nThis use of ``*`` has resulted in matrix multiplication.
-\nUsing ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
-\n\tUse ``*`` for matrix-scalar and vector-scalar multiplication.
-\n\tUse ``@`` for matrix-matrix and matrix-vector multiplication.
-\n\tUse ``multiply`` for elementwise multiplication.
+This use of ``*`` has resulted in matrix multiplication.
+Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
+    Use ``*`` for matrix-scalar and vector-scalar multiplication.
+    Use ``@`` for matrix-matrix and matrix-vector multiplication.
+    Use ``multiply`` for elementwise multiplication.
 """
 
 

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -114,7 +114,7 @@ class CvxAttr2Constr(Reduction):
                     upper_tri.set_variable_of_provenance(var)
                     id2new_var[var.id] = upper_tri
                     fill_coeff = Constant(upper_tri_to_full(n))
-                    full_mat = fill_coeff*upper_tri
+                    full_mat = fill_coeff @ upper_tri
                     obj = reshape(full_mat, (n, n))
                 elif var.attributes['diag']:
                     diag_var = Variable(var.shape[0], var_id=var.id, **new_attr)

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_sum_exp_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_sum_exp_canon.py
@@ -35,10 +35,10 @@ def log_sum_exp_canon(expr, args):
     if axis is None:  # shape = (1, 1)
         promoted_t = promote(t, x.shape)
     elif axis == 0:  # shape = (1, n)
-        promoted_t = Constant(np.ones((x.shape[0], 1))) * reshape(
+        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(
                                                         t, (1,) + x.shape[1:])
     else:  # shape = (m, 1)
-        promoted_t = reshape(t, x.shape[:-1] + (1,)) * Constant(
+        promoted_t = reshape(t, x.shape[:-1] + (1,)) @ Constant(
                                                       np.ones((1, x.shape[1])))
 
     exp_expr = exp(x - promoted_t)

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/mul_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/mul_canon.py
@@ -33,7 +33,7 @@ def mul_canon(expr, args):
 
     if lhs_affine:
         t = Variable(rhs.shape)
-        return lhs * t, [t == rhs]
+        return lhs @ t, [t == rhs]
     else:
         t = Variable(lhs.shape)
-        return t * rhs, [t == lhs]
+        return t @ rhs, [t == lhs]

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/quad_form_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/quad_form_canon.py
@@ -24,9 +24,9 @@ def quad_form_canon(expr, args):
     # TODO this doesn't work with parameters!
     scale, M1, M2 = decomp_quad(args[1].value)
     if M1.size > 0:
-        expr = sum_squares(Constant(M1.T) * args[0])
+        expr = sum_squares(Constant(M1.T) @ args[0])
     if M2.size > 0:
         scale = -scale
-        expr = sum_squares(Constant(M2.T) * args[0])
+        expr = sum_squares(Constant(M2.T) @ args[0])
     obj, constr = quad_over_lin_canon(expr, expr.args)
     return scale * obj, constr

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/max_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/max_canon.py
@@ -29,10 +29,10 @@ def max_canon(expr, args):
     if axis is None:  # shape = (1, 1)
         promoted_t = promote(t, x.shape)
     elif axis == 0:  # shape = (1, n)
-        promoted_t = Constant(np.ones((x.shape[0], 1))) * reshape(
+        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(
                                                             t, (1, x.shape[1]))
     else:  # shape = (m, 1)
-        promoted_t = reshape(t, (x.shape[0], 1)) * Constant(
+        promoted_t = reshape(t, (x.shape[0], 1)) @ Constant(
                                                       np.ones((1, x.shape[1])))
 
     constraints = [x <= promoted_t]

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/norm_inf_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/norm_inf_canon.py
@@ -29,10 +29,10 @@ def norm_inf_canon(expr, args):
     if axis is None:  # shape = (1, 1)
         promoted_t = promote(t, x.shape)
     elif axis == 0:  # shape = (1, n)
-        promoted_t = Constant(np.ones((x.shape[0], 1))) * reshape(
+        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(
                                                             t, (1, x.shape[1]))
     else:  # shape = (m, 1)
-        promoted_t = reshape(t, (x.shape[0], 1)) * Constant(
+        promoted_t = reshape(t, (x.shape[0], 1)) @ Constant(
                                                       np.ones((1, x.shape[1])))
 
     return t, [x <= promoted_t, x + promoted_t >= 0]

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -60,7 +60,7 @@ class QpMatrixStuffing(MatrixStuffing):
         # concatenate all variables in one vector
         boolean, integer = extract_mip_idx(problem.variables())
         x = Variable(extractor.x_length, boolean=boolean, integer=integer)
-        new_obj = QuadForm(x, P) + q.T*x
+        new_obj = QuadForm(x, P) + q.T @ x
 
         return new_obj, x, r
 
@@ -96,7 +96,7 @@ class QpMatrixStuffing(MatrixStuffing):
             for arg in con.args:
                 A = Afull[offset:offset+arg.size, :]
                 b = bfull[offset:offset+arg.size]
-                arg_list.append(reshape(A*new_var + b, arg.shape))
+                arg_list.append(reshape(A @ new_var + b, arg.shape))
                 offset += arg.size
             new_constraint = con.copy(arg_list)
             new_cons.append(new_constraint)

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -42,7 +42,7 @@ def special_index_canon(expr, args):
     # Select the chosen entries from expr.
     arg = args[0]
     identity = sp.eye(arg.size).tocsc()
-    lowered = reshape(identity[select_vec]*vec(arg), final_shape)
+    lowered = reshape(identity[select_vec] @ vec(arg), final_shape)
     return lowered, []
 
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -411,7 +411,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.sum(Variable((2, 1)), keepdims=True).shape, (1, 1))
         # Mixed curvature.
         mat = np.array([[1, -1]])
-        self.assertEqual(cp.sum(mat*cp.square(Variable(2))).curvature, s.UNKNOWN)
+        self.assertEqual(cp.sum(mat @ cp.square(Variable(2))).curvature, s.UNKNOWN)
 
         # Test with axis argument.
         self.assertEqual(cp.sum(Variable(2), axis=0).shape, tuple())

--- a/cvxpy/tests/test_benchmarks.py
+++ b/cvxpy/tests/test_benchmarks.py
@@ -57,7 +57,7 @@ class TestBenchmarks(BaseTest):
                         known[i, j, k] = 1
 
         def tv_inpainting():
-            Ucorr = known*Uorig
+            Ucorr = known * Uorig  # This is elementwise mult on numpy arrays.
             variables = []
             constraints = []
             for i in range(colors):
@@ -78,7 +78,7 @@ class TestBenchmarks(BaseTest):
 
         def least_squares():
             x = cp.Variable(n)
-            cost = cp.sum_squares(A*x - b)
+            cost = cp.sum_squares(A @ x - b)
             cp.Problem(cp.Minimize(cost)).get_problem_data(cp.OSQP)
         benchmark(least_squares, iters=1)
 
@@ -109,7 +109,7 @@ class TestBenchmarks(BaseTest):
         b = np.random.randn(m)
 
         x = cp.Variable(n)
-        cost = cp.sum(A*x)
+        cost = cp.sum(A @ x)
 
         constraints = [C[i] * x[i] <= b[i] for i in range(m // 2)]
         constraints.extend([C[i] * x[m // 2 + i] == b[m // 2 + i] for i in range(m // 2)])
@@ -133,7 +133,7 @@ class TestBenchmarks(BaseTest):
         b.value = np.random.randn(m)
 
         x = cp.Variable(n)
-        cost = cp.sum(A*x)
+        cost = cp.sum(A @ x)
 
         constraints = [C[i] * x[i] <= b[i] for i in range(m // 2)]
         constraints.extend([C[i] * x[m // 2 + i] == b[m // 2 + i] for i in range(m // 2)])
@@ -153,7 +153,7 @@ class TestBenchmarks(BaseTest):
         b = np.random.randn(m)
 
         x = cp.Variable(n)
-        cost = cp.sum(A*x)
+        cost = cp.sum(A @ x)
 
         constraints = [C[i] * x[i] <= b[i] for i in range(m // 2)]
         constraints.extend([C[i] * x[m // 2 + i] == b[m // 2 + i] for i in range(m // 2)])
@@ -176,7 +176,7 @@ class TestBenchmarks(BaseTest):
         b.value = np.random.randn(m)
 
         x = cp.Variable(n)
-        cost = cp.sum(A*x)
+        cost = cp.sum(A @ x)
 
         constraints = [C[i] * x[i] <= b[i] for i in range(m // 2)]
         constraints.extend([C[i] * x[m // 2 + i] == b[m // 2 + i] for i in range(m // 2)])

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -137,7 +137,7 @@ class TestComplex(BaseTest):
         assert not expr.is_imag()
 
         A = np.ones((2, 2))
-        expr = A*y*A
+        expr = (A*A)*y
         assert expr.is_complex()
         assert expr.is_imag()
 
@@ -475,7 +475,7 @@ class TestComplex(BaseTest):
         rho = cvx.Variable((2, 2), complex=True)
         Id = np.identity(2)
         obj = cvx.Maximize(0)
-        cons = [A*rho == Id]
+        cons = [A @ rho == Id]
         prob = cvx.Problem(obj, cons)
         prob.solve()
         rho_sparse = rho.value
@@ -485,7 +485,7 @@ class TestComplex(BaseTest):
         rho = cvx.Variable((2, 2), complex=True)
         Id = np.identity(2)
         obj = cvx.Maximize(0)
-        cons = [A.toarray()*rho == Id]
+        cons = [A.toarray() @ rho == Id]
         prob = cvx.Problem(obj, cons)
         prob.solve()
         self.assertItemsAlmostEqual(rho.value, rho_sparse)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -403,7 +403,7 @@ class TestMosek(unittest.TestCase):
             # Solve a simple basis pursuit problem for testing purposes.
             z = cp.Variable(n)
             objective = cp.Minimize(cp.norm1(z))
-            constraints = [A * z == y]
+            constraints = [A @ z == y]
             problem = cp.Problem(objective, constraints)
 
             invalid_mosek_params = {
@@ -686,7 +686,7 @@ class TestCPLEX(BaseTest):
             objective = cp.Maximize(c[0] * self.x[0] + c[1] * self.x[1])
             constraints = [self.x[0] <= h[0],
                            self.x[1] <= h[1],
-                           A * self.x == b]
+                           A @ self.x == b]
             prob = cp.Problem(objective, constraints)
             result = prob.solve(solver=cp.CPLEX, warm_start=True)
             self.assertEqual(result, 3)
@@ -744,7 +744,7 @@ class TestCPLEX(BaseTest):
             # Solve a simple basis pursuit problem for testing purposes.
             z = cp.Variable(n)
             objective = cp.Minimize(cp.norm1(z))
-            constraints = [A * z == y]
+            constraints = [A @ z == y]
             problem = cp.Problem(objective, constraints)
 
             invalid_cplex_params = {
@@ -842,7 +842,7 @@ class TestGUROBI(BaseTest):
             objective = cp.Maximize(c[0] * self.x[0] + c[1] * self.x[1])
             constraints = [self.x[0] <= h[0],
                            self.x[1] <= h[1],
-                           A * self.x == b]
+                           A @ self.x == b]
             prob = cp.Problem(objective, constraints)
             result = prob.solve(solver=cp.GUROBI, warm_start=True)
             self.assertEqual(result, 3)

--- a/cvxpy/tests/test_convolution.py
+++ b/cvxpy/tests/test_convolution.py
@@ -68,19 +68,19 @@ class TestConvolution(BaseTest):
                                               var_offsets, var_sizes,
                                               x_length)
         vec = np.array(range(1, x_length+1))
-        # A*vec
+        # A @ vec
         result = np.zeros(A.shape[0])
         Amul(vec, result)
-        self.assertItemsAlmostEqual(A*vec, result)
+        self.assertItemsAlmostEqual(A @ vec, result)
         Amul(vec, result)
-        self.assertItemsAlmostEqual(2*A*vec, result)
-        # A.T*vec
+        self.assertItemsAlmostEqual(2*A @ vec, result)
+        # A.T @ vec
         vec = np.array(range(A.shape[0]))
         result = np.zeros(A.shape[1])
         ATmul(vec, result)
-        self.assertItemsAlmostEqual(A.T*vec, result)
+        self.assertItemsAlmostEqual(A.T @ vec, result)
         ATmul(vec, result)
-        self.assertItemsAlmostEqual(2*A.T*vec, result)
+        self.assertItemsAlmostEqual(2*A.T @ vec, result)
 
     def mat_from_func(self, func, rows, cols):
         """Convert a multiplier function to a matrix.

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -213,7 +213,7 @@ class TestBackward(BaseTest):
         k = 2
         x = cp.Parameter(4)
         y = cp.Variable(4)
-        obj = -x * y - cp.sum(cp.entr(y)) - cp.sum(cp.entr(1. - y))
+        obj = -x @ y - cp.sum(cp.entr(y)) - cp.sum(cp.entr(1. - y))
         cons = [cp.sum(y) == k]
         problem = cp.Problem(cp.Minimize(obj), cons)
 

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -198,8 +198,8 @@ class TestBackward(BaseTest):
         F = cp.Parameter((p, n))
         g = cp.Parameter(p)
         obj = cp.Maximize(cp.sum(cp.entr(x)) - cp.sum_squares(x))
-        constraints = [A * x == b,
-                       F * x <= g]
+        constraints = [A @ x == b,
+                       F @ x <= g]
         problem = cp.Problem(obj, constraints)
         A.value = A_np
         b.value = b_np

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -44,10 +44,10 @@ class TestExamples(BaseTest):
         x_c = cvx.Variable(2, name='x_c')
         obj = cvx.Maximize(r)
         constraints = [  # TODO have atoms compute values for constants.
-            a1.T*x_c + np.linalg.norm(a1)*r <= b[0],
-            a2.T*x_c + np.linalg.norm(a2)*r <= b[1],
-            a3.T*x_c + np.linalg.norm(a3)*r <= b[2],
-            a4.T*x_c + np.linalg.norm(a4)*r <= b[3],
+            a1.T @ x_c + np.linalg.norm(a1)*r <= b[0],
+            a2.T @ x_c + np.linalg.norm(a2)*r <= b[1],
+            a3.T @ x_c + np.linalg.norm(a3)*r <= b[2],
+            a4.T @ x_c + np.linalg.norm(a4)*r <= b[3],
         ]
 
         p = cvx.Problem(obj, constraints)
@@ -87,10 +87,10 @@ class TestExamples(BaseTest):
         slack = cvx.Variable()
         # Form the problem
         x = cvx.Variable(n)
-        objective = cvx.Minimize(0.5*cvx.quad_form(x, P0) + q0.T*x + r0 + slack)
-        constraints = [0.5*cvx.quad_form(x, P1) + q1.T*x + r1 <= slack,
-                       0.5*cvx.quad_form(x, P2) + q2.T*x + r2 <= slack,
-                       0.5*cvx.quad_form(x, P3) + q3.T*x + r3 <= slack,
+        objective = cvx.Minimize(0.5*cvx.quad_form(x, P0) + q0.T @ x + r0 + slack)
+        constraints = [0.5*cvx.quad_form(x, P1) + q1.T @ x + r1 <= slack,
+                       0.5*cvx.quad_form(x, P2) + q2.T @ x + r2 <= slack,
+                       0.5*cvx.quad_form(x, P3) + q3.T @ x + r3 <= slack,
                        ]
 
         # We now find the primal result and compare it to the dual result
@@ -126,7 +126,7 @@ class TestExamples(BaseTest):
 
         # Construct the problem.
         x = cvx.Variable(n)
-        objective = cvx.Minimize(cvx.sum_squares(A*x - b))
+        objective = cvx.Minimize(cvx.sum_squares(A @ x - b))
         constraints = [0 <= x, x <= 1]
         p = cvx.Problem(objective, constraints)
 
@@ -190,7 +190,7 @@ class TestExamples(BaseTest):
 
         # Construct the problem.
         x = cvx.Variable(m)
-        objective = cvx.Minimize(cvx.sum_squares(A*x - b) + gamma*cvx.norm(x, 1))
+        objective = cvx.Minimize(cvx.sum_squares(A @ x - b) + gamma*cvx.norm(x, 1))
         p = cvx.Problem(objective)
 
         # Assign a value to gamma and find the optimal x.
@@ -221,7 +221,7 @@ class TestExamples(BaseTest):
         # cvx.Variables:
         # x is a vector of stock holdings as fractions of total assets.
 
-        expected_return = mu*x
+        expected_return = mu @ x
         risk = cvx.quad_form(x, sigma)
 
         objective = cvx.Maximize(expected_return - gamma*risk)
@@ -252,7 +252,7 @@ class TestExamples(BaseTest):
         a = cvx.Variable(n)  # mi.SparseVar(n, nonzeros=6)
         b = cvx.Variable()
 
-        slack = [cvx.pos(1 - label*(sample.T*a - b)) for (label, sample) in data]
+        slack = [cvx.pos(1 - label*(sample.T @ a - b)) for (label, sample) in data]
         objective = cvx.Minimize(cvx.norm(a, 2) + gamma*sum(slack))
         p = cvx.Problem(objective)
         # Extensions can attach new solve methods to the CVXPY cvx.Problem class.
@@ -262,7 +262,7 @@ class TestExamples(BaseTest):
         # Count misclassifications.
         errors = 0
         for label, sample in data:
-            if label*(sample.T*a - b).value < 0:
+            if label*(sample.T @ a - b).value < 0:
                 errors += 1
 
         print("%s misclassifications" % errors)
@@ -340,7 +340,7 @@ class TestExamples(BaseTest):
         obj = cvx.Maximize(cvx.log_det(A))
         constraints = []
         for i in range(m):
-            constraints.append(cvx.norm(A*x[:, i] + b) <= 1)
+            constraints.append(cvx.norm(A @ x[:, i] + b) <= 1)
         p = cvx.Problem(obj, constraints)
         result = p.solve()
         self.assertAlmostEqual(result, 1.9746, places=2)
@@ -362,11 +362,11 @@ class TestExamples(BaseTest):
         Z = Z.dot(Z.T)
 
         x = cvx.Variable(n)
-        y = x.__rmul__(F)
+        y = F @ x
         # DCP attr causes error because not all the curvature
         # matrices are reduced to constants when an atom
         # is scalar.
-        cvx.square(cvx.norm(D*x)) + cvx.square(Z*y)
+        cvx.square(cvx.norm(D @ x)) + cvx.square(Z @ y)
 
     def test_intro(self):
         """Test examples from cvxpy.org introduction.
@@ -382,7 +382,7 @@ class TestExamples(BaseTest):
 
         # Construct the problem.
         x = cvx.Variable(n)
-        objective = cvx.Minimize(cvx.sum_squares(A*x - b))
+        objective = cvx.Minimize(cvx.sum_squares(A @ x - b))
         constraints = [0 <= x, x <= 1]
         prob = cvx.Problem(objective, constraints)
 
@@ -500,7 +500,7 @@ class TestExamples(BaseTest):
 
         # Construct the problem.
         x = cvx.Variable(n)
-        objective = cvx.Minimize(cvx.sum_squares(A*x - b))
+        objective = cvx.Minimize(cvx.sum_squares(A @ x - b))
         constraints = [0 <= x, x <= 1]
         prob = cvx.Problem(objective, constraints)
 
@@ -546,7 +546,7 @@ class TestExamples(BaseTest):
 
         # Construct the problem.
         x = cvx.Variable(m)
-        error = cvx.sum_squares(A*x - b)
+        error = cvx.sum_squares(A @ x - b)
         obj = cvx.Minimize(error + gamma*cvx.norm(x, 1))
         prob = cvx.Problem(obj)
 
@@ -573,7 +573,7 @@ class TestExamples(BaseTest):
         # Use expr.size to get the dimensions.
         print("dimensions of X:", X.size)
         print("dimensions of sum(X):", cvx.sum(X).size)
-        print("dimensions of A*X:", (A*X).size)
+        print("dimensions of A @ X:", (A @ X).size)
 
         # ValueError raised for invalid dimensions.
         try:
@@ -645,47 +645,11 @@ class TestExamples(BaseTest):
         X = np.ones((m, n))
         w = cvx.Variable(n)
 
-        expr2 = [cvx.log_sum_exp(cvx.hstack([0, X[i, :]*w])) for i in range(m)]
+        expr2 = [cvx.log_sum_exp(cvx.hstack([0, X[i, :] @ w])) for i in range(m)]
         expr3 = sum(expr2)
         obj = cvx.Minimize(expr3)
         p = cvx.Problem(obj)
         p.solve(solver=cvx.SCS, max_iters=1)
-
-    # # Risk return tradeoff curve
-    # def test_risk_return_tradeoff(self):
-    #     from math import sqrt
-    #     from cvxopt import matrix
-    #     from cvxopt.blas import dot
-    #     from cvxopt.solvers import qp, options
-    #     import scipy
-
-    #     n = 4
-    #     S = matrix( [[ 4e-2,  6e-3, -4e-3,   0.0 ],
-    #                  [ 6e-3,  1e-2,  0.0,    0.0 ],
-    #                  [-4e-3,  0.0,   2.5e-3, 0.0 ],
-    #                  [ 0.0,   0.0,   0.0,    0.0 ]] )
-    #     pbar = matrix([.12, .10, .07, .03])
-
-    #     N = 100
-    #     # CVXPY
-    #     Sroot = numpy.asmatrix(scipy.linalg.sqrtm(S))
-    #     x = cvx.Variable(n, name='x')
-    #     mu = cvx.Parameter(name='mu')
-    #     mu.value = 1 # TODO cvx.Parameter("positive")
-    #     objective = cvx.Minimize(-pbar*x + mu*quad_over_lin(Sroot*x,1))
-    #     constraints = [sum(x) == 1, x >= 0]
-    #     p = cvx.Problem(objective, constraints)
-
-    #     mus = [ 10**(5.0*t/N-1.0) for t in range(N) ]
-    #     xs = []
-    #     for mu_val in mus:
-    #         mu.value = mu_val
-    #         p.solve()
-    #         xs.append(x.value)
-    #     returns = [ dot(pbar,x) for x in xs ]
-    #     risks = [ sqrt(dot(x, S*x)) for x in xs ]
-
-    #     # QP solver
 
 
 if __name__ == '__main__':

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -40,7 +40,7 @@ class TestGrad(BaseTest):
     def test_affine_prod(self):
         """Test gradient for affine_prod
         """
-        expr = self.C * self.A
+        expr = self.C @ self.A
         self.C.value = np.array([[1, -2], [3, 4], [-1, -3]])
         self.A.value = np.array([[3, 2], [-5, 1]])
 
@@ -297,7 +297,7 @@ class TestGrad(BaseTest):
         self.assertAlmostEqual(lin_expr.value, expr.value)
 
         # Convex.
-        expr = (self.A)**2 + 5
+        expr = self.A**2 + 5
 
         with self.assertRaises(Exception) as cm:
             linearize(expr)
@@ -307,7 +307,7 @@ class TestGrad(BaseTest):
         self.A.value = [[1, 2], [3, 4]]
         lin_expr = linearize(expr)
         manual = expr.value + 2*cp.reshape(
-            cp.diag(cp.vec(self.A)).value*cp.vec(self.A - self.A.value),
+            cp.diag(cp.vec(self.A)).value @ cp.vec(self.A - self.A.value),
             (2, 2)
         )
         self.assertItemsAlmostEqual(lin_expr.value, expr.value)
@@ -319,7 +319,7 @@ class TestGrad(BaseTest):
         expr = cp.log(self.x)/2
         self.x.value = [1, 2]
         lin_expr = linearize(expr)
-        manual = expr.value + cp.diag(0.5*self.x**-1).value*(self.x - self.x.value)
+        manual = expr.value + cp.diag(0.5*self.x**-1).value @ (self.x - self.x.value)
         self.assertItemsAlmostEqual(lin_expr.value, expr.value)
         self.x.value = [3, 4.4]
         assert (lin_expr.value >= expr.value).all()

--- a/cvxpy/tests/test_linear_cone.py
+++ b/cvxpy/tests/test_linear_cone.py
@@ -134,7 +134,7 @@ class TestLinearCone(BaseTest):
     def test_vector_lp(self):
         for solver in self.solvers:
             c = Constant(numpy.array([1, 2]))
-            p = Problem(Minimize(c.T*self.x), [self.x >= c])
+            p = Problem(Minimize(c.T @ self.x), [self.x >= c])
             result = p.solve(solver.name())
             self.assertTrue(ConeMatrixStuffing().accepts(p))
             p_new = ConeMatrixStuffing().apply(p)
@@ -155,9 +155,9 @@ class TestLinearCone(BaseTest):
 
             A = Constant(numpy.array([[3, 5], [1, 2]]).T).value
             Imat = Constant([[1, 0], [0, 1]])
-            p = Problem(Minimize(c.T*self.x + self.a),
-                        [A*self.x >= [-1, 1],
-                         4*Imat*self.z == self.x,
+            p = Problem(Minimize(c.T @ self.x + self.a),
+                        [A @ self.x >= [-1, 1],
+                         4*Imat @ self.z == self.x,
                          self.z >= [2, 2],
                          self.a >= 2])
             self.assertTrue(ConeMatrixStuffing().accepts(p))
@@ -189,7 +189,7 @@ class TestLinearCone(BaseTest):
                                             var.value)
 
             T = Constant(numpy.ones((2, 3))*2).value
-            p = Problem(Minimize(1), [self.A >= T*self.C,
+            p = Problem(Minimize(1), [self.A >= T @ self.C,
                                       self.A == self.B, self.C == T.T])
             self.assertTrue(ConeMatrixStuffing().accepts(p))
             result = p.solve(solver.name())

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -61,9 +61,7 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(v == self.x, (2,))
         # Matrix
         A = numpy.arange(8).reshape((4, 2))
-        self.assertExpression(A*self.x, (4,))
-        if PY35:
-            self.assertExpression(self.x.__rmatmul__(A), (4,))
+        self.assertExpression(A @ self.x, (4,))
         # PSD inequalities.
         A = numpy.ones((2, 2))
         self.assertExpression(A << self.A, (2, 2))
@@ -83,10 +81,8 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(v == self.x, (2,))
         # Matrix
         A = numpy.arange(8).reshape((4, 2))
-        self.assertExpression(A*self.x, (4,))
-        self.assertExpression((A.T.dot(A)) * self.x, (2,))
-        if PY35:
-            self.assertExpression(self.x.__rmatmul__(A), (4,))
+        self.assertExpression(A @ self.x, (4,))
+        self.assertExpression((A.T.dot(A)) @ self.x, (2,))
         # PSD inequalities.
         A = numpy.ones((2, 2))
         self.assertExpression(A << self.A, (2, 2))
@@ -108,35 +104,6 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(v << self.A, (2, 2))
         self.assertExpression(v >> self.A, (2, 2))
 
-    # def test_cvxopt_matrices(self):
-    #     """Test cvxopt dense matrices.
-    #     """
-    #     # Vector
-    #     v = cvxopt.matrix( numpy.arange(2).reshape((2,1)) )
-    #     self.assertExpression(self.x + v, (2,1))
-    #     self.assertExpression(v + v + self.x, (2,1))
-    #     self.assertExpression(self.x - v, (2,1))
-    #     self.assertExpression(v - v - self.x, (2,1))
-    #     self.assertExpression(self.x <= v, (2,1))
-    #     self.assertExpression(v <= self.x, (2,1))
-    #     self.assertExpression(self.x == v, (2,1))
-    #     self.assertExpression(v == self.x, (2,1))
-    #     # Matrix
-    #     A = cvxopt.matrix( numpy.arange(8).reshape((4,2)) )
-    #     self.assertExpression(A*self.x, (4,1))
-    #     self.assertExpression( (A.T*A) * self.x, (2,1))
-
-    # # Test cvxopt sparse matrices.
-    # def test_cvxopt_sparse(self):
-    #     m = 100
-    #     n = 20
-
-    #     mu = cvxopt.exp(cvxopt.normal(m))
-    #     F = cvxopt.normal(m, n)
-    #     D = cvxopt.spdiag(cvxopt.uniform(m))
-    #     x = Variable(m)
-    #     exp = square(norm2(D*x))
-
     def test_scipy_sparse(self):
         """Test scipy sparse matrices."""
         # Constants.
@@ -157,7 +124,7 @@ class TestMatrices(unittest.TestCase):
         B = sp.hstack([A, A])
         self.assertExpression(var + A, (4, 2))
         self.assertExpression(A + var, (4, 2))
-        self.assertExpression(B * var, (4, 2))
+        self.assertExpression(B @ var, (4, 2))
         self.assertExpression(var - A, (4, 2))
         self.assertExpression(A - A - var, (4, 2))
         if PY35:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -117,7 +117,7 @@ class TestProblem(BaseTest):
         """
         c1 = numpy.random.randn(1, 2)
         c2 = numpy.random.randn(2)
-        p = Problem(cp.Minimize(c1*self.x), [self.x >= c2])
+        p = Problem(cp.Minimize(c1 @ self.x), [self.x >= c2])
         constants_ = p.constants()
         ref = [c1, c2]
         self.assertEqual(len(ref), len(constants_))
@@ -395,11 +395,11 @@ class TestProblem(BaseTest):
         beq = numpy.random.randn(2)
         F = numpy.random.randn(2, 3)
         g = numpy.random.randn(2)
-        obj = cp.sum_squares(A*self.y - b)
-        qpwa_obj = 3*cp.sum_squares(-cp.abs(A*self.y)) +\
-            cp.quad_over_lin(cp.maximum(cp.abs(A*self.y), [3., 3., 3., 3.]), 2.)
-        not_qpwa_obj = 3*cp.sum_squares(cp.abs(A*self.y)) +\
-            cp.quad_over_lin(cp.minimum(cp.abs(A*self.y), [3., 3., 3., 3.]), 2.)
+        obj = cp.sum_squares(A @ self.y - b)
+        qpwa_obj = 3*cp.sum_squares(-cp.abs(A @ self.y)) +\
+            cp.quad_over_lin(cp.maximum(cp.abs(A @ self.y), [3., 3., 3., 3.]), 2.)
+        not_qpwa_obj = 3*cp.sum_squares(cp.abs(A @ self.y)) +\
+            cp.quad_over_lin(cp.minimum(cp.abs(A @ self.y), [3., 3., 3., 3.]), 2.)
 
         p = Problem(cp.Minimize(obj), [])
         self.assertEqual(p.is_qp(), True)
@@ -411,23 +411,23 @@ class TestProblem(BaseTest):
         self.assertEqual(p.is_qp(), False)
 
         p = Problem(cp.Minimize(obj),
-                    [Aeq * self.y == beq, F * self.y <= g])
+                    [Aeq @ self.y == beq, F @ self.y <= g])
         self.assertEqual(p.is_qp(), True)
 
         p = Problem(cp.Minimize(qpwa_obj),
-                    [Aeq * self.y == beq, F * self.y <= g])
+                    [Aeq @ self.y == beq, F @ self.y <= g])
         self.assertEqual(p.is_qp(), True)
 
         p = Problem(cp.Minimize(obj), [cp.maximum(1, 3 * self.y) <= 200,
                                        cp.abs(2 * self.y) <= 100,
                                        cp.norm(2 * self.y, 1) <= 1000,
-                                       Aeq * self.y == beq])
+                                       Aeq @ self.y == beq])
         self.assertEqual(p.is_qp(), True)
 
         p = Problem(cp.Minimize(qpwa_obj), [cp.maximum(1, 3 * self.y) <= 200,
                                             cp.abs(2 * self.y) <= 100,
                                             cp.norm(2 * self.y, 1) <= 1000,
-                                            Aeq * self.y == beq])
+                                            Aeq @ self.y == beq])
         self.assertEqual(p.is_qp(), True)
 
         p = Problem(cp.Minimize(obj), [cp.maximum(1, 3 * self.y ** 2) <= 200])
@@ -578,21 +578,21 @@ class TestProblem(BaseTest):
     # Test vector LP problems.
     def test_vector_lp(self):
         c = Constant(numpy.array([[1, 2]]).T).value
-        p = Problem(cp.Minimize(c.T*self.x), [self.x[:, None] >= c])
+        p = Problem(cp.Minimize(c.T @ self.x), [self.x[:, None] >= c])
         result = p.solve()
         self.assertAlmostEqual(result, 5)
         self.assertItemsAlmostEqual(self.x.value, [1, 2])
 
         A = Constant(numpy.array([[3, 5], [1, 2]]).T).value
         Imat = Constant([[1, 0], [0, 1]])
-        p = Problem(cp.Minimize(c.T*self.x + self.a),
-                    [A*self.x >= [-1, 1],
-                     4*Imat*self.z == self.x,
+        p = Problem(cp.Minimize(c.T @ self.x + self.a),
+                    [A @ self.x >= [-1, 1],
+                     4*Imat @ self.z == self.x,
                      self.z >= [2, 2],
                      self.a >= 2])
         result = p.solve()
         self.assertAlmostEqual(result, 26, places=3)
-        obj = (c.T*self.x + self.a).value[0]
+        obj = (c.T @ self.x + self.a).value[0]
         self.assertAlmostEqual(obj, result)
         self.assertItemsAlmostEqual(self.x.value, [8, 8], places=3)
         self.assertItemsAlmostEqual(self.z.value, [2, 2], places=3)
@@ -615,13 +615,13 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.A.value, T)
 
         T = Constant(numpy.ones((2, 3))*2).value
-        p = Problem(cp.Minimize(1), [self.A >= T*self.C,
+        p = Problem(cp.Minimize(1), [self.A >= T @ self.C,
                                      self.A == self.B, self.C == T.T])
         result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.A.value, self.B.value)
         self.assertItemsAlmostEqual(self.C.value, T)
-        assert (self.A.value >= (T*self.C).value).all()
+        assert (self.A.value >= (T @ self.C).value).all()
 
         # Test variables are dense.
         self.assertEqual(type(self.A.value), intf.DEFAULT_INTF.TARGET_MATRIX)
@@ -642,7 +642,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(self.a.value, 4)
 
         # Promotion must happen before the multiplication.
-        p = Problem(cp.Minimize([[1], [1]]*(self.x + self.a + 1)),
+        p = Problem(cp.Minimize([[1], [1]] @ (self.x + self.a + 1)),
                     [self.a + self.x >= [1, 2]])
         result = p.solve()
         self.assertAlmostEqual(result, 5)
@@ -650,7 +650,7 @@ class TestProblem(BaseTest):
     # Test parameter promotion.
     def test_parameter_promotion(self):
         a = Parameter()
-        exp = [[1, 2], [3, 4]]*a
+        exp = [[1, 2], [3, 4]] * a
         a.value = 2
         assert not (exp.value - 2*numpy.array([[1, 2], [3, 4]]).T).any()
 
@@ -837,7 +837,7 @@ class TestProblem(BaseTest):
                     acc = 5
                 p = Problem(cp.Minimize(cp.norm1(self.x + self.z)),
                             [self.x >= [2, 3],
-                            [[1, 2], [3, 4]]*self.z == [-1, -4],
+                            [[1, 2], [3, 4]] @ self.z == [-1, -4],
                             cp.pnorm(self.x + self.z, p=2) <= 100])
                 result = p.solve(solver=solver)
                 self.assertAlmostEqual(result, 4, places=acc)
@@ -850,7 +850,7 @@ class TestProblem(BaseTest):
 
                 T = numpy.ones((2, 3))*2
                 p = Problem(cp.Minimize(1),
-                            [self.A >= T*self.C,
+                            [self.A >= T @ self.C,
                              self.A == self.B,
                              self.C == T.T])
                 result = p.solve(solver=solver)
@@ -884,7 +884,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.A.value, [1, -2, -3, 4])
 
         # Indexing arithmetic expressions.
-        expr = [[1, 2], [3, 4]]*self.z + self.x
+        expr = [[1, 2], [3, 4]] @ self.z + self.x
         p = Problem(cp.Minimize(expr[1]), [self.x == self.z, self.z == [1, 2]])
         result = p.solve()
         self.assertAlmostEqual(result, 12)
@@ -941,9 +941,9 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.C.value[0:2, :], [1, 2, 1, 2])
         self.assertItemsAlmostEqual(self.A.value, [2, 2, 1, 1])
 
-        p = Problem(cp.Maximize([[3], [4]]*(self.C[0:2, :] + self.A)[:, 0]),
+        p = Problem(cp.Maximize([[3], [4]] @ (self.C[0:2, :] + self.A)[:, 0]),
                     [self.C[1:3, :] <= 2, self.C[0, :] == 1,
-                     [[1], [2]]*(self.A + self.B)[:, 0] == 3, (self.A + self.B)[:, 1] == 2,
+                     [[1], [2]] @ (self.A + self.B)[:, 0] == 3, (self.A + self.B)[:, 1] == 2,
                      self.B == 1, 3*self.A[:, 0] <= 3])
         result = p.solve()
         self.assertAlmostEqual(result, 12)
@@ -974,14 +974,14 @@ class TestProblem(BaseTest):
         y = Variable((3, 1), name='y')
 
         c = numpy.ones((1, 5))
-        p = Problem(cp.Minimize(c * cp.vstack([x, y])),
+        p = Problem(cp.Minimize(c @ cp.vstack([x, y])),
                     [x == [[1, 2]],
                      y == [[3, 4, 5]]])
         result = p.solve()
         self.assertAlmostEqual(result, 15)
 
         c = numpy.ones((1, 4))
-        p = Problem(cp.Minimize(c * cp.vstack([x, x])),
+        p = Problem(cp.Minimize(c @ cp.vstack([x, x])),
                     [x == [[1, 2]]])
         result = p.solve()
         self.assertAlmostEqual(result, 6)
@@ -994,14 +994,14 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, -4)
 
         c = numpy.ones((1, 2))
-        p = Problem(cp.Minimize(cp.sum(cp.vstack([c*self.A, c*self.B]))),
+        p = Problem(cp.Minimize(cp.sum(cp.vstack([c @ self.A, c @ self.B]))),
                     [self.A >= 2,
                      self.B == -2])
         result = p.solve()
         self.assertAlmostEqual(result, 0)
 
         c = numpy.array([[1, -1]]).T
-        p = Problem(cp.Minimize(c.T * cp.vstack([cp.square(a), cp.sqrt(b)])),
+        p = Problem(cp.Minimize(c.T @ cp.vstack([cp.square(a), cp.sqrt(b)])),
                     [a == 2,
                      b == 16])
         with self.assertRaises(Exception) as cm:
@@ -1018,14 +1018,14 @@ class TestProblem(BaseTest):
         y = Variable((3, 1), name='y')
 
         c = numpy.ones((1, 5))
-        p = Problem(cp.Minimize(c * cp.hstack([x.T, y.T]).T),
+        p = Problem(cp.Minimize(c @ cp.hstack([x.T, y.T]).T),
                     [x == [[1, 2]],
                      y == [[3, 4, 5]]])
         result = p.solve()
         self.assertAlmostEqual(result, 15)
 
         c = numpy.ones((1, 4))
-        p = Problem(cp.Minimize(c * cp.hstack([x.T, x.T]).T),
+        p = Problem(cp.Minimize(c @ cp.hstack([x.T, x.T]).T),
                     [x == [[1, 2]]])
         result = p.solve()
         self.assertAlmostEqual(result, 6)
@@ -1046,7 +1046,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 13)
 
         c = numpy.array([[1, -1]]).T
-        p = Problem(cp.Minimize(c.T * cp.hstack([cp.square(a).T, cp.sqrt(b).T]).T),
+        p = Problem(cp.Minimize(c.T @ cp.hstack([cp.square(a).T, cp.sqrt(b).T]).T),
                     [a == 2,
                      b == 16])
         with self.assertRaises(Exception) as cm:
@@ -1070,7 +1070,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.x.value, [1, 2])
 
         p = Problem(cp.Minimize(cp.sum(self.C)),
-                    [numpy.array([[1, 1]])*self.C.T >= numpy.array([[0, 1, 2]])])
+                    [numpy.array([[1, 1]]) @ self.C.T >= numpy.array([[0, 1, 2]])])
         result = p.solve()
         value = self.C.value
 
@@ -1114,7 +1114,7 @@ class TestProblem(BaseTest):
         """Test multiplication on the left by a non-constant.
         """
         c = numpy.array([[1, 2]]).T
-        p = Problem(cp.Minimize(c.T*self.A*c), [self.A >= 2])
+        p = Problem(cp.Minimize(c.T @ self.A @ c), [self.A >= 2])
         result = p.solve()
         self.assertAlmostEqual(result, 18)
 
@@ -1122,11 +1122,11 @@ class TestProblem(BaseTest):
         result = p.solve()
         self.assertAlmostEqual(result, 4)
 
-        p = Problem(cp.Minimize(self.x.T*c), [self.x >= 2])
+        p = Problem(cp.Minimize(self.x.T @ c), [self.x >= 2])
         result = p.solve()
         self.assertAlmostEqual(result, 6)
 
-        p = Problem(cp.Minimize((self.x.T + self.z.T)*c),
+        p = Problem(cp.Minimize((self.x.T + self.z.T) @ c),
                     [self.x >= 2, self.z >= 1])
         result = p.solve()
         self.assertAlmostEqual(result, 9)
@@ -1134,7 +1134,7 @@ class TestProblem(BaseTest):
         # TODO segfaults in Python 3
         A = numpy.ones((5, 10))
         x = Variable(5)
-        p = cp.Problem(cp.Minimize(cp.sum(x*A)), [x >= 0])
+        p = cp.Problem(cp.Minimize(cp.sum(x @ A)), [x >= 0])
         result = p.solve()
         self.assertAlmostEqual(result, 0)
 
@@ -1333,7 +1333,7 @@ class TestProblem(BaseTest):
         vec = numpy.array([[1, 2, 3, 4]]).T
         vec_mat = numpy.array([[1, 2], [3, 4]]).T
         expr = cp.reshape(x, (2, 2))
-        obj = cp.Minimize(cp.sum(mat*expr))
+        obj = cp.Minimize(cp.sum(mat @ expr))
         prob = Problem(obj, [x[:, None] == vec])
         result = prob.solve()
         self.assertAlmostEqual(result, numpy.sum(mat.dot(vec_mat)))
@@ -1341,7 +1341,7 @@ class TestProblem(BaseTest):
         # Test on matrix to vector.
         c = [1, 2, 3, 4]
         expr = cp.reshape(self.A, (4, 1))
-        obj = cp.Minimize(expr.T*c)
+        obj = cp.Minimize(expr.T @ c)
         constraints = [self.A == [[-1, -2], [3, 4]]]
         prob = Problem(obj, constraints)
         result = prob.solve()
@@ -1353,7 +1353,7 @@ class TestProblem(BaseTest):
         expr = cp.reshape(self.C, (2, 3))
         mat = numpy.array([[1, -1], [2, -2]])
         C_mat = numpy.array([[1, 4], [2, 5], [3, 6]])
-        obj = cp.Minimize(cp.sum(mat*expr))
+        obj = cp.Minimize(cp.sum(mat @ expr))
         prob = Problem(obj, [self.C == C_mat])
         result = prob.solve()
         reshaped = numpy.reshape(C_mat, (2, 3), 'F')
@@ -1362,15 +1362,15 @@ class TestProblem(BaseTest):
 
         # Test promoted expressions.
         c = numpy.array([[1, -1], [2, -2]]).T
-        expr = cp.reshape(c*self.a, (1, 4))
-        obj = cp.Minimize(expr*[1, 2, 3, 4])
+        expr = cp.reshape(c * self.a, (1, 4))
+        obj = cp.Minimize(expr @ [1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])
         result = prob.solve()
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(expr.value, 2*c)
 
-        expr = cp.reshape(c*self.a, (4, 1))
-        obj = cp.Minimize(expr.T*[1, 2, 3, 4])
+        expr = cp.reshape(c * self.a, (4, 1))
+        obj = cp.Minimize(expr.T @ [1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])
         result = prob.solve()
         self.assertAlmostEqual(result, -6)
@@ -1399,7 +1399,7 @@ class TestProblem(BaseTest):
         """
         c = [1, 2, 3, 4]
         expr = cp.vec(self.A)
-        obj = cp.Minimize(expr.T*c)
+        obj = cp.Minimize(expr.T @ c)
         constraints = [self.A == [[-1, -2], [3, 4]]]
         prob = Problem(obj, constraints)
         result = prob.solve()
@@ -1635,7 +1635,7 @@ class TestProblem(BaseTest):
         # todo: add -1, .5, .3, -2.3 and testing positivity constraints
 
         for p in (1, 1.6, 1.3, 2, 1.99, 3, 3.7, np.inf):
-            prob = Problem(cp.Minimize(cp.pnorm(x, p=p)), [x.T*a >= 1])
+            prob = Problem(cp.Minimize(cp.pnorm(x, p=p)), [x.T @ a >= 1])
             prob.solve(verbose=True)
 
             # formula is true for any a >= 0 with p > 1
@@ -1690,7 +1690,7 @@ class TestProblem(BaseTest):
         theta = Variable(J)
 
         delta = 1e-3
-        loglambda = rvec*theta  # rvec: TxJ regressor matrix, theta: (Jx1) cp variable
+        loglambda = rvec @ theta  # rvec: TxJ regressor matrix, theta: (Jx1) cp variable
         a = cp.multiply(dy[0:T], loglambda)  # size(Tx1)
         b1 = cp.exp(loglambda)
         b2 = cp.multiply(delta, b1)
@@ -1790,11 +1790,11 @@ class TestProblem(BaseTest):
         D_sparse = sp.coo_matrix(D_dense)
 
         def make_problem(D):
-            obj = cp.Minimize(0.5 * cp.quad_form(a, P) - a.T * q)
+            obj = cp.Minimize(0.5 * cp.quad_form(a, P) - a.T @ q)
             assert obj.is_dcp()
 
             alpha = cp.Parameter(nonneg=True, value=2)
-            constraints = [a >= 0., -alpha <= D.T * a, D.T * a <= alpha]
+            constraints = [a >= 0., -alpha <= D.T @ a, D.T @ a <= alpha]
 
             prob = cp.Problem(obj, constraints)
             prob.solve(solver=cp.settings.ECOS)
@@ -1810,7 +1810,7 @@ class TestProblem(BaseTest):
         np.testing.assert_almost_equal(expected_coef, coef_dense)
 
         make_problem(D_sparse)
-        coef_sparse = a.value.T * D_sparse
+        coef_sparse = a.value.T @ D_sparse
         np.testing.assert_almost_equal(expected_coef, coef_sparse)
 
     def test_special_index(self):

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -135,7 +135,7 @@ class TestQp(BaseTest):
     def square_affine(self, solver):
         A = np.random.randn(10, 2)
         b = np.random.randn(10)
-        p = Problem(Minimize(sum_squares(A*self.x - b)))
+        p = Problem(Minimize(sum_squares(A @ self.x - b)))
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(),
@@ -148,7 +148,7 @@ class TestQp(BaseTest):
         z = np.random.randn(5)
         P = A.T.dot(A)
         q = -2*P.dot(z)
-        p = Problem(Minimize(QuadForm(self.w, P) + q.T*self.w))
+        p = Problem(Minimize(QuadForm(self.w, P) + q.T @ self.w))
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual(z, var.value, places=4)
@@ -158,7 +158,7 @@ class TestQp(BaseTest):
         A = np.maximum(A, 0)
         b = np.random.randn(5)
         b = np.maximum(b, 0)
-        p = Problem(Minimize(sum(self.x)), [self.x >= 0, A*self.x <= b])
+        p = Problem(Minimize(sum(self.x)), [self.x >= 0, A @ self.x <= b])
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual([0., 0.], var.value, places=3)
@@ -168,7 +168,7 @@ class TestQp(BaseTest):
         A = np.maximum(A, 0)
         b = np.random.randn(5)
         b = np.maximum(b, 0)
-        p = Problem(Maximize(-sum(self.x)), [self.x >= 0, A*self.x <= b])
+        p = Problem(Maximize(-sum(self.x)), [self.x >= 0, A @ self.x <= b])
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual([0., 0.], var.value, places=3)
@@ -176,7 +176,7 @@ class TestQp(BaseTest):
     def norm_2(self, solver):
         A = np.random.randn(10, 5)
         b = np.random.randn(10)
-        p = Problem(Minimize(norm(A*self.w - b, 2)))
+        p = Problem(Minimize(norm(A @ self.w - b, 2)))
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(), var.value,
@@ -185,7 +185,7 @@ class TestQp(BaseTest):
     def mat_norm_2(self, solver):
         A = np.random.randn(5, 3)
         B = np.random.randn(5, 2)
-        p = Problem(Minimize(norm(A*self.C - B, 2)))
+        p = Problem(Minimize(norm(A @ self.C - B, 2)))
         s = self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual(lstsq(A, B)[0],
@@ -197,7 +197,7 @@ class TestQp(BaseTest):
         z = np.random.randn(5)
         P = A.T.dot(A)
         q = -2*P.dot(z)
-        p = Problem(Minimize(QuadForm(self.w, P) + q.T*self.w))
+        p = Problem(Minimize(QuadForm(self.w, P) + q.T @ self.w))
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual(z, var.value, places=4)
@@ -207,7 +207,7 @@ class TestQp(BaseTest):
         q = np.array([[-22], [-14.5], [13]])
         r = 1
         y_star = np.array([[1], [0.5], [-1]])
-        p = Problem(Minimize(0.5*QuadForm(self.y, P) + q.T*self.y + r),
+        p = Problem(Minimize(0.5*QuadForm(self.y, P) + q.T @ self.y + r),
                     [self.y >= -1, self.y <= 1])
         self.solve_QP(p, solver)
         for var in p.variables():
@@ -248,7 +248,7 @@ class TestQp(BaseTest):
         print(x_data_expanded.shape, true_coeffs.shape)
         y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n)
 
-        quadratic = self.offset + x_data*self.slope + \
+        quadratic = self.offset + x_data * self.slope + \
             self.quadratic_coeff*np.power(x_data, 2)
         residuals = quadratic.T - y_data
         fit_error = sum_squares(residuals)
@@ -272,7 +272,7 @@ class TestQp(BaseTest):
         # Add constraints on our variables
         for i in range(T - 1):
             constraints += [self.position[:, i + 1] == self.position[:, i] +
-                            h*self.velocity[:, i]]
+                            h * self.velocity[:, i]]
             acceleration = self.force[:, i]/mass + g - \
                 drag * self.velocity[:, i]
             constraints += [self.velocity[:, i + 1] == self.velocity[:, i] +
@@ -297,7 +297,7 @@ class TestQp(BaseTest):
         A = sp.rand(m, n, density)
         b = np.random.randn(m)
 
-        p = Problem(Minimize(sum_squares(A*self.xs - b)), [self.xs == 0])
+        p = Problem(Minimize(sum_squares(A @ self.xs - b)), [self.xs == 0])
         self.solve_QP(p, solver)
         self.assertAlmostEqual(b.T.dot(b), p.value, places=4)
 
@@ -309,7 +309,7 @@ class TestQp(BaseTest):
 
         A = np.ones((k, n))
         b = np.ones((k))
-        obj = sum_squares(A*self.xsr - b) + \
+        obj = sum_squares(A @ self.xsr - b) + \
             eta*sum_squares(self.xsr[:-1]-self.xsr[1:])
         p = Problem(Minimize(obj), [])
         self.solve_QP(p, solver)
@@ -339,7 +339,7 @@ class TestQp(BaseTest):
 
         # Solve the Huber regression problem
         x = Variable(n)
-        objective = sum(huber(A * x - b))
+        objective = sum(huber(A @ x - b))
 
         # Solve problem with QP
         p = Problem(Minimize(objective))
@@ -359,8 +359,8 @@ class TestQp(BaseTest):
         G = np.random.randn(r, n)
         h = np.random.randn(r)
 
-        obj1 = .1 * sum((A*self.xef - b) ** 2)
-        cons = [G*self.xef == h]
+        obj1 = .1 * sum((A @ self.xef - b) ** 2)
+        cons = [G @ self.xef == h]
 
         p1 = Problem(Minimize(obj1), cons)
         self.solve_QP(p1, solver)
@@ -381,8 +381,8 @@ class TestQp(BaseTest):
         q = -2*np.dot(A.T, b)
         r = np.dot(b.T, b)
 
-        obj2 = .1*(QuadForm(self.xef, P)+q.T*self.xef+r)
-        cons = [G*self.xef == h]
+        obj2 = .1*(QuadForm(self.xef, P)+q.T @ self.xef+r)
+        cons = [G @ self.xef == h]
 
         p2 = Problem(Minimize(obj2), cons)
         self.solve_QP(p2, solver)
@@ -404,8 +404,8 @@ class TestQp(BaseTest):
         r = np.dot(b.T, b)
         Pinv = np.linalg.inv(P)
 
-        obj3 = .1 * (matrix_frac(self.xef, Pinv)+q.T*self.xef+r)
-        cons = [G*self.xef == h]
+        obj3 = .1 * (matrix_frac(self.xef, Pinv)+q.T @ self.xef+r)
+        cons = [G @ self.xef == h]
 
         p3 = Problem(Minimize(obj3), cons)
         self.solve_QP(p3, solver)
@@ -422,7 +422,7 @@ class TestQp(BaseTest):
 
         # Construct the problem.
         x = Variable(n)
-        prob = Problem(Minimize(sum_squares(A*x - b)))
+        prob = Problem(Minimize(sum_squares(A @ x - b)))
 
         b.value = np.random.randn(m)
         result = prob.solve(warm_start=False)

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -139,8 +139,8 @@ class TestNonOptimal(BaseTest):
         x = cvxpy.Variable((2, 1))
         A = np.array([[1.0]])
         B = np.array([[1.0, 1.0]]).T
-        obj0 = -B.T * x
-        obj1 = cvxpy.quad_form(B.T * x, A)
+        obj0 = -B.T @ x
+        obj1 = cvxpy.quad_form(B.T @ x, A)
         prob = cvxpy.Problem(cvxpy.Minimize(obj0 + obj1))
         prob.solve()
         self.assertAlmostEqual(prob.value, prob.objective.value)
@@ -155,9 +155,9 @@ class TestNonOptimal(BaseTest):
         laplacian_matrix = np.ones((2, 2))
         design_matrix = cvxpy.Constant(M)
         objective = cvxpy.Minimize(
-            cvxpy.sum_squares(design_matrix * c - data_norm) +
+            cvxpy.sum_squares(design_matrix @ c - data_norm) +
             lopt * cvxpy.quad_form(c, laplacian_matrix)
         )
-        constraints = [(M[0] * c) == 1]  # (K * c) >= -0.1]
+        constraints = [(M[0] @ c) == 1]  # (K * c) >= -0.1]
         prob = cvxpy.Problem(objective, constraints)
         prob.solve()

--- a/cvxpy/tests/test_quadratic.py
+++ b/cvxpy/tests/test_quadratic.py
@@ -108,7 +108,7 @@ class TestExpressions(BaseTest):
         q = np.ones((5, 1))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            s = x.T @ P*x + q.T @ x
+            s = x.T @ P @ x + q.T @ x
         self.assertFalse(s.is_constant())
         self.assertFalse(s.is_affine())
         self.assertTrue(s.is_quadratic())
@@ -171,7 +171,7 @@ class TestExpressions(BaseTest):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            s = x*y
+            s = x @ y
 
         self.assertFalse(s.is_constant())
         self.assertFalse(s.is_affine())

--- a/cvxpy/tests/test_quadratic.py
+++ b/cvxpy/tests/test_quadratic.py
@@ -39,7 +39,7 @@ class TestExpressions(BaseTest):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            s = power(x.T*y, 0)
+            s = power(x.T @ y, 0)
             self.assertTrue(s.is_constant())
             self.assertTrue(s.is_affine())
             self.assertTrue(s.is_quadratic())
@@ -70,7 +70,7 @@ class TestExpressions(BaseTest):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            s = x.T*y
+            s = x.T @ y
         self.assertFalse(s.is_constant())
         self.assertFalse(s.is_affine())
         self.assertTrue(s.is_quadratic())
@@ -95,7 +95,7 @@ class TestExpressions(BaseTest):
     def test_matrix_frac(self):
         x = Variable(5)
         M = np.eye(5)
-        P = M.T*M
+        P = M.T @ M
         s = cp.matrix_frac(x, P)
         self.assertFalse(s.is_constant())
         self.assertFalse(s.is_affine())
@@ -108,7 +108,7 @@ class TestExpressions(BaseTest):
         q = np.ones((5, 1))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            s = x.T*P*x + q.T*x
+            s = x.T @ P*x + q.T @ x
         self.assertFalse(s.is_constant())
         self.assertFalse(s.is_affine())
         self.assertTrue(s.is_quadratic())
@@ -120,7 +120,7 @@ class TestExpressions(BaseTest):
         Q = np.ones((4, 7))
         M = np.ones((3, 7))
 
-        y = P*X*Q + M
+        y = P @ X @ Q + M
         self.assertFalse(y.is_constant())
         self.assertTrue(y.is_affine())
         self.assertTrue(y.is_quadratic())

--- a/cvxpy/transforms/linearize.py
+++ b/cvxpy/transforms/linearize.py
@@ -55,8 +55,8 @@ def linearize(expr):
             if grad_map[var] is None:
                 return None
             elif var.is_matrix():
-                flattened = Constant(grad_map[var]).T*vec(var - var.value)
+                flattened = Constant(grad_map[var]).T @ vec(var - var.value)
                 tangent = tangent + reshape(flattened, expr.shape)
             else:
-                tangent = tangent + Constant(grad_map[var]).T*(var - var.value)
+                tangent = tangent + Constant(grad_map[var]).T @ (var - var.value)
         return tangent

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -229,8 +229,8 @@ class PartialProblem(Expression):
             lagr = self.args[0].objective.args[0]
             for constr in self.args[0].constraints:
                 # TODO: better way to get constraint expressions.
-                lagr_multiplier = self.cast_to_const(sign*constr.dual_value)
-                prod = lagr_multiplier.T*constr.expr
+                lagr_multiplier = self.cast_to_const(sign * constr.dual_value)
+                prod = lagr_multiplier.T @ constr.expr
                 if prod.is_scalar():
                     lagr += sum(prod)
                 else:

--- a/doc/source/examples/basic/least_squares.rst
+++ b/doc/source/examples/basic/least_squares.rst
@@ -52,7 +52,7 @@ In the following code, we solve a least-squares problem with CVXPY.
     
     # Define and solve the CVXPY problem.
     x = cp.Variable(n)
-    cost = cp.sum_squares(A*x - b)
+    cost = cp.sum_squares(A @ x - b)
     prob = cp.Problem(cp.Minimize(cost))
     prob.solve()
     
@@ -60,7 +60,7 @@ In the following code, we solve a least-squares problem with CVXPY.
     print("\nThe optimal value is", prob.value)
     print("The optimal x is")
     print(x.value)
-    print("The norm of the residual is ", cp.norm(A*x - b, p=2).value)
+    print("The norm of the residual is ", cp.norm(A @ x - b, p=2).value)
 
 
 .. parsed-literal::

--- a/doc/source/examples/basic/linear_program.rst
+++ b/doc/source/examples/basic/linear_program.rst
@@ -53,13 +53,13 @@ In the following code, we solve a linear program with CVXPY.
     s0 = np.maximum(s0, 0)
     x0 = np.random.randn(n)
     A = np.random.randn(m, n)
-    b = A@x0 + s0
-    c = -A.T@lamb0
+    b = A @ x0 + s0
+    c = -A.T @ lamb0
     
     # Define and solve the CVXPY problem.
     x = cp.Variable(n)
     prob = cp.Problem(cp.Minimize(c.T@x),
-                     [A@x <= b])
+                     [A @ x <= b])
     prob.solve()
     
     # Print result.

--- a/doc/source/examples/basic/mixed_integer_quadratic_program.rst
+++ b/doc/source/examples/basic/mixed_integer_quadratic_program.rst
@@ -60,7 +60,7 @@ with CVXPY.
 
     # Construct a CVXPY problem
     x = cp.Variable(n, integer=True)
-    objective = cp.Minimize(cp.sum_squares(A@x - b))
+    objective = cp.Minimize(cp.sum_squares(A @ x - b))
     prob = cp.Problem(objective)
     prob.solve()
 

--- a/doc/source/examples/basic/quadratic_program.rst
+++ b/doc/source/examples/basic/quadratic_program.rst
@@ -63,18 +63,18 @@ In the following code, we solve a quadratic program with CVXPY.
     p = 5
     np.random.seed(1)
     P = np.random.randn(n, n)
-    P = P.T@P
+    P = P.T @ P
     q = np.random.randn(n)
     G = np.random.randn(m, n)
-    h = G@np.random.randn(n)
+    h = G @ np.random.randn(n)
     A = np.random.randn(p, n)
     b = np.random.randn(p)
     
     # Define and solve the CVXPY problem.
     x = cp.Variable(n)
-    prob = cp.Problem(cp.Minimize((1/2)*cp.quad_form(x, P) + q.T@x),
-                     [G@x <= h,
-                      A@x == b])
+    prob = cp.Problem(cp.Minimize((1/2)*cp.quad_form(x, P) + q.T @ x),
+                     [G @ x <= h,
+                      A @ x == b])
     prob.solve()
     
     # Print result.

--- a/doc/source/examples/basic/sdp.rst
+++ b/doc/source/examples/basic/sdp.rst
@@ -61,9 +61,9 @@ In the following code, we solve a SDP with CVXPY.
     # The operator >> denotes matrix inequality.
     constraints = [X >> 0]
     constraints += [
-        cp.trace(A[i]@X) == b[i] for i in range(p)
+        cp.trace(A[i] @ X) == b[i] for i in range(p)
     ]
-    prob = cp.Problem(cp.Minimize(cp.trace(C@X)),
+    prob = cp.Problem(cp.Minimize(cp.trace(C @ X)),
                       constraints)
     prob.solve()
     

--- a/doc/source/examples/basic/socp.rst
+++ b/doc/source/examples/basic/socp.rst
@@ -76,18 +76,18 @@ In the following code, we solve a SOCP with CVXPY.
         A.append(np.random.randn(n_i, n))
         b.append(np.random.randn(n_i))
         c.append(np.random.randn(n))
-        d.append(np.linalg.norm(A[i]@x0 + b, 2) - c[i].T@x0)
+        d.append(np.linalg.norm(A[i] @ x0 + b, 2) - c[i].T @ x0)
     F = np.random.randn(p, n)
-    g = F@x0
+    g = F @ x0
     
     # Define and solve the CVXPY problem.
     x = cp.Variable(n)
     # We use cp.SOC(t, x) to create the SOC constraint ||x||_2 <= t.
     soc_constraints = [
-          cp.SOC(c[i].T@x + d[i], A[i]@x + b[i]) for i in range(m)
+          cp.SOC(c[i].T @ x + d[i], A[i] @ x + b[i]) for i in range(m)
     ]
     prob = cp.Problem(cp.Minimize(f.T@x),
-                      soc_constraints + [F@x == g])
+                      soc_constraints + [F @ x == g])
     prob.solve()
     
     # Print result.

--- a/doc/source/examples/machine_learning/lasso_regression.rst
+++ b/doc/source/examples/machine_learning/lasso_regression.rst
@@ -33,7 +33,7 @@ squares loss function** and an :math:`\ell_1` **regularizer**.
 .. code:: python
 
     def loss_fn(X, Y, beta):
-        return cp.norm2(cp.matmul(X, beta) - Y)**2
+        return cp.norm2(X @ beta - Y)**2
     
     def regularizer(beta):
         return cp.norm1(beta)

--- a/doc/source/examples/machine_learning/ridge_regression.rst
+++ b/doc/source/examples/machine_learning/ridge_regression.rst
@@ -42,7 +42,7 @@ squares loss function** and an :math:`\ell_2` **regularizer**.
 .. code:: python
 
     def loss_fn(X, Y, beta):
-        return cp.pnorm(cp.matmul(X, beta) - Y, p=2)**2
+        return cp.pnorm(X @ beta - Y, p=2)**2
     
     def regularizer(beta):
         return cp.pnorm(beta, p=2)**2

--- a/doc/source/examples/machine_learning/svm.rst
+++ b/doc/source/examples/machine_learning/svm.rst
@@ -61,7 +61,7 @@ We next formulate the optimization problem using CVXPY.
     import cvxpy as cp
     beta = cp.Variable((n,1))
     v = cp.Variable()
-    loss = cp.sum(cp.pos(1 - cp.multiply(Y, X*beta - v)))
+    loss = cp.sum(cp.pos(1 - cp.multiply(Y, X @ beta - v)))
     reg = cp.norm(beta, 1)
     lambd = cp.Parameter(nonneg=True)
     prob = cp.Problem(cp.Minimize(loss/m + lambd*reg))

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -555,7 +555,7 @@ The code below shows how warm start can accelerate solving a sequence of related
 
     # Construct the problem.
     x = cp.Variable(n)
-    prob = cp.Problem(cp.Minimize(cp.sum_squares(A*x - b)),
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)),
                        [x >= 0])
 
     b.value = numpy.random.randn(m)
@@ -1009,7 +1009,7 @@ solves of a DPP problem.
     gamma = cp.Parameter(nonneg=True)
 
     x = cp.Variable(m)
-    error = cp.sum_squares(A*x - b)
+    error = cp.sum_squares(A @ x - b)
     obj = cp.Minimize(error + gamma*cp.norm(x, 1))
     problem = cp.Problem(obj)
     assert problem.is_dpp()

--- a/doc/source/tutorial/dcp/index.rst
+++ b/doc/source/tutorial/dcp/index.rst
@@ -15,7 +15,7 @@ Expressions
 
 Expressions in CVXPY are formed from variables, parameters, numerical
 constants such as Python floats and Numpy matrices, the standard
-arithmetic operators ``+, -, *, /``, and a library of
+arithmetic operators ``+, -, *, /, @``, and a library of
 :ref:`functions <functions>`. Here are some examples of CVXPY expressions:
 
 .. code:: python
@@ -55,7 +55,7 @@ are the same as for NumPy ndarrays (except some broadcasting is banned).
     print("size of X:", X.size)
     print("number of dimensions:", X.ndim)
     print("dimensions of sum(X):", cp.sum(X).shape)
-    print("dimensions of A*X:", (A*X).shape)
+    print("dimensions of A @ X:", (A @ X).shape)
 
     # ValueError raised for invalid dimensions.
     try:
@@ -69,7 +69,7 @@ are the same as for NumPy ndarrays (except some broadcasting is banned).
     size of X: 20
     number of dimensions: 2
     dimensions of sum(X): ()
-    dimensions of A*X: (3, 4)
+    dimensions of A @ X: (3, 4)
     Cannot broadcast dimensions (3, 5) (5, 4)
 
 CVXPY uses DCP analysis to determine the sign and curvature of each expression.

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -10,18 +10,19 @@ the :ref:`DCP rules <dcp>` to mark expressions with a sign and curvature.
 Operators
 ---------
 
-The infix operators ``+, -, *, /`` are treated as functions. ``+`` and
-``-`` are affine functions. The expression ``expr1*expr2`` is affine in
+The infix operators ``+, -, *, /, @`` are treated as functions. The operators ``+`` and
+``-`` are always affine functions. The expression ``expr1*expr2`` is affine in
 CVXPY when one of the expressions is constant, and ``expr1/expr2`` is affine
 when ``expr2`` is a scalar constant.
 
-Note that in CVXPY, ``expr1 * expr2`` denotes matrix multiplication
-when ``expr1`` and ``expr2`` are matrices; if you're running Python 3,
-you can alternatively use the ``@`` operator for matrix multiplication.
-Regardless of your Python version, you can also use the function
-:ref:`matmul` to multiply
-two matrices. To multiply two arrays or matrices elementwise, use
-:ref:`multiply`.
+Historically, CVXPY has used ``expr1 * expr2`` to denote matrix multiplication.
+Starting with Python 3.5, users could also write ``expr1 @ expr2`` for
+matrix multiplication. As of CVXPY version 1.1, we are adopting a new standard:
+
+* ``@`` should be used for matrix-matrix and matrix-vector multiplication,
+* ``*`` should be matrix-scalar and vector-scalar multiplication
+
+Elementwise multiplication can be applied with the :ref:`multiply` function.
 
 
 Indexing and slicing

--- a/doc/source/tutorial/intro/index.rst
+++ b/doc/source/tutorial/intro/index.rst
@@ -167,7 +167,7 @@ vectors, or matrices, meaning they are 0, 1, or 2 dimensional.
 
 You can use your numeric library of choice to construct matrix and
 vector constants. For instance, if ``x`` is a CVXPY Variable in the
-expression ``A*x + b``, ``A`` and ``b`` could be Numpy ndarrays, SciPy
+expression ``A @ x + b``, ``A`` and ``b`` could be Numpy ndarrays, SciPy
 sparse matrices, etc. ``A`` and ``b`` could even be different types.
 
 Currently the following types may be used as constants:
@@ -194,7 +194,7 @@ Here's an example of a CVXPY problem with vectors and matrices:
 
     # Construct the problem.
     x = cp.Variable(n)
-    objective = cp.Minimize(cp.sum_squares(A*x - b))
+    objective = cp.Minimize(cp.sum_squares(A @ x - b))
     constraints = [0 <= x, x <= 1]
     prob = cp.Problem(objective, constraints)
 
@@ -280,7 +280,7 @@ computes a trade-off curve for a LASSO problem.
 
     # Construct the problem.
     x = cp.Variable(m)
-    error = cp.sum_squares(A*x - b)
+    error = cp.sum_squares(A @ x - b)
     obj = cp.Minimize(error + gamma*cp.norm(x, 1))
     prob = cp.Problem(obj)
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     zip_safe=False,
     description='A domain-specific language for modeling convex optimization '
                 'problems in Python.',
+    python_requires='>=3.5',
     install_requires=["osqp >= 0.4.1",
                       "ecos >= 2",
                       "scs >= 1.1.3",


### PR DESCRIPTION
The main motivation for this PR is to resolve #885. The basics of that change can be confined to ``cvxpy/expressions/expression.py:Expression``. However, once the deprecation warning was introduced, I thought it best to bring the rest of cvxpy code into compliance the the warning's recommendation. There were two ways to do this:
1. find offending instances of ``a * b``, and replace them with ``matmul(a, b)``, or
2. find offending instances of ``a * b``, and replace them with ``a @ b``.

I opted for the second of these. The most important thing to note about this decision is that it means cvxpy can't support python 3.4. At first I thought that was a big jump (we had previously only discussed dropping python 2.7), but the more I thought about it, it seemed like a better idea. Here are some key reasons that come to mind:

1. The Python Foundation dropped support for [python 3.4](https://www.python.org/downloads/release/python-3410/) in March of last year. Note: this happened 9 months *before* the Python Foundation dropped support for [python 2.7](https://www.python.org/doc/sunset-python-2/).
2. We don't run continuous integration tests with python 3.4, so we haven't been testing against it for a long time.
3. I don't think we've ever built a python 3.4 wheel or a conda distribution for cvxpy 1.x. The only way python 3.4 users get a hold of cvxpy 1.x is by installing from a source distribution.
4. Several unittests already used the ``@``operator. So we were already on a course to *effectively* drop support for python 3.4. This just makes it explicit.
5. Perhaps most importantly: I think it would be best to mark a big change like this as we shift from cvxpy 1.0 to cvxpy 1.1.

To help with this, I've done a pretty thorough job of changing not only cvxpy code, but also key documentation, and build files. Merging this PR (perhaps with minor modifications) would go a long way in setting us up for a clean release of version 1.1.