### PR TITLE
ExpCone and SOC testing. Bugfix for SOC axis settings.

### DIFF
--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
 import numpy as np
 
 
@@ -49,9 +50,10 @@ class ExpCone(Constraint):
     """
 
     def __init__(self, x, y, z, constr_id=None):
-        self.x = x
-        self.y = y
-        self.z = z
+        Expression = cvxtypes.expression()
+        self.x = Expression.cast_to_const(x)
+        self.y = Expression.cast_to_const(y)
+        self.z = Expression.cast_to_const(z)
         super(ExpCone, self).__init__([self.x, self.y, self.z],
                                       constr_id)
 

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
 import numpy as np
 
 
@@ -31,6 +32,7 @@ class SOC(Constraint):
     """
 
     def __init__(self, t, X, axis=0, constr_id=None):
+        t = cvxtypes.expression().cast_to_const(t)
         if len(t.shape) >= 2 or not t.is_real():
             raise ValueError("Invalid first argument.")
         # Check t has one entry per cone.

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -35,7 +35,8 @@ class SOC(Constraint):
             raise ValueError("Invalid first argument.")
         # Check t has one entry per cone.
         if (len(X.shape) <= 1 and t.size > 1) or \
-           (len(X.shape) == 2 and t.size != X.shape[1-axis]):
+           (len(X.shape) == 2 and t.size != X.shape[1-axis]) or \
+           (len(X.shape) == 1 and axis == 1):
             raise ValueError(
                 "Argument dimensions %s and %s, with axis=%i, are incompatible."
                 % (t.shape, X.shape, axis)
@@ -117,11 +118,11 @@ class SOC(Constraint):
         return self.is_dcp()
 
     def save_dual_value(self, value):
-        # TODO(akshaya,SteveDiamond): verify that reshaping below works correctly
         cone_size = 1 + self.args[1].shape[self.axis]
         value = np.reshape(value, newshape=(-1, cone_size))
         t = value[:, 0]
         X = value[:, 1:]
-        X = np.reshape(X, newshape=self.args[1].shape)
+        if self.axis == 0:
+            X = X.T
         self.dual_variables[0].save_value(t)
         self.dual_variables[1].save_value(X)

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/kl_div_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/kl_div_canon.py
@@ -24,6 +24,6 @@ def kl_div_canon(expr, args):
     x = promote(args[0], shape)
     y = promote(args[1], shape)
     t = Variable(shape)
-    constraints = [ExpCone(t, x, y), y >= 0]
+    constraints = [ExpCone(t, x, y)]
     obj = y - x - t
     return obj, constraints

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -252,16 +252,16 @@ def socp_1():
 def socp_2():
     """
     An (unnecessarily) SOCP-based reformulation of LP_1.
-    Doesn't use SOC objects.
     """
     x = cp.Variable(shape=(2,), name='x')
     objective = cp.Minimize(-4 * x[0] - 5 * x[1])
+    expr = cp.reshape(x[0] + 2 * x[1], (1, 1))
     constraints = [2 * x[0] + x[1] <= 3,
-                   (x[0] + 2 * x[1])**2 <= 3**2,
+                   cp.constraints.SOC(cp.Constant([3]), expr),
                    x[0] >= 0,
                    x[1] >= 0]
     con_pairs = [(constraints[0], 1),
-                 (constraints[1], 1.0/3.0),
+                 (constraints[1], [np.array([2.]), np.array([[-2.]])]),
                  (constraints[2], 0),
                  (constraints[3], 0)]
     var_pairs = [(x, np.array([1, 1]))]
@@ -270,7 +270,38 @@ def socp_2():
     return sth
 
 
-# TODO: add vectorized SOCP test cases (with different axis options)
+def socp_3(axis):
+    x = cp.Variable(shape=(2,))
+    c = np.array([-1, 2])
+    root2 = np.sqrt(2)
+    u = np.array([[1 / root2, -1 / root2], [1 / root2, 1 / root2]])
+    mat1 = np.diag([root2, 1 / root2]) @ u.T
+    mat2 = np.diag([1, 1])
+    mat3 = np.diag([0.2, 1.8])
+
+    X = cp.vstack([mat1 @ x, mat2 @ x, mat3 @ x])  # stack these as rows
+    t = cp.Constant(np.ones(3, ))
+    objective = cp.Minimize(c @ x)
+    if axis == 0:
+        con = cp.constraints.SOC(t, X.T, axis=0)
+        con_expect = [
+            np.array([0, 1.16454469e+00, 7.67560451e-01]),
+            np.array([[0, -9.74311819e-01, -1.28440860e-01],
+                      [0, 6.37872081e-01, 7.56737724e-01]])
+        ]
+    else:
+        con = cp.constraints.SOC(t, X, axis=1)
+        con_expect = [
+            np.array([0, 1.16454469e+00, 7.67560451e-01]),
+            np.array([[0, 0],
+                      [-9.74311819e-01, 6.37872081e-01],
+                      [-1.28440860e-01, 7.56737724e-01]])
+        ]
+    obj_pair = (objective, -1.932105)
+    con_pairs = [(con, con_expect)]
+    var_pairs = [(x, np.array([0.83666003, -0.54772256]))]
+    sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
+    return sth
 
 
 def sdp_1(objective_sense):
@@ -328,7 +359,37 @@ def expcone_1():
     return sth
 
 
-# TODO: add a vectorized exponential cone test case.
+def expcone_socp_1():
+    """
+    A random risk-parity portfolio optimization problem.
+    """
+    sigma = np.array([[1.83, 1.79, 3.22],
+                      [1.79, 2.18, 3.18],
+                      [3.22, 3.18, 8.69]])
+    L = np.linalg.cholesky(sigma)
+    c = 0.75
+    t = cp.Variable(name='t')
+    x = cp.Variable(shape=(3,), name='x')
+    s = cp.Variable(shape=(3,), name='s')
+    e = cp.Constant(np.ones(3, ))
+    objective = cp.Minimize(t - c * e @ s)
+    con1 = cp.norm(L.T @ x, p=2) <= t
+    con2 = cp.constraints.ExpCone(s, e, x)
+    # SolverTestHelper data
+    obj_pair = (objective, 4.0751197)
+    var_pairs = [
+        (x, np.array([0.576079, 0.54315, 0.28037])),
+        (s, np.array([-0.55150, -0.61036, -1.27161])),
+    ]
+    con_pairs = [
+        (con1, 1.0),
+        (con2, [np.array([-0.75, -0.75, -0.75]),
+                np.array([-1.16363, -1.20777, -1.70371]),
+                np.array([1.30190, 1.38082, 2.67496])]
+         )
+    ]
+    sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
+    return sth
 
 
 def mi_lp_0():
@@ -538,6 +599,24 @@ class StandardTestSOCPs(object):
         sth.verify_dual_values(places)
 
     @staticmethod
+    def test_socp_3ax0(solver, places=3, **kwargs):
+        sth = socp_3(axis=0)
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.verify_primal_values(places)
+        sth.check_complementarity(places)
+        sth.verify_dual_values(places)
+
+    @staticmethod
+    def test_socp_3ax1(solver, places=3, **kwargs):
+        sth = socp_3(axis=1)
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.verify_primal_values(places)
+        sth.check_complementarity(places)
+        sth.verify_dual_values(places)
+
+    @staticmethod
     def test_mi_socp_1(solver, places=4, **kwargs):
         sth = mi_socp_1()
         sth.solve(solver, **kwargs)
@@ -578,6 +657,17 @@ class StandardTestECPs(object):
     @staticmethod
     def test_expcone_1(solver, places=4, **kwargs):
         sth = expcone_1()
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.verify_dual_values(places)
+        sth.verify_primal_values(places)
+
+
+class StandardTestMixedCPs(object):
+
+    @staticmethod
+    def test_exp_soc_1(solver, places=3, **kwargs):
+        sth = expcone_socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_dual_values(places)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -22,6 +22,7 @@ import unittest
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.tests.solver_test_helpers import StandardTestECPs, StandardTestSDPs
 from cvxpy.tests.solver_test_helpers import StandardTestSOCPs, StandardTestLPs
+from cvxpy.tests.solver_test_helpers import StandardTestMixedCPs
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
 
 
@@ -96,8 +97,17 @@ class TestECOS(BaseTest):
     def test_ecos_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='ECOS')
 
