### PR TITLE
[WIP] Add ParamQuadProg

### DIFF
--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -197,10 +197,8 @@ class Atom(Expression):
             return False
 
     @perf.compute_once
-    def is_dpp(self, context='CP'):
+    def is_dpp(self):
         """The expression is a disciplined parameterized expression.
-
-           context: cone program (CP) or quadratic program (QP)
         """
         with scopes.dpp_scope():
             return self.is_dcp()

--- a/cvxpy/problems/param_prob.py
+++ b/cvxpy/problems/param_prob.py
@@ -1,0 +1,44 @@
+"""
+Copyright 2013 Steven Diamond, 2017 Akshay Agrawal
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import abc
+
+
+class ParamProb(object):
+    """An abstract base class for parameterized problems.
+
+    Parameterized problems are produced during the first canonicalization
+    and allow canonicalization to be short-circuited for future solves.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractproperty
+    def is_mixed_integer(self):
+        """Is the problem mixed-integer?"""
+        return NotImplemented
+
+    @abc.abstractproperty
+    def apply_parameters(self, id_to_param_value=None, zero_offset=False,
+                         keep_zeros=False):
+        """Returns A, b after applying parameters (and reshaping).
+
+        Args:
+          id_to_param_value: (optional) dict mapping parameter ids to values
+          zero_offset: (optional) if True, zero out the constant offset in the
+                       parameter vector
+          keep_zeros: (optional) if True, store explicit zeros in A where
+                        parameters are affected
+        """
+        return NotImplemented

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -798,7 +798,7 @@ class Problem(u.Canonical):
                 param_deltas[parameter.id] = np.asarray(parameter.delta,
                                                         dtype=np.float64)
         dc, _, dA, db = param_prog.apply_parameters(param_deltas,
-                                                         zero_offset=True)
+                                                    zero_offset=True)
         dx, _, _ = D(-dA, db, dc)
         dvars = param_prog.split_solution(
             dx, [v.id for v in self.variables()])

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -19,6 +19,7 @@ from cvxpy.constraints import (Equality, ExpCone, Inequality,
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
+from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import InverseData, Solution, cvx_attr2constr
 from cvxpy.reductions.matrix_stuffing import extract_mip_idx, MatrixStuffing
 from cvxpy.reductions.utilities import (are_args_affine,
@@ -32,7 +33,7 @@ import scipy.sparse as sp
 
 
 # TODO(akshayka): unit tests
-class ParamConeProg(object):
+class ParamConeProg(ParamProb):
     """Represents a parameterized cone program
 
     minimize   c'x  + d
@@ -69,6 +70,7 @@ class ParamConeProg(object):
         self.formatted = formatted
 
     def is_mixed_integer(self):
+        """Is the problem mixed-integer?"""
         return self.x.attributes['boolean'] or \
             self.x.attributes['integer']
 

--- a/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
+++ b/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
@@ -138,10 +138,10 @@ class Dqcp2Dcp(Canonicalization):
         if isinstance(constr, Inequality):
             lhs_val = np.array(lhs.value)
             rhs_val = np.array(rhs.value)
-            if (lhs_val == -np.inf).all() or (rhs_val == np.inf).all():
+            if np.all(lhs_val == -np.inf) or np.all(rhs_val == np.inf):
                 # constraint is redundant
                 return [None]
-            elif (lhs_val == np.inf).any() or (rhs_val == -np.inf).any():
+            elif np.any(lhs_val == np.inf) or np.any(rhs_val == -np.inf):
                 return [s.INFEASIBLE]
 
         if constr.is_dcp():

--- a/cvxpy/reductions/inverse_data.py
+++ b/cvxpy/reductions/inverse_data.py
@@ -22,8 +22,8 @@ class InverseData(object):
 
     def __init__(self, problem):
         varis = problem.variables()
-        self.id_map, self.var_offsets, self.x_length, self.var_shapes = (
-                                                self.get_var_offsets(varis))
+        self.id_map, self.var_offsets, self.x_length, self.var_shapes = \
+            InverseData.get_var_offsets(varis)
 
         self.param_shapes = {}
         # Always start with CONSTANT_ID.
@@ -42,7 +42,8 @@ class InverseData(object):
         self.cons_id_map = dict()
         self.constraints = None
 
-    def get_var_offsets(self, variables):
+    @staticmethod
+    def get_var_offsets(variables):
         var_shapes = {}
         var_offsets = {}
         id_map = {}

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -99,8 +99,9 @@ class ParamQuadProg(object):
             tensor_application = self.P
         else:
             if sp.issparse(self.P):
-                param_vec = sp.csc_matrix(param_vec[:, None])
-            tensor_application = self.P @ param_vec
+                tensor_application = self.P @ sp.csc_matrix(param_vec[:, None])
+            else:
+                tensor_application = self.P @ param_vec
         P = tensor_application.reshape(
             (self.x.size, self.x.size), order='F').tocsc()
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -31,6 +31,15 @@ from cvxpy.utilities.coeff_extractor import CoeffExtractor
 import numpy as np
 
 
+
+# TODO: Implement parametric quadratic program
+class ParamQuadProg(object):
+    """Represents a parameterized quadratic program"""
+    pass
+
+
+
+
 class QpMatrixStuffing(MatrixStuffing):
     """Fills in numeric values for this problem instance.
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -236,7 +236,7 @@ class QpMatrixStuffing(MatrixStuffing):
 
         inverse_data.constraints = ordered_cons
         # Batch expressions together, then split apart.
-        expr_list = [arg for c in cons for arg in c.args]
+        expr_list = [arg for c in ordered_cons for arg in c.args]
         params_to_Ab = extractor.affine(expr_list)
 
         inverse_data.minimize = type(problem.objective) == Minimize

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -14,30 +14,159 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import problems
-from cvxpy.atoms import QuadForm, reshape
+from cvxpy.cvxcore.python import canonInterface
 from cvxpy.constraints import NonPos, Zero, Equality, Inequality
-from cvxpy.cvxcore.python import canonInterface as canon
-from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
-from cvxpy.reductions import Solution, InverseData
+from cvxpy.reductions import Solution, InverseData, cvx_attr2constr
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
 from cvxpy.reductions.matrix_stuffing import extract_mip_idx, MatrixStuffing
-from cvxpy.reductions.utilities import are_args_affine, lower_equality, lower_inequality
-import cvxpy.settings as s
+from cvxpy.reductions.utilities import (are_args_affine,
+                                        lower_equality,
+                                        lower_inequality,
+                                        group_constraints)
 from cvxpy.utilities.coeff_extractor import CoeffExtractor
-
+import cvxpy.settings as s
 import numpy as np
-
+import scipy.sparse as sp
 
 
 # TODO: Implement parametric quadratic program
 class ParamQuadProg(object):
-    """Represents a parameterized quadratic program"""
-    pass
+    """Represents a parameterized quadratic program.
+
+    minimize   x'Px  + q^Tx + d
+    subject to (in)equality_constr1(A_1*x + b_1, ...)
+               ...
+               (in)equality_constrK(A_i*x + b_i, ...)
 
 
+    The constant offsets d and b are the last column of c and A.
+    """
+    def __init__(self, P, q, x, A,
+                 variables,
+                 var_id_to_col,
+                 constraints,
+                 parameters,
+                 param_id_to_col,
+                 formatted=False):
+        self.P = P
+        self.q = q
+        self.x = x
+        self.A = A
+        self._A_mapping_nonzero = None
+        self.constraints = constraints
+        self.constr_size = sum([c.size for c in constraints])
+        self.parameters = parameters
+        self.param_id_to_col = param_id_to_col
+        self.id_to_param = {p.id: p for p in self.parameters}
+        self.param_id_to_size = {p.id: p.size for p in self.parameters}
+        self.total_param_size = sum([p.size for p in self.parameters])
+        # TODO technically part of inverse data.
+        self.variables = variables
+        self.var_id_to_col = var_id_to_col
+        self.id_to_var = {v.id: v for v in self.variables}
+        # whether this param cone prog has been formatted for a solver
+        self.formatted = formatted
+
+    def is_mixed_integer(self):
+        return self.x.attributes['boolean'] or \
+            self.x.attributes['integer']
+
+    def apply_parameters(self, id_to_param_value=None, zero_offset=False,
+                         keep_zeros=False):
+        """Returns A, b after applying parameters (and reshaping).
+
+        Args:
+          id_to_param_value: (optional) dict mapping parameter ids to values
+          zero_offset: (optional) if True, zero out the constant offset in the
+                       parameter vector
+          keep_zeros: (optional) if True, store explicit zeros in A where
+                        parameters are affected
+        """
+        def param_value(idx):
+            return (np.array(self.id_to_param[idx].value) if id_to_param_value
+                    is None else id_to_param_value[idx])
+        param_vec = canonInterface.get_parameter_vector(
+            self.total_param_size,
+            self.param_id_to_col,
+            self.param_id_to_size,
+            param_value,
+            zero_offset=zero_offset)
+        q, d = canonInterface.get_matrix_and_offset_from_tensor(
+            self.q, param_vec, self.x.size)
+        q = q.toarray().flatten()
+        if keep_zeros and self._A_mapping_nonzero is None:
+            self._A_mapping_nonzero = canonInterface.A_mapping_nonzero_rows(
+                self.A, self.x.size)
+        A, b = canonInterface.get_matrix_and_offset_from_tensor(
+            self.A, param_vec, self.x.size,
+            nonzero_rows=self._A_mapping_nonzero)
+        return q, d, A, np.atleast_1d(b)
+
+    def apply_param_jac(self, delP, delq, delA, delb, active_params=None):
+        """Multiplies by Jacobian of parameter mapping.
+
+        Assumes delA is sparse.
+
+        Returns:
+            A dictionary param.id -> dparam
+        """
+        if active_params is None:
+            active_params = {p.id for p in self.parameters}
+
+        del_param_vec = delq @ self.q[:-1]
+        flatdelA = delA.reshape((np.prod(delA.shape), 1), order='F')
+        delAb = sp.vstack([flatdelA, sp.csc_matrix(delb[:, None])])
+        del_param_vec += np.squeeze((delAb.T @ self.A).A)
+        del_param_vec = np.squeeze(del_param_vec)
+
+        param_id_to_delta_param = {}
+        for param_id, col in self.param_id_to_col.items():
+            if param_id in active_params:
+                param = self.id_to_param[param_id]
+                delta = del_param_vec[col:col + param.size]
+                param_id_to_delta_param[param_id] = np.reshape(
+                    delta, param.shape, order='F')
+        return param_id_to_delta_param
+
+    def split_solution(self, sltn, active_vars=None):
+        """Splits the solution into individual variables.
+        """
+        if active_vars is None:
+            active_vars = [v.id for v in self.variables]
+        # var id to solution.
+        sltn_dict = {}
+        for var_id, col in self.var_id_to_col.items():
+            if var_id in active_vars:
+                var = self.id_to_var[var_id]
+                value = sltn[col:var.size+col]
+                if var.attributes_were_lowered():
+                    orig_var = var.variable_of_provenance()
+                    value = cvx_attr2constr.recover_value_for_variable(
+                        orig_var, value, project=False)
+                    sltn_dict[orig_var.id] = np.reshape(
+                        value, orig_var.shape, order='F')
+                else:
+                    sltn_dict[var_id] = np.reshape(
+                        value, var.shape, order='F')
+        return sltn_dict
+
+    def split_adjoint(self, del_vars=None):
+        """Adjoint of split_solution.
+        """
+        var_vec = np.zeros(self.x.size)
+        for var_id, delta in del_vars.items():
+            var = self.id_to_var[var_id]
+            col = self.var_id_to_col[var_id]
+            if var.attributes_were_lowered():
+                orig_var = var.variable_of_provenance()
+                if cvx_attr2constr.attributes_present(
+                        [orig_var], cvx_attr2constr.SYMMETRIC_ATTRIBUTES):
+                    delta = delta + delta.T - np.diag(np.diag(delta))
+                delta = cvx_attr2constr.lower_value(orig_var, delta)
+            var_vec[col:col + var.size] = delta.flatten(order='F')
+        return var_vec
 
 
 class QpMatrixStuffing(MatrixStuffing):
@@ -64,22 +193,21 @@ class QpMatrixStuffing(MatrixStuffing):
     def stuffed_objective(self, problem, extractor):
         # extract to x.T * P * x + q.T * x + r
         expr = problem.objective.expr.copy()
-        P, q, r = extractor.quad_form(expr)
+        P, q = extractor.quad_form(expr)
 
         # concatenate all variables in one vector
         boolean, integer = extract_mip_idx(problem.variables())
         x = Variable(extractor.x_length, boolean=boolean, integer=integer)
-        new_obj = QuadForm(x, P) + q.T @ x
 
-        return new_obj, x, r
+        return P, q, x
 
     def apply(self, problem):
         """See docstring for MatrixStuffing.apply"""
         inverse_data = InverseData(problem)
         # Form the constraints
         extractor = CoeffExtractor(inverse_data)
-        new_obj, new_var, r = self.stuffed_objective(problem, extractor)
-        inverse_data.r = r
+        params_to_P, params_to_q, flattened_variable = self.stuffed_objective(
+            problem, extractor)
         # Lower equality and inequality to Zero and NonPos.
         cons = []
         for con in problem.constraints:
@@ -89,30 +217,26 @@ class QpMatrixStuffing(MatrixStuffing):
                 con = lower_inequality(con)
             cons.append(con)
 
+        # Reorder constraints to Zero, NonPos.
+        constr_map = group_constraints(cons)
+        ordered_cons = constr_map[Zero] + constr_map[NonPos]
+        inverse_data.cons_id_map = {con.id: con.id for con in ordered_cons}
+
+        inverse_data.constraints = ordered_cons
         # Batch expressions together, then split apart.
         expr_list = [arg for c in cons for arg in c.args]
-        problem_data_tensor = extractor.affine(expr_list)
-        Afull, bfull = canon.get_matrix_and_offset_from_unparameterized_tensor(
-            problem_data_tensor, new_var.size)
-        if 0 not in Afull.shape and 0 not in bfull.shape:
-            Afull = cvxtypes.constant()(Afull)
-            bfull = cvxtypes.constant()(np.atleast_1d(bfull))
+        params_to_Ab = extractor.affine(expr_list)
 
-        new_cons = []
-        offset = 0
-        for orig_con, con in zip(problem.constraints, cons):
-            arg_list = []
-            for arg in con.args:
-                A = Afull[offset:offset+arg.size, :]
-                b = bfull[offset:offset+arg.size]
-                arg_list.append(reshape(A @ new_var + b, arg.shape))
-                offset += arg.size
-            new_constraint = con.copy(arg_list)
-            new_cons.append(new_constraint)
-
-        inverse_data.constraints = new_cons
         inverse_data.minimize = type(problem.objective) == Minimize
-        new_prob = problems.problem.Problem(Minimize(new_obj), new_cons)
+        new_prob = ParamQuadProg(params_to_P,
+                                 params_to_q,
+                                 flattened_variable,
+                                 params_to_Ab,
+                                 problem.variables(),
+                                 inverse_data.var_offsets,
+                                 ordered_cons,
+                                 problem.parameters(),
+                                 inverse_data.param_id_map)
         return new_prob, inverse_data
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -18,6 +18,7 @@ from cvxpy.cvxcore.python import canonInterface
 from cvxpy.constraints import NonPos, Zero, Equality, Inequality
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
+from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import Solution, InverseData
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
 from cvxpy.reductions.matrix_stuffing import extract_mip_idx, MatrixStuffing
@@ -31,7 +32,7 @@ import numpy as np
 import scipy.sparse as sp
 
 
-class ParamQuadProg(object):
+class ParamQuadProg(ParamProb):
     """Represents a parameterized quadratic program.
 
     minimize   x'Px  + q^Tx + d
@@ -69,6 +70,7 @@ class ParamQuadProg(object):
         self.formatted = formatted
 
     def is_mixed_integer(self):
+        """Is the problem mixed-integer?"""
         return self.x.attributes['boolean'] or \
             self.x.attributes['integer']
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -203,9 +203,11 @@ class QpMatrixStuffing(MatrixStuffing):
                 and problem.is_dpp())
 
     def stuffed_objective(self, problem, extractor):
-        # extract to x.T * P * x + q.T * x + r
+        # extract to 0.5 * x.T * P * x + q.T * x + r
         expr = problem.objective.expr.copy()
         P, q = extractor.quad_form(expr)
+        # Handle 0.5 factor.
+        P = 2*P
 
         # concatenate all variables in one vector
         boolean, integer = extract_mip_idx(problem.variables())

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -444,10 +444,9 @@ class CPLEX(SCS):
             # Ignore empty constraints.
             if ind:
                 lin_expr_list.append((ind, val))
-                lin_rhs.append(vec[i])
             else:
                 lin_expr_list.append(None)
-                lin_rhs.append(0.0)
+            lin_rhs.append(vec[i])
 
         # Make a variable and equality constraint for each term.
         soc_vars, is_first = [], True

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -51,7 +51,8 @@ class CPLEX(QpSolver):
 
         if status in s.SOLUTION_PRESENT:
             # Get objective value
-            opt_val = model.solution.get_objective_value()
+            opt_val = model.solution.get_objective_value() + \
+                inverse_data[s.OFFSET]
 
             # Get solution
             x = np.array(model.solution.get_values())

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -44,7 +44,7 @@ class CPLEX(QpSolver):
             attr[s.SOLVE_TIME] = results["cputime"]
         attr[s.NUM_ITERS] = \
             int(model.solution.progress.get_num_barrier_iterations()) \
-            if not inverse_data.is_mip \
+            if not inverse_data[CPLEX.IS_MIP] \
             else 0
 
         status = get_status(model)
@@ -56,13 +56,13 @@ class CPLEX(QpSolver):
             # Get solution
             x = np.array(model.solution.get_values())
             primal_vars = {
-                list(inverse_data.id_map.keys())[0]:
+                CPLEX.VAR_ID:
                 intf.DEFAULT_INTF.const_to_matrix(np.array(x))
             }
 
             # Only add duals if not a MIP.
             dual_vars = None
-            if not inverse_data.is_mip:
+            if not inverse_data[CPLEX.IS_MIP]:
                 y = -np.array(model.solution.get_dual_values())
                 dual_vars = {CPLEX.DUAL_VAR_ID: y}
 

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -67,13 +67,13 @@ class GUROBI(QpSolver):
             x = np.array([x_grb[i].X for i in range(n)])
 
             primal_vars = {
-                list(inverse_data.id_map.keys())[0]:
+                GUROBI.VAR_ID:
                 intf.DEFAULT_INTF.const_to_matrix(np.array(x))
             }
 
             # Only add duals if not a MIP.
             dual_vars = None
-            if not inverse_data.is_mip:
+            if not inverse_data[GUROBI.IS_MIP]:
                 y = -np.array([constraints_grb[i].Pi for i in range(m)])
                 dual_vars = {GUROBI.DUAL_VAR_ID: y}
 

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -63,7 +63,7 @@ class GUROBI(QpSolver):
         status = self.STATUS_MAP.get(model.Status, s.SOLVER_ERROR)
 
         if status in s.SOLUTION_PRESENT:
-            opt_val = model.objVal
+            opt_val = model.objVal + inverse_data[s.OFFSET]
             x = np.array([x_grb[i].X for i in range(n)])
 
             primal_vars = {

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -44,9 +44,9 @@ class OSQP(QpSolver):
         data['n_eq'] = data[QpSolver.DIMS].zero
         data['n_ineq'] = data[QpSolver.DIMS].nonpos
 
-        data[s.P] = sp.csc_matrix(P)
+        data[s.P] = P
         data[s.Q] = q
-        data[s.A] = sp.csc_matrix(A)
+        data[s.A] = A
         data[s.B] = -b
 
         return data, inv_data

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -27,6 +27,30 @@ class OSQP(QpSolver):
         import osqp
         osqp
 
+    def apply(self, problem):
+        """
+        Construct QP problem data stored in a dictionary.
+        The QP has the following form
+
+            minimize      1/2 x' P x + q' x
+            subject to    A x =  b
+                          F x <= g
+
+        """
+        problem, data, inv_data = self._prepare_data_and_inv_data(problem)
+
+        P, q, d, A, b = problem.apply_parameters()
+        inv_data[s.OFFSET] = d
+        data['n_eq'] = data[QpSolver.DIMS].zero
+        data['n_ineq'] = data[QpSolver.DIMS].nonpos
+
+        data[s.P] = sp.csc_matrix(P)
+        data[s.Q] = q
+        data[s.A] = sp.csc_matrix(A)
+        data[s.B] = -b
+
+        return data, inv_data
+
     def invert(self, solution, inverse_data):
         attr = {s.SOLVE_TIME: solution.info.run_time}
 
@@ -54,11 +78,11 @@ class OSQP(QpSolver):
         import osqp
         P = data[s.P]
         q = data[s.Q]
-        A = sp.vstack([data[s.A], data[s.F]]).tocsc()
-        data['full_A'] = A
-        uA = np.concatenate((data[s.B], data[s.G]))
+        A = data[s.A]
+        uA = data[s.B]
         data['u'] = uA
-        lA = np.concatenate([data[s.B], -np.inf*np.ones(data[s.G].shape)])
+        lA = np.concatenate([data[s.B][:data['n_eq']],
+                             -np.inf*np.ones(data['n_ineq'])])
         data['l'] = lA
 
         # Overwrite defaults eps_abs=eps_rel=1e-3, max_iter=4000
@@ -72,9 +96,9 @@ class OSQP(QpSolver):
             same_pattern = (P.shape == old_data[s.P].shape and
                             all(P.indptr == old_data[s.P].indptr) and
                             all(P.indices == old_data[s.P].indices)) and \
-                           (A.shape == old_data['full_A'].shape and
-                            all(A.indptr == old_data['full_A'].indptr) and
-                            all(A.indices == old_data['full_A'].indices))
+                           (A.shape == old_data[s.A].shape and
+                            all(A.indptr == old_data[s.A].indptr) and
+                            all(A.indices == old_data[s.A].indices))
         else:
             same_pattern = False
 
@@ -89,7 +113,7 @@ class OSQP(QpSolver):
                 P_triu = sp.triu(P).tocsc()
                 new_args['Px'] = P_triu.data
                 factorizing = True
-            if any(A.data != old_data['full_A'].data):
+            if any(A.data != old_data[s.A].data):
                 new_args['Ax'] = A.data
                 factorizing = True
 

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -34,7 +34,7 @@ class OSQP(QpSolver):
         status = self.STATUS_MAP.get(solution.info.status_val, s.SOLVER_ERROR)
 
         if status in s.SOLUTION_PRESENT:
-            opt_val = solution.info.obj_val
+            opt_val = solution.info.obj_val + inverse_data[s.OFFSET]
             primal_vars = {
                 OSQP.VAR_ID:
                 intf.DEFAULT_INTF.const_to_matrix(np.array(solution.x))

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -36,7 +36,7 @@ class OSQP(QpSolver):
         if status in s.SOLUTION_PRESENT:
             opt_val = solution.info.obj_val
             primal_vars = {
-                list(inverse_data.id_map.keys())[0]:
+                OSQP.VAR_ID:
                 intf.DEFAULT_INTF.const_to_matrix(np.array(solution.x))
             }
             dual_vars = {OSQP.DUAL_VAR_ID: solution.y}

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -111,6 +111,5 @@ class QpSolver(Solver):
         data['n_var'] = n
         data['n_eq'] = A.shape[0]
         data['n_ineq'] = F.shape[0]
-        print(data)
 
         return data, inv_data

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -111,5 +111,6 @@ class QpSolver(Solver):
         data['n_var'] = n
         data['n_eq'] = A.shape[0]
         data['n_ineq'] = F.shape[0]
+        print(data)
 
         return data, inv_data

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -73,9 +73,6 @@ class QpSolver(Solver):
 
         P, q, d, AF, bg = problem.apply_parameters()
         inv_data[s.OFFSET] = d
-        # quadratic part of objective is x.T * P * x but solvers expect
-        # 0.5*x.T * P * x.
-        P = 2*P
 
         # Get number of variables
         n = problem.x.size

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -14,68 +14,52 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from cvxpy.reductions.cvx_attr2constr import convex_attributes
+from cvxpy.constraints import NonPos, Zero
+from cvxpy.reductions.solvers.solver import Solver, ConeDims
+from cvxpy.reductions.utilities import group_constraints
+from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import ParamQuadProg
+import cvxpy.settings as s
 import numpy as np
 import scipy.sparse as sp
-
-from cvxpy.atoms.affine.add_expr import AddExpression
-from cvxpy.atoms.affine.binary_operators import MulExpression
-from cvxpy.atoms.affine.reshape import reshape as reshape_atom
-from cvxpy.atoms.quad_form import QuadForm
-from cvxpy.constraints import NonPos, Zero
-from cvxpy.problems.objective import Minimize
-from cvxpy.reductions import InverseData
-from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.reductions.utilities import are_args_affine
-import cvxpy.settings as s
-
-
-def is_stuffed_qp_objective(objective):
-    """QPSolver requires objectives to be stuffed in the following way.
-    """
-    expr = objective.expr
-    return (type(expr) == AddExpression
-            and len(expr.args) == 2
-            and type(expr.args[0]) == QuadForm
-            and type(expr.args[1]) == MulExpression
-            and expr.args[1].is_affine())
-
-
-def get_coeff_offset(expr):
-    """Return the coefficient A and offset b in A*x + b.
-    Args:
-      expr: A CVXPY expression.
-    Returns:
-      (SciPy COO sparse matrix, NumPy 1D array)
-    """
-    # May be a reshape as root.
-    if type(expr) == reshape_atom:
-        expr = expr.args[0]
-    # Convert data to float64.
-    if len(expr.args[0].args) == 0:
-        # expr is c.T*x
-        offset = 0
-        coeff = expr.args[0].value.astype(np.float64)
-    else:
-        # expr is c.T*x + d
-        offset = expr.args[1].value.ravel().astype(np.float64)
-        coeff = expr.args[0].args[0].value.astype(np.float64)
-    # Convert scalars to sparse matrices.
-    if np.isscalar(coeff):
-        coeff = sp.coo_matrix(([coeff], ([0], [0])), shape=(1, 1))
-    return (coeff, offset)
 
 
 class QpSolver(Solver):
     """
     A QP solver interface.
     """
+    # Every QP solver supports Zero and NonPos constraints.
+    SUPPORTED_CONSTRAINTS = [Zero, NonPos]
+
+    # Some solvers cannot solve problems that do not have constraints.
+    # For such solvers, REQUIRES_CONSTR should be set to True.
+    REQUIRES_CONSTR = False
 
     def accepts(self, problem):
-        return (type(problem.objective) == Minimize
-                and is_stuffed_qp_objective(problem.objective)
-                and all(type(c) == Zero or type(c) == NonPos
-                        for c in problem.constraints)
-                and are_args_affine(problem.constraints))
+        return (isinstance(problem, ParamQuadProg)
+                and (self.MIP_CAPABLE or not problem.is_mixed_integer())
+                and not convex_attributes([problem.x])
+                and (len(problem.constraints) > 0 or not self.REQUIRES_CONSTR)
+                and all(type(c) in self.SUPPORTED_CONSTRAINTS for c in
+                        problem.constraints))
+
+    def _prepare_data_and_inv_data(self, problem):
+        data = {}
+        inv_data = {self.VAR_ID: problem.x.id}
+
+        constr_map = group_constraints(problem.constraints)
+        data[QpSolver.DIMS] = ConeDims(constr_map)
+        inv_data[QpSolver.DIMS] = data[QpSolver.DIMS]
+        zero_constr = constr_map[Zero]
+        neq_constr = constr_map[NonPos]
+        inv_data[QpSolver.EQ_CONSTR] = zero_constr
+        inv_data[QpSolver.NEQ_CONSTR] = neq_constr
+
+        # Add information about integer variables
+        inv_data['MIP'] = problem.is_mixed_integer()
+
+        data[s.PARAM_PROB] = problem
+        return problem, data, inv_data
 
     def apply(self, problem):
         """
@@ -87,18 +71,17 @@ class QpSolver(Solver):
                           F x <= g
 
         """
-        inverse_data = InverseData(problem)
+        problem, data, inv_data = self._prepare_data_and_inv_data(problem)
 
-        obj = problem.objective
+        P, q, d, A, b = problem.apply_parameters()
+        inv_data[s.OFFSET] = d
         # quadratic part of objective is x.T * P * x but solvers expect
         # 0.5*x.T * P * x.
-        P = 2*obj.expr.args[0].args[1].value
-        q = obj.expr.args[1].args[0].value.flatten()
+        P = 2*P
 
         # Get number of variables
-        n = problem.size_metrics.num_scalar_variables
+        n = x.size
 
-        eq_cons = [c for c in problem.constraints if type(c) == Zero]
         if eq_cons:
             eq_coeffs = list(zip(*[get_coeff_offset(con.expr)
                                    for con in eq_cons]))
@@ -117,7 +100,6 @@ class QpSolver(Solver):
             F, g = sp.csr_matrix((0, n)), -np.array([])
 
         # Create dictionary with problem data
-        variables = problem.variables()[0]
         data = {}
         data[s.P] = sp.csc_matrix(P)
         data[s.Q] = q
@@ -125,16 +107,10 @@ class QpSolver(Solver):
         data[s.B] = b
         data[s.F] = sp.csc_matrix(F)
         data[s.G] = g
-        data[s.BOOL_IDX] = [t[0] for t in variables.boolean_idx]
-        data[s.INT_IDX] = [t[0] for t in variables.integer_idx]
+        data[s.BOOL_IDX] = [t[0] for t in problem.x.boolean_idx]
+        data[s.INT_IDX] = [t[0] for t in problem.x.integer_idx]
         data['n_var'] = n
         data['n_eq'] = A.shape[0]
         data['n_ineq'] = F.shape[0]
-
-        inverse_data.sorted_constraints = eq_cons + ineq_cons
-
-        # Add information about integer variables
-        inverse_data.is_mip = \
-            len(data[s.BOOL_IDX]) > 0 or len(data[s.INT_IDX]) > 0
 
         return data, inverse_data

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -52,10 +52,6 @@ class QpSolver(Solver):
         constr_map = group_constraints(problem.constraints)
         data[QpSolver.DIMS] = ConeDims(constr_map)
         inv_data[QpSolver.DIMS] = data[QpSolver.DIMS]
-        zero_constr = constr_map[Zero]
-        neq_constr = constr_map[NonPos]
-        inv_data[QpSolver.EQ_CONSTR] = zero_constr
-        inv_data[QpSolver.NEQ_CONSTR] = neq_constr
 
         # Add information about integer variables
         inv_data[QpSolver.IS_MIP] = problem.is_mixed_integer()

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -35,6 +35,8 @@ class QpSolver(Solver):
     # For such solvers, REQUIRES_CONSTR should be set to True.
     REQUIRES_CONSTR = False
 
+    IS_MIP = "IS_MIP"
+
     def accepts(self, problem):
         return (isinstance(problem, ParamQuadProg)
                 and (self.MIP_CAPABLE or not problem.is_mixed_integer())
@@ -56,7 +58,7 @@ class QpSolver(Solver):
         inv_data[QpSolver.NEQ_CONSTR] = neq_constr
 
         # Add information about integer variables
-        inv_data['MIP'] = problem.is_mixed_integer()
+        inv_data[QpSolver.IS_MIP] = problem.is_mixed_integer()
 
         data[s.PARAM_PROB] = problem
         return problem, data, inv_data

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -15,12 +15,72 @@ limitations under the License.
 """
 
 import abc
+from cvxpy.constraints import SOC, ExpCone, NonPos, PSD, Zero
 from cvxpy.reductions.reduction import Reduction
+import cvxpy.settings as s
+
+
+class ConeDims(object):
+    """Summary of cone dimensions present in constraints.
+
+    Constraints must be formatted as dictionary that maps from
+    constraint type to a list of constraints of that type.
+
+    Attributes
+    ----------
+    zero : int
+        The dimension of the zero cone.
+    nonpos : int
+        The dimension of the non-positive cone.
+    exp : int
+        The dimension of the exponential cone.
+    soc : list of int
+        A list of the second-order cone dimensions.
+    psd : list of int
+        A list of the positive semidefinite cone dimensions, where the
+        dimension of the PSD cone of k by k matrices is k.
+    """
+    def __init__(self, constr_map):
+        self.zero = int(sum(c.size for c in constr_map[Zero]))
+        self.nonpos = int(sum(c.size for c in constr_map[NonPos]))
+        self.exp = int(sum(c.num_cones() for c in constr_map[ExpCone]))
+        self.soc = [int(dim) for c in constr_map[SOC] for dim in c.cone_sizes()]
+        self.psd = [int(c.shape[0]) for c in constr_map[PSD]]
+
+    def __repr__(self):
+        return "(zero: {0}, nonpos: {1}, exp: {2}, soc: {3}, psd: {4})".format(
+            self.zero, self.nonpos, self.exp, self.soc, self.psd)
+
+    def __str__(self):
+        """String representation.
+        """
+        return ("%i equalities, %i inequalities, %i exponential cones, \n"
+                "SOC constraints: %s, PSD constraints: %s.") % (self.zero,
+                                                                self.nonpos,
+                                                                self.exp,
+                                                                self.soc,
+                                                                self.psd)
+
+    def __getitem__(self, key):
+        if key == s.EQ_DIM:
+            return self.zero
+        elif key == s.LEQ_DIM:
+            return self.nonpos
+        elif key == s.EXP_DIM:
+            return self.exp
+        elif key == s.SOC_DIM:
+            return self.soc
+        elif key == s.PSD_DIM:
+            return self.psd
+        else:
+            raise KeyError(key)
 
 
 class Solver(Reduction):
     """Generic interface for a solver that uses reduction semantics
     """
+    # The key that maps to ConeDims in the data returned by apply().
+    DIMS = "dims"
 
     __metaclass__ = abc.ABCMeta
 

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -33,7 +33,7 @@ class ConeDims(object):
     nonpos : int
         The dimension of the non-positive cone.
     exp : int
-        The dimension of the exponential cone.
+        The number of 3-dimensional exponential cones
     soc : list of int
         A list of the second-order cone dimensions.
     psd : list of int

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -145,6 +145,15 @@ def construct_solving_chain(problem, candidates, gp=False):
         return SolvingChain(reductions=[ConstantSolver()])
     reductions = _reductions_for_problem_class(problem, candidates, gp)
 
+    if not problem.is_dpp():
+        warnings.warn(
+            "You are solving a parameterized problem that is not DPP. "
+            "Because the problem is not DPP, subsequent solves will not be "
+            "faster than the first one.")
+        reductions += [EvalParams()]
+    elif any(param.is_complex() for param in problem.parameters()):
+        reductions += [EvalParams()]
+
     # Conclude with matrix stuffing; choose one of the following paths:
     #   (1) QpMatrixStuffing --> [a QpSolver],
     #   (2) ConeMatrixStuffing --> [a ConicSolver]
@@ -162,15 +171,6 @@ def construct_solving_chain(problem, candidates, gp=False):
         raise SolverError("Problem could not be reduced to a QP, and no "
                           "conic solvers exist among candidate solvers "
                           "(%s)." % candidates)
-
-    if not problem.is_dpp():
-        warnings.warn(
-            "You are solving a parameterized problem that is not DPP. "
-            "Because the problem is not DPP, subsequent solves will not be "
-            "faster than the first one.")
-        reductions += [EvalParams()]
-    elif any(param.is_complex() for param in problem.parameters()):
-        reductions += [EvalParams()]
 
     # Our choice of solver depends upon which atoms are present in the
     # problem. The types of atoms to check for are SOC atoms, PSD atoms,

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -153,8 +153,6 @@ def construct_solving_chain(problem, candidates, gp=False):
         solver = sorted(candidates['qp_solvers'],
                         key=lambda s: slv_def.QP_SOLVERS.index(s))[0]
         solver_instance = slv_def.SOLVER_MAP_QP[solver]
-        # TODO remove when QPs can handle parameters.
-        reductions += [EvalParams()]
         reductions += [QpMatrixStuffing(),
                        solver_instance]
         return SolvingChain(reductions=reductions)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -818,7 +818,13 @@ class TestCPLEX(BaseTest):
         StandardTestSOCPs.test_socp_0(solver='CPLEX')
 
     def test_cplex_socp_1(self):
-        StandardTestSOCPs.test_socp_1(solver='CPLEX', places=2)
+        # Parameters are set due to a minor dual-variable related
+        # presolve bug in CPLEX, which will be fixed in the next
+        # CPLEX release.
+        StandardTestSOCPs.test_socp_1(solver='CPLEX', places=2,
+                                      cplex_params={
+                                          "preprocessing.presolve": 0,
+                                          "preprocessing.reduce": 2})
 
     def test_cplex_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='CPLEX')

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -102,6 +102,7 @@ class CoeffExtractor(object):
         extractor = CoeffExtractor(affine_inverse_data)
         param_coeffs = extractor.affine(affine_problem.objective.expr)
 
+        # TODO how to figure out length of parameter vector/map in global parameter map?
         coeff_list = []
         constant = param_coeffs[-1, :]
         for p in range(param_coeffs.shape[1]):
@@ -191,7 +192,7 @@ class CoeffExtractor(object):
                 raise RuntimeError("Constant must be a scalar")
 
             P_size = P.shape[0]*P.shape[1]
-            P_list.append(P.reshape((P_size, 1)))
+            P_list.append(P.reshape((P_size, 1), order='F'))
             q_list.append(q)
 
         # Stitch together Ps and qs and constant.

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -103,7 +103,7 @@ class CoeffExtractor(object):
                                                          self.param_id_map,
                                                          affine_expr.size)
 
-        # TODO how to figure out length of parameter vector/map in global parameter map?
+        # TODO vectorize this code.
         coeff_list = []
         constant = param_coeffs[-1, :]
         for p in range(param_coeffs.shape[1]):


### PR DESCRIPTION
Work in progress to add parametric QPs.

Things needed:
- [x] Fix `CoeffExtractor.quad_form` and `CoeffExtractor.extract_quadratic_coeffs` from [coeff_extractor.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/utilities/coeff_extractor.py) (the most important step)
- [x] Add `ParamQuadProg` in [qp_matrix_stuffing.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py) to mimic `ConeQuadProg` in [cone_matrix_stuffing.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py) while using `Q` matrix as well
- [x] Adapt `QpMatrixStuffing` class from [qp_matrix_stuffing.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py) to return `ParamQuadProg`. Always mimic [cone_matrix_stuffing.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py)


I think the easiest way to define quad forms in DPP is to keep them as `sum_squares(S @ x)` where `S` is a matrix in `R`. This might make the first step way easier.