### PR TITLE
Expose the transpose atom

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -67,6 +67,7 @@ from cvxpy.atoms.affine.real import real
 from cvxpy.atoms.affine.reshape import reshape, deep_flatten
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
+from cvxpy.atoms.affine.transpose import transpose
 from cvxpy.atoms.affine.upper_tri import upper_tri
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.atoms.affine.vstack import vstack


### PR DESCRIPTION
Previously, transpose was only exported via the `T` method on the Expression class. This exposes the `transpose` atom under the `cvxpy` namespace. (So a user can write `cp.transpose(expr)` if they want to.)

Fixes #964