### PR TITLE
a test for cvxcore overflows (and other minor changes)

### DIFF
--- a/cvxpy/cvxcore/src/ProblemData.hpp
+++ b/cvxpy/cvxcore/src/ProblemData.hpp
@@ -77,9 +77,9 @@ public:
   /**
    * Returns the data vector V as a contiguous 1D numpy array.
    */
-  void getV(double *values, int num_values) {
+  void getV(double *values, long num_values) {
     std::vector<double> V = TensorV[param_id][vec_idx];
-    for (int i = 0; i < num_values; i++) {
+    for (long i = 0; i < num_values; i++) {
       values[i] = V[i];
     }
   }
@@ -87,9 +87,9 @@ public:
   /**
    * Returns the row index vector I as a contiguous 1D numpy array.
    */
-  void getI(double *values, int num_values) {
+  void getI(double *values, long num_values) {
     std::vector<int> I = TensorI[param_id][vec_idx];
-    for (int i = 0; i < num_values; i++) {
+    for (long i = 0; i < num_values; i++) {
       values[i] = I[i];
     }
   }
@@ -97,9 +97,9 @@ public:
   /**
    * Returns the column index vector J as a contiguous 1D numpy array.
    */
-  void getJ(double *values, int num_values) {
+  void getJ(double *values, long num_values) {
     std::vector<int> J = TensorJ[param_id][vec_idx];
-    for (int i = 0; i < num_values; i++) {
+    for (long i = 0; i < num_values; i++) {
       values[i] = J[i];
     }
   }

--- a/cvxpy/cvxcore/src/ProblemData.hpp
+++ b/cvxpy/cvxcore/src/ProblemData.hpp
@@ -77,9 +77,9 @@ public:
   /**
    * Returns the data vector V as a contiguous 1D numpy array.
    */
-  void getV(double *values, long num_values) {
+  void getV(double *values, int num_values) {
     std::vector<double> V = TensorV[param_id][vec_idx];
-    for (long i = 0; i < num_values; i++) {
+    for (int i = 0; i < num_values; i++) {
       values[i] = V[i];
     }
   }
@@ -87,9 +87,9 @@ public:
   /**
    * Returns the row index vector I as a contiguous 1D numpy array.
    */
-  void getI(double *values, long num_values) {
+  void getI(double *values, int num_values) {
     std::vector<int> I = TensorI[param_id][vec_idx];
-    for (long i = 0; i < num_values; i++) {
+    for (int i = 0; i < num_values; i++) {
       values[i] = I[i];
     }
   }
@@ -97,9 +97,9 @@ public:
   /**
    * Returns the column index vector J as a contiguous 1D numpy array.
    */
-  void getJ(double *values, long num_values) {
+  void getJ(double *values, int num_values) {
     std::vector<int> J = TensorJ[param_id][vec_idx];
-    for (long i = 0; i < num_values; i++) {
+    for (int i = 0; i < num_values; i++) {
       values[i] = J[i];
     }
   }

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -191,7 +191,7 @@ class ConicSolver(Solver):
             Semidefinite cone: (A, b) such that A * x <=_{SDP} b,
 
         The CVXPY standard for the exponential cone is:
-            K_e = closure{(x,y,z) |  y >= z * exp(x/z), z>0}.
+            K_e = closure{(x,y,z) |  z >= y * exp(x/y), y>0}.
         Whenever a solver uses this convention, EXP_CONE_ORDER should be
         [0, 1, 2].
 

--- a/cvxpy/tests/ram_limited.py
+++ b/cvxpy/tests/ram_limited.py
@@ -35,12 +35,12 @@ def issue826():
     # constraint matrix) to have at most 2^(32)-1 nonzero entries.
     #
     # This test is for checking that #826 is resolved.
-    n = 2**3
+    n = 2**8
     m = int(2 ** 32 / n) + 1
 
     vals = np.arange(m*n, dtype=np.double) / 1000.0
-    A = vals.reshape(m, n)
-    x = cp.Variable(shape=(n,))
+    A = vals.reshape(n, m)
+    x = cp.Variable(shape=(m,))
     cons = [A @ x >= 0]
     prob = cp.Problem(cp.Maximize(0), cons)
     data = prob.get_problem_data(solver='SCS')

--- a/cvxpy/tests/ram_limited.py
+++ b/cvxpy/tests/ram_limited.py
@@ -1,0 +1,60 @@
+"""
+Copyright 2020, the CVXPY developers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import unittest
+import cvxpy as cp
+import numpy as np
+
+"""
+This file contains tests which require massive amounts of RAM.
+
+The tests might be for benchmarking CVXPY compile time,
+or checking correctness of canonicalization.
+
+The tests here are run on a case-by-case basis by CVXPY developers.
+"""
+
+
+def issue826():
+    # In GitHub issue #826, it was discovered that cvxcore's C++
+    # implementation implicitly limited problem data (such as a
+    # constraint matrix) to have at most 2^(32)-1 nonzero entries.
+    #
+    # This test is for checking that #826 is resolved.
+    n = 1
+    m = int(2 ** 32 / n) + 1
+
+    vals = np.arange(m*n, dtype=np.double) / 1000.0
+    A = vals.reshape(m, n)
+    x = cp.Variable(shape=(n,))
+    cons = [A @ x >= 0]
+    prob = cp.Problem(cp.Maximize(0), cons)
+    data = prob.get_problem_data(solver='SCS')
+    vals_canon = data[0]['A'].data
+
+    tester = unittest.TestCase()
+    diff = vals - vals_canon
+    err = np.abs(diff)
+    tester.assertLessEqual(err, 1e-3)
+
+
+if __name__ == '__main__':
+    for arg in sys.argv[1:]:
+        if arg == 'issue826':
+            issue826()
+        else:
+            print('Unknown argument:\n\t' + arg)

--- a/cvxpy/tests/ram_limited.py
+++ b/cvxpy/tests/ram_limited.py
@@ -35,7 +35,7 @@ def issue826():
     # constraint matrix) to have at most 2^(32)-1 nonzero entries.
     #
     # This test is for checking that #826 is resolved.
-    n = 1
+    n = 2**3
     m = int(2 ** 32 / n) + 1
 
     vals = np.arange(m*n, dtype=np.double) / 1000.0
@@ -50,11 +50,17 @@ def issue826():
     diff = vals - vals_canon
     err = np.abs(diff)
     tester.assertLessEqual(err, 1e-3)
+    print('\t issue826 test finished')
 
 
 if __name__ == '__main__':
-    for arg in sys.argv[1:]:
-        if arg == 'issue826':
-            issue826()
-        else:
-            print('Unknown argument:\n\t' + arg)
+    if len(sys.argv) > 1:
+        for arg in sys.argv[1:]:
+            if arg == 'issue826':
+                print('Start issue826 test')
+                issue826()
+            else:
+                print('Unknown argument:\n\t' + arg)
+    else:
+        print('Start issue826 test')
+        issue826()

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -741,7 +741,13 @@ class TestCPLEX(BaseTest):
         StandardTestSOCPs.test_socp_0(solver='CPLEX')
 
     def test_cplex_socp_1(self):
-        StandardTestSOCPs.test_socp_1(solver='CPLEX', places=2)
+        # Parameters are set due to a minor dual-variable related
+        # presolve bug in CPLEX, which will be fixed in the next
+        # CPLEX release.
+        StandardTestSOCPs.test_socp_1(solver='CPLEX', places=2,
+                                      cplex_params={
+                                          "preprocessing.presolve": 0,
+                                          "preprocessing.reduce": 2})
 
     def test_cplex_socp_2(self):
         StandardTestSOCPs.test_socp_2(solver='CPLEX')

--- a/cvxpy/tests/test_curvature.py
+++ b/cvxpy/tests/test_curvature.py
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import unittest
 from cvxpy import log
 from cvxpy import Constant, Variable
 from cvxpy.settings import UNKNOWN, QUASILINEAR
-from nose.tools import assert_equals
 
 
-class TestCurvature(object):
+class TestCurvature(unittest.TestCase):
     """ Unit tests for the expression/curvature class. """
-    @classmethod
-    def setup_class(self):
+
+    def setUp(self):
         self.cvx = Variable()**2
         self.ccv = Variable()**0.5
         self.aff = Variable()
@@ -36,32 +36,32 @@ class TestCurvature(object):
         self.unknown_sign = self.pos + self.neg
 
     def test_add(self):
-        assert_equals((self.const + self.cvx).curvature, self.cvx.curvature)
-        assert_equals((self.unknown_curv + self.ccv).curvature, UNKNOWN)
-        assert_equals((self.cvx + self.ccv).curvature, UNKNOWN)
-        assert_equals((self.cvx + self.cvx).curvature, self.cvx.curvature)
-        assert_equals((self.aff + self.ccv).curvature, self.ccv.curvature)
+        self.assertEqual((self.const + self.cvx).curvature, self.cvx.curvature)
+        self.assertEqual((self.unknown_curv + self.ccv).curvature, UNKNOWN)
+        self.assertEqual((self.cvx + self.ccv).curvature, UNKNOWN)
+        self.assertEqual((self.cvx + self.cvx).curvature, self.cvx.curvature)
+        self.assertEqual((self.aff + self.ccv).curvature, self.ccv.curvature)
 
     def test_sub(self):
-        assert_equals((self.const - self.cvx).curvature, self.ccv.curvature)
-        assert_equals((self.unknown_curv - self.ccv).curvature, UNKNOWN)
-        assert_equals((self.cvx - self.ccv).curvature, self.cvx.curvature)
-        assert_equals((self.cvx - self.cvx).curvature, UNKNOWN)
-        assert_equals((self.aff - self.ccv).curvature, self.cvx.curvature)
+        self.assertEqual((self.const - self.cvx).curvature, self.ccv.curvature)
+        self.assertEqual((self.unknown_curv - self.ccv).curvature, UNKNOWN)
+        self.assertEqual((self.cvx - self.ccv).curvature, self.cvx.curvature)
+        self.assertEqual((self.cvx - self.cvx).curvature, UNKNOWN)
+        self.assertEqual((self.aff - self.ccv).curvature, self.cvx.curvature)
 
     def test_sign_mult(self):
-        assert_equals((self.zero * self.cvx).curvature, self.aff.curvature)
-        assert_equals((self.neg*self.cvx).curvature, self.ccv.curvature)
-        assert_equals((self.neg*self.ccv).curvature, self.cvx.curvature)
-        assert_equals((self.neg*self.unknown_curv).curvature, QUASILINEAR)
-        assert_equals((self.pos*self.aff).curvature, self.aff.curvature)
-        assert_equals((self.pos*self.ccv).curvature, self.ccv.curvature)
-        assert_equals((self.unknown_sign*self.const).curvature, self.const.curvature)
-        assert_equals((self.unknown_sign*self.ccv).curvature, UNKNOWN)
+        self.assertEqual((self.zero * self.cvx).curvature, self.aff.curvature)
+        self.assertEqual((self.neg*self.cvx).curvature, self.ccv.curvature)
+        self.assertEqual((self.neg*self.ccv).curvature, self.cvx.curvature)
+        self.assertEqual((self.neg*self.unknown_curv).curvature, QUASILINEAR)
+        self.assertEqual((self.pos*self.aff).curvature, self.aff.curvature)
+        self.assertEqual((self.pos*self.ccv).curvature, self.ccv.curvature)
+        self.assertEqual((self.unknown_sign*self.const).curvature, self.const.curvature)
+        self.assertEqual((self.unknown_sign*self.ccv).curvature, UNKNOWN)
 
     def test_neg(self):
-        assert_equals((-self.cvx).curvature, self.ccv.curvature)
-        assert_equals((-self.aff).curvature, self.aff.curvature)
+        self.assertEqual((-self.cvx).curvature, self.ccv.curvature)
+        self.assertEqual((-self.aff).curvature, self.aff.curvature)
 
     # Tests the is_affine, is_convex, and is_concave methods
     def test_is_curvature(self):


### PR DESCRIPTION
@SteveDiamond following our slack thread, here's a PR containing a test to cause a cvxcore overflow error. I created a new file within ``cvxpy/tests`` which won't be discovered by automatic testing suites. The intention is that we execute that file with command line arguments only when necessary. The current file contains a test which takes about 100GB RAM; the overflow happens in Eigen. To see what's going on in Eigen you're going to need to execute the python test script within GDB, and make sure cvxcore was built without GCC compiler optimizations (change line 50 of setup.py to use flag ``"-O0"``).

[One of these commits](https://github.com/cvxgrp/cvxpy/commit/2698c33f2641a53e75c8cc274d1c416a777ae665) modified ``cvxpy/cvxcore/src/ProblemData.hpp``. Our normal test suite passed after those changes, and those changes did seem to address the ``int`` vs ``long`` issue in ``getI``, ``getJ``, ``getV`` from #826. However, the changes didn't actually help with the Eigen error mentioned above. Since I'd rather not mess with cvxcore without good reason, I rolled those changes back.

Other changes:
 *  ``test_curvature.py`` to resolve deprecation warnings.
 * CPLEX tests, in keeping with #920.
 * an incorrect docstring regarding the exponential cone.