### PR TITLE
Fix bug with RHS values in cplex_conif.py:add_model_soc_constr

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -444,10 +444,9 @@ class CPLEX(SCS):
             # Ignore empty constraints.
             if ind:
                 lin_expr_list.append((ind, val))
-                lin_rhs.append(vec[i])
             else:
                 lin_expr_list.append(None)
-                lin_rhs.append(0.0)
+            lin_rhs.append(vec[i])
 
         # Make a variable and equality constraint for each term.
         soc_vars, is_first = [], True


### PR DESCRIPTION
If the supporting linear equality constraint was empty, we were
setting the RHS to 0, but we should have been using the RHS given in
vec[i].

With this change, the test_cplex_socp_2 and test_cplex_socp_3 tests
should now pass. This is for #920.