### PR TITLE
Symmetry checks for matrix atoms

### DIFF
--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -64,7 +64,7 @@ class lambda_max(Atom):
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError("The argument '%s' to lambda_max must resolve to a square matrix."
                              % self.args[0].name())
-        if not np.allclose(self.args[0].value, self.args[0].value.T, rtol=1e-03, atol=1e-04):
+        if not self.args[0].is_symmetric():
             raise ValueError("The argument '%s' to lambda_max must be symmetric."
                              % self.args[0].name())
 

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -64,6 +64,9 @@ class lambda_max(Atom):
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError("The argument '%s' to lambda_max must resolve to a square matrix."
                              % self.args[0].name())
+        if not np.allclose(self.args[0].value, self.args[0].value.T, rtol=1e-03, atol=1e-04):
+            raise ValueError("The argument '%s' to lambda_max must be symmetric."
+                             % self.args[0].name())
 
     def shape_from_args(self):
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -64,9 +64,6 @@ class lambda_max(Atom):
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError("The argument '%s' to lambda_max must resolve to a square matrix."
                              % self.args[0].name())
-        if not self.args[0].is_symmetric():
-            raise ValueError("The argument '%s' to lambda_max must be symmetric."
-                             % self.args[0].name())
 
     def shape_from_args(self):
         """Returns the (row, col) shape of the expression.
@@ -97,3 +94,11 @@ class lambda_max(Atom):
         """Is the composition non-increasing in argument idx?
         """
         return False
+
+    @property
+    def value(self):
+        if not np.allclose(self.args[0].value, self.args[0].value.T.conj()):
+            raise ValueError("Input matrix was not Hermitian/symmetric.")
+        if any([p.value is None for p in self.parameters()]):
+            return None
+        return self._value_impl()

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from scipy import linalg as LA
+import numpy as np
 from cvxpy.atoms.lambda_max import lambda_max
 from cvxpy.atoms.sum_largest import sum_largest
 

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from scipy import linalg as LA
+import numpy as np
 from cvxpy.atoms.lambda_max import lambda_max
 from cvxpy.atoms.sum_largest import sum_largest
 
@@ -34,6 +35,8 @@ class lambda_sum_largest(lambda_max):
         X = self.args[0]
         if not X.ndim == 2 or X.shape[0] != X.shape[1]:
             raise ValueError("First argument must be a square matrix.")
+        if not np.allclose(X.value, X.value.T, rtol=1e-03, atol=1e-04):
+            raise ValueError("First argument must be a symmetric matrix.")
         elif int(self.k) != self.k or self.k <= 0:
             raise ValueError("Second argument must be a positive integer.")
 

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 from scipy import linalg as LA
-import numpy as np
 from cvxpy.atoms.lambda_max import lambda_max
 from cvxpy.atoms.sum_largest import sum_largest
 
@@ -35,7 +34,7 @@ class lambda_sum_largest(lambda_max):
         X = self.args[0]
         if not X.ndim == 2 or X.shape[0] != X.shape[1]:
             raise ValueError("First argument must be a square matrix.")
-        if not np.allclose(X.value, X.value.T, rtol=1e-03, atol=1e-04):
+        if not X.is_symmetric():
             raise ValueError("First argument must be a symmetric matrix.")
         elif int(self.k) != self.k or self.k <= 0:
             raise ValueError("Second argument must be a positive integer.")

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -34,8 +34,6 @@ class lambda_sum_largest(lambda_max):
         X = self.args[0]
         if not X.ndim == 2 or X.shape[0] != X.shape[1]:
             raise ValueError("First argument must be a square matrix.")
-        if not X.is_symmetric():
-            raise ValueError("First argument must be a symmetric matrix.")
         elif int(self.k) != self.k or self.k <= 0:
             raise ValueError("Second argument must be a positive integer.")
 
@@ -64,3 +62,11 @@ class lambda_sum_largest(lambda_max):
             A list of SciPy CSC sparse matrices or None.
         """
         return NotImplemented
+
+    @property
+    def value(self):
+        if not np.allclose(self.args[0].value, self.args[0].value.T.conj()):
+            raise ValueError("Input matrix was not Hermitian/symmetric.")
+        if any([p.value is None for p in self.parameters()]):
+            return None
+        return self._value_impl()

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -42,9 +42,11 @@ class log_det(Atom):
 
     # Any argument shape is valid.
     def validate_arguments(self):
-        shape = self.args[0].shape
-        if len(shape) == 1 or shape[0] != shape[1]:
+        X = self.args[0]
+        if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to log_det must be a square matrix.")
+        if not np.allclose(X.value, X.value.T, rtol=1e-03, atol=1e-04):
+            raise ValueError("The argument must be a symmetric matrix.")
 
     def shape_from_args(self):
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -45,7 +45,7 @@ class log_det(Atom):
         X = self.args[0]
         if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to log_det must be a square matrix.")
-        if not np.allclose(X.value, X.value.T, rtol=1e-03, atol=1e-04):
+        if not X.is_symmetric():
             raise ValueError("The argument must be a symmetric matrix.")
 
     def shape_from_args(self):

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -45,8 +45,6 @@ class log_det(Atom):
         X = self.args[0]
         if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to log_det must be a square matrix.")
-        if not X.is_symmetric():
-            raise ValueError("The argument must be a symmetric matrix.")
 
     def shape_from_args(self):
         """Returns the (row, col) shape of the expression.
@@ -103,3 +101,11 @@ class log_det(Atom):
         """Returns constraints describing the domain of the node.
         """
         return [self.args[0] >> 0]
+
+    @property
+    def value(self):
+        if not np.allclose(self.args[0].value, self.args[0].value.T.conj()):
+            raise ValueError("Input matrix was not Hermitian/symmetric.")
+        if any([p.value is None for p in self.parameters()]):
+            return None
+        return self._value_impl()


### PR DESCRIPTION
Hi, I added symmetry checks for the arguments of some matrix atoms which require symmetric input (like @rileyjmurray suggested in issue #932). 