### PR TITLE
[DGP] Propagate Parameter names in Dgp2Dcp

### DIFF
--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/parameter_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/parameter_canon.py
@@ -21,6 +21,6 @@ import numpy as np
 
 def parameter_canon(expr, args):
     del args
-    param = Parameter(expr.shape, name=expr.name)
+    param = Parameter(expr.shape, name=expr.name())
     param.value = np.log(expr.value)
     return param, []

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -573,3 +573,11 @@ class TestDgp2Dcp(BaseTest):
         param.value = 2.0
         problem.solve(SOLVER, gp=True)
         self.assertAlmostEqual(problem.value, 2.0)
+
+    def test_parameter_name(self):
+        param = cvxpy.Parameter(pos=True, name='alpha')
+        param.value = 1.0
+        dgp = cvxpy.Problem(cvxpy.Minimize(param), [])
+        dgp2dcp = cvxpy.reductions.Dgp2Dcp(dgp)
+        dcp = dgp2dcp.reduce()
+        self.assertAlmostEqual(dcp.parameters()[0].name(), 'alpha')


### PR DESCRIPTION
Parameters in a DGP problem are converted into new parameters in a DCP
problem, via Dgp2Dcp. Before this change, the names of the original parameters
were not properly propagated to the new parameters, leading to an error when
the DCP problem was printed. Users don't interact with the output of
Dgp2Dcp directly, but this bug showed up during internal testing.

Note that the code path in parameter_canon.py is not currently exercised by problem.solve(), since we evaluate parameters for DGP problems as of ed5dd6a355f3c4dae3de385f25b9925a878b9ac2. However, I'd like to eventually (maybe soon) support DPP for DGP problems, so I'm keeping this code around instead of deleting it.

Riley or Steven, a review from just one of you should be fine. It's a very small change.