### PR TITLE
[DGP] Fix quad_over_lin canon

### DIFF
--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/quad_over_lin_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/quad_over_lin_canon.py
@@ -1,6 +1,8 @@
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.add_canon import add_canon
 from cvxpy.reductions.dgp2dcp.util import explicit_sum
 
 
 def quad_over_lin_canon(expr, args):
-    numerator = explicit_sum(2 * args[0])
+    summed = explicit_sum(2 * args[0])
+    numerator, _ = add_canon(summed, summed.args)
     return numerator - args[1], []

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -525,6 +525,17 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(h.value, np.array([2, 2]))
         np.testing.assert_almost_equal(w.value, np.array([5, 5]))
 
+    def test_sum_squares_vector(self):
+        w = cvxpy.Variable(2, pos=True)
+        h = cvxpy.Variable(2, pos=True)
+        problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum_squares(h)),
+                                [cvxpy.multiply(w, h) >= 10,
+                                cvxpy.sum(w) <= 10])
+        problem.solve(SOLVER, gp=True)
+        np.testing.assert_almost_equal(problem.value, 8)
+        np.testing.assert_almost_equal(h.value, np.array([2, 2]))
+        np.testing.assert_almost_equal(w.value, np.array([5, 5]))
+
     def test_sum_matrix(self):
         w = cvxpy.Variable((2, 2), pos=True)
         h = cvxpy.Variable((2, 2), pos=True)


### PR DESCRIPTION
The quad_over_lin canon was previously missing a transformation. Because
the sum_squares atom is implemented using quad_over_lin, this lead to
errors when the sum_squares atom was used in a DGP program.

Issue #982 surfaced this problem.