+    def test_ecos_socp_3(self):
+        # axis 0
+        StandardTestSOCPs.test_socp_3ax0(solver='ECOS')
+        # axis 1
+        StandardTestSOCPs.test_socp_3ax1(solver='ECOS')
+
     def test_ecos_expcone_1(self):
         StandardTestECPs.test_expcone_1(solver='ECOS')
+
+    def test_ecos_exp_soc_1(self):
+        StandardTestMixedCPs.test_exp_soc_1(solver='ECOS')
 
 
 class TestSCS(BaseTest):
@@ -330,11 +340,20 @@ class TestSCS(BaseTest):
     def test_scs_socp_1(self):
         StandardTestSOCPs.test_socp_1(solver='SCS')
 
+    def test_scs_socp_3(self):
+        # axis 0
+        StandardTestSOCPs.test_socp_3ax0(solver='SCS')
+        # axis 1
+        StandardTestSOCPs.test_socp_3ax1(solver='SCS')
+
     def test_scs_sdp_1min(self):
         StandardTestSDPs.test_sdp_1min(solver='SCS')
 
     def test_scs_expcone_1(self):
         StandardTestECPs.test_expcone_1(solver='SCS')
+
+    def test_scs_exp_soc_1(self):
+        StandardTestMixedCPs.test_exp_soc_1(solver='SCS')
 
 
 @unittest.skipUnless('MOSEK' in INSTALLED_SOLVERS, 'MOSEK is not installed.')
@@ -367,6 +386,12 @@ class TestMosek(unittest.TestCase):
     def test_mosek_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='MOSEK')
 
