### PR TITLE
[DGP] Fix canonicalization of eye_minus_inv atom

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -23,7 +23,7 @@ from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
 from cvxpy.atoms.affine.reshape import deep_flatten
-from cvxpy.atoms import conj
+from cvxpy.atoms.affine.conj import conj
 from cvxpy.expressions.constants.parameter import is_param_affine, is_param_free
 from cvxpy.error import DCPError
 import cvxpy.lin_ops.lin_utils as lu

--- a/cvxpy/atoms/one_minus_pos.py
+++ b/cvxpy/atoms/one_minus_pos.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.atoms.affine.binary_operators import multiply
 import numpy as np
 import scipy.sparse as sp
 
@@ -31,7 +32,7 @@ def diff_pos(x, y):
     y : :class:`~cvxpy.expressions.expression.Expression`
         An Expression.
     """
-    return x * one_minus_pos(y/x)
+    return multiply(x, one_minus_pos(y/x))
 
 
 class one_minus_pos(Atom):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/eye_minus_inv_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/eye_minus_inv_canon.py
@@ -1,15 +1,39 @@
 from cvxpy.atoms.affine.binary_operators import matmul
+from cvxpy.atoms.affine.diag import diag
+from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.one_minus_pos_canon import one_minus_pos_canon
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import mulexpression_canon
-import numpy as np
 
 
 def eye_minus_inv_canon(expr, args):
     X = args[0]
-    # (I - X)^{-1} \leq T iff there exists 0 <= Y <= T s.t.  YX + Y <= Y
-    # Y represents log Y here, hence no positivity constraint
-    Y = Variable(X.shape)
-    prod = matmul(Y, X)
-    lhs, _ = mulexpression_canon(prod, prod.args)
-    lhs += np.eye(prod.shape[0])
-    return Y, [lhs <= Y]
+
+    # (I - X)^{-1} \leq T iff there exists 0 <= Y <= T s.t.  YX + I <= Y
+    #
+    # This function implements the log-log transformation of these constraints
+    #
+    # We can't use I in DGP, because it has zeros (we'd need to take its log).
+    #
+    # Instead, the constraint can be written as
+    #     diag(diff_pos(Y - YX)) >= 1,
+    # or, canonicalized,
+    #     lhs_canon >= 0.
+    #
+    # Here, U = \log Y.
+    U = Variable(X.shape)
+
+    # Canonicalization of diag(diff_pos(Y - YX))
+    #
+    # Note
+    #     Y - YX = Y \hadamard (\ones\ones^T - YX/Y) =
+    #            = Y \hadamard one_minus_pos(YX/Y),
+    # and
+    #    Y \hadamard one_minus_pos(YX/Y) canonicalizes to
+    #    U + one_minus_pos_canon(YX_canon - Y_canon)
+    YX = matmul(U, X)
+    YX_canon, _ = mulexpression_canon(YX, YX.args)
+    one_minus = one_minus_pos(YX_canon - U)
+    canon, _ = one_minus_pos_canon(one_minus, one_minus.args)
+    lhs_canon = diag(U + canon)
+    return U, [lhs_canon >= 0]

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -434,10 +434,22 @@ class TestDgp2Dcp(BaseTest):
     def test_paper_example_eye_minus_inv(self):
         X = cvxpy.Variable((2, 2), pos=True)
         obj = cvxpy.Minimize(cvxpy.trace(cvxpy.eye_minus_inv(X)))
-        constr = [cvxpy.geo_mean(cvxpy.diag(X)) == 0.1]
+        constr = [cvxpy.geo_mean(cvxpy.diag(X)) == 0.1,
+                  cvxpy.geo_mean(cvxpy.hstack([X[0, 1], X[1, 0]])) == 0.1]
         problem = cvxpy.Problem(obj, constr)
-        # smoke test.
         problem.solve(gp=True, solver="ECOS")
+        np.testing.assert_almost_equal(X.value, 0.1*np.ones((2, 2)), decimal=3)
+        self.assertAlmostEqual(problem.value, 2.25)
+
+    def test_simpler_eye_minus_inv(self):
+        X = cvxpy.Variable((2, 2), pos=True)
+        obj = cvxpy.Minimize(cvxpy.trace(cvxpy.eye_minus_inv(X)))
+        constr = [cvxpy.diag(X) == 0.1,
+                  cvxpy.hstack([X[0, 1], X[1, 0]]) == 0.1]
+        problem = cvxpy.Problem(obj, constr)
+        problem.solve(gp=True, solver="ECOS")
+        np.testing.assert_almost_equal(X.value, 0.1*np.ones((2, 2)), decimal=3)
+        self.assertAlmostEqual(problem.value, 2.25)
 
     def test_paper_example_exp_log(self):
         x = cvxpy.Variable(pos=True)


### PR DESCRIPTION
The canonicalization of eye_minus_inv was previously incorrect. This was
discovered during internal testing. A test is added to ensure that
checks for correctness of the canonicalization.