### PR TITLE
Require NumPy >= 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ os:
 env:
   matrix:
     - DISTRIB="conda" PYTHON_VERSION="3.5" CVXOPT="true"
-      NUMPY_VERSION="1.15" SCIPY_VERSION="1.1.0"
+      NUMPY_VERSION="1.16" SCIPY_VERSION="1.1.0"
       COVERAGE="false"
       DEPLOY_PYPI_SOURCE="False"
     - DISTRIB="conda" PYTHON_VERSION="3.6" CVXOPT="true"
-      NUMPY_VERSION="1.15" SCIPY_VERSION="1.1.0"
+      NUMPY_VERSION="1.16" SCIPY_VERSION="1.1.0"
       COVERAGE="false"
       DEPLOY_PYPI_SOURCE="True"
     - DISTRIB="conda" PYTHON_VERSION="3.7" CVXOPT="true"
-      NUMPY_VERSION="1.15" SCIPY_VERSION="1.1.0"
+      NUMPY_VERSION="1.16" SCIPY_VERSION="1.1.0"
       COVERAGE="false"
       DEPLOY_PYPI_SOURCE="False"
 sudo: required

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     install_requires=["osqp >= 0.4.1",
                       "ecos >= 2",
                       "scs >= 1.1.3",
-                      "numpy >= 1.15",
+                      "numpy >= 1.16",
                       "scipy >= 1.1.0"],
     setup_requires=["numpy >= 1.15"],
 )


### PR DESCRIPTION
Issue #968 revealed that on some platforms, CVXPY requires NumPy >= 1.16.