+    def test_mosek_socp_3(self):
+        # axis 0
+        StandardTestSOCPs.test_socp_3ax0(solver='MOSEK')
+        # axis 1
+        StandardTestSOCPs.test_socp_3ax1(solver='MOSEK')
+
     def test_mosek_sdp_1(self):
         # minimization
         StandardTestSDPs.test_sdp_1min(solver='MOSEK')
@@ -375,6 +400,9 @@ class TestMosek(unittest.TestCase):
 
     def test_mosek_expcone_1(self):
         StandardTestECPs.test_expcone_1(solver='MOSEK')
+
+    def test_mosek_exp_soc_1(self):
+        StandardTestMixedCPs.test_exp_soc_1(solver='MOSEK')
 
     def test_mosek_mi_lp_0(self):
         StandardTestLPs.test_mi_lp_0(solver='MOSEK')
@@ -552,6 +580,12 @@ class TestCVXOPT(BaseTest):
 
     def test_cvxopt_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='CVXOPT')
+
+    def test_cvxopt_socp_3(self):
+        # axis 0
+        StandardTestSOCPs.test_socp_3ax0(solver='CVXOPT')
+        # axis 1
+        StandardTestSOCPs.test_socp_3ax1(solver='CVXOPT')
 
     def test_cvxopt_sdp_1(self):
         # minimization
@@ -784,10 +818,16 @@ class TestCPLEX(BaseTest):
         StandardTestSOCPs.test_socp_0(solver='CPLEX')
 
     def test_cplex_socp_1(self):
-        StandardTestSOCPs.test_socp_1(solver='CPLEX')
+        StandardTestSOCPs.test_socp_1(solver='CPLEX', places=2)
 
     def test_cplex_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='CPLEX')
+
+    def test_cplex_socp_3(self):
+        # axis 0
+        StandardTestSOCPs.test_socp_3ax0(solver='CPLEX')
+        # axis 1
+        StandardTestSOCPs.test_socp_3ax1(solver='CPLEX')
 
     def test_cplex_mi_lp_0(self):
         StandardTestLPs.test_mi_lp_0(solver='CPLEX')
@@ -914,6 +954,12 @@ class TestGUROBI(BaseTest):
     def test_gurobi_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='GUROBI')
 
+    def test_gurobi_socp_3(self):
+        # axis 0
+        StandardTestSOCPs.test_socp_3ax0(solver='GUROBI')
+        # axis 1
+        StandardTestSOCPs.test_socp_3ax1(solver='GUROBI')
+
     def test_gurobi_mi_lp_0(self):
         StandardTestLPs.test_mi_lp_0(solver='GUROBI')
 
@@ -924,7 +970,7 @@ class TestGUROBI(BaseTest):
         StandardTestLPs.test_mi_lp_2(solver='GUROBI')
 
     def test_gurobi_mi_socp_1(self):
-        StandardTestSOCPs.test_mi_socp_1(solver='GUROBI', places=3)
+        StandardTestSOCPs.test_mi_socp_1(solver='GUROBI', places=2)
 
     def test_gurobi_mi_socp_2(self):
         StandardTestSOCPs.test_mi_socp_2(solver='GUROBI')

--- a/cvxpy/tests/test_linear_cone.py
+++ b/cvxpy/tests/test_linear_cone.py
@@ -259,9 +259,6 @@ class TestLinearCone(BaseTest):
                                             var.value, places=1)
 
             # More complex.
-            # TODO CVXOPT fails here.
-            if solver.name() == 'CVXOPT':
-                return
             p = Problem(Minimize(self.b), [exp(self.a/2 + self.c) <= self.b+5,
                                            self.a >= 1, self.c >= 5])
             pmod = Problem(Minimize(self.b), [ExpCone(self.a/2 + self.c, Constant(1), self.b+5),


### PR DESCRIPTION
General issues resolved:
 * #936, by adding some dedicated tests for SOC constraints with the axis option. 
 * While implementing the above tests it became clear that SOC with axis=0 was not recovering dual variables properly. This is now fixed for most solvers (I'll elaborate on this below).
 * A standing TODO for ExpCone tests and vectorization.
 * SOC and ExpCone input casting to cvxpy Expressions.
 * A compilation inefficiency in ``kl_div_canon``. 

Details on SOC changes
------------------------

This PR modifies a test called ``socp_2`` and introduces a test called ``socp_3``.
* The modification to ``socp_2`` was to use ``SOC(expr2, expr1)`` in lieu of ``cp.norm(expr1) <= expr2``. The effect is that ``socp_2`` now meaningfully tests for conic dual variables, while before it did not.
* The test ``socp_3`` makes nontrivial use of the ``axis`` option for SOC objects.

Solvers ECOS, SCS, MOSEK, CVXOPT are passing this SOC test suite. GUROBI and CPLEX are not, because their interface files are not recovering conic dual variables properly. The issues with GUROBI and CPLEX interfaces were known (see #948 , #920 ), however before only ``socp_1`` failed. With the current suite of SOC tests, our GUROBI and CPLEX interface files fail for ``socp_1``, ``socp_2``, and ``socp_3`` -- all specifically because of dual variable issues.