### PR TITLE
Enable shift-invert mode for finding small eigenvalues

### DIFF
--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -20,6 +20,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import scipy.sparse as sp
 import cvxpy
+from cvxpy.settings import EIGVAL_TOL
 import warnings
 
 from cvxpy.tests.base_test import BaseTest
@@ -132,6 +133,30 @@ class TestNonOptimal(BaseTest):
             prob.solve()
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
+
+    def test_psd_exactly_tolerance(self):
+        """Test that PSD check when eigenvalue is exactly -EIGVAL_TOL
+        """
+        P = np.array([[-EIGVAL_TOL, 0], [0, 10]])
+        x = cvxpy.Variable(2)
+        # Forming quad_form is okay
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cost = cvxpy.quad_form(x, P)
+        prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
+        prob.solve()
+
+    def test_nsd_exactly_tolerance(self):
+        """Test that NSD check when eigenvalue is exactly EIGVAL_TOL
+        """
+        P = np.array([[EIGVAL_TOL, 0], [0, -10]])
+        x = cvxpy.Variable(2)
+        # Forming quad_form is okay
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cost = cvxpy.quad_form(x, P)
+        prob = cvxpy.Problem(cvxpy.Maximize(cost), [x == [1, 2]])
+        prob.solve()
 
     def test_obj_eval(self):
         """Test case where objective evaluation differs from result.


### PR DESCRIPTION
Follow up from https://github.com/cvxgrp/cvxpy/issues/929#issuecomment-579972424

For eigenvalues with very small magnitude, scipy recommends using shift-invert mode to solve an equivalent eigenvalue problem with large magnitude eigenvalues: https://docs.scipy.org/doc/scipy/reference/tutorial/arpack.html#shift-invert-mode.

The motivation for this pull request is that I had run into PSD matrices in quadratic forms that had eigenvalues that were (according to eigsh) ~-5e-9, just outside the tolerance. Enabling shift-invert mode fixed the issue.