### PR TITLE
[DGP] Always eval params

### DIFF
--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -564,3 +564,12 @@ class TestDgp2Dcp(BaseTest):
         dgp2dcp = cvxpy.reductions.Dgp2Dcp(dgp)
         dcp = dgp2dcp.reduce()
         self.assertAlmostEqual(dcp.parameters()[0].value, np.log(param.value))
+
+        x = cvxpy.Variable(pos=True)
+        problem = cvxpy.Problem(cvxpy.Minimize(x), [x == param])
+        problem.solve(SOLVER, gp=True)
+        self.assertAlmostEqual(problem.value, 1.0)
+
+        param.value = 2.0
+        problem.solve(SOLVER, gp=True)
+        self.assertAlmostEqual(problem.value, 2.0)


### PR DESCRIPTION
Evaluate parameters when solving log-log convex programs. DGP requires a
specialized DPP ruleset to ensure the corresponding DCP program is
DCP. We haven't worked that ruleset out yet, so for now always evaluate the
parameters.