### PR TITLE
QP Solvers Fixes

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -516,6 +516,7 @@ class Problem(u.Canonical):
                     if param in old_params_to_new_params:
                         old_params_to_new_params[param].value = np.log(
                             param.value)
+
             data, solver_inverse_data = solving_chain.solver.apply(
                 self._cache.param_prog)
             inverse_data = self._cache.inverse_data + [solver_inverse_data]

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -33,9 +33,8 @@ class GUROBI(QpSolver):
                   6: s.INFEASIBLE,
                   7: s.SOLVER_ERROR,
                   8: s.SOLVER_ERROR,
+                  9: s.USER_LIMIT,  # Maximum time expired
                   # TODO could be anything.
-                  # means time expired.
-                  9: s.SOLVER_ERROR,
                   10: s.SOLVER_ERROR,
                   11: s.SOLVER_ERROR,
                   12: s.SOLVER_ERROR,
@@ -62,7 +61,7 @@ class GUROBI(QpSolver):
         # Map GUROBI statuses back to CVXPY statuses
         status = self.STATUS_MAP.get(model.Status, s.SOLVER_ERROR)
 
-        if status in s.SOLUTION_PRESENT:
+        if (status in s.SOLUTION_PRESENT) or (model.solCount > 0):
             opt_val = model.objVal + inverse_data[s.OFFSET]
             x = np.array([x_grb[i].X for i in range(n)])
 

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -34,7 +34,7 @@ class OSQP(QpSolver):
         # Map OSQP statuses back to CVXPY statuses
         status = self.STATUS_MAP.get(solution.info.status_val, s.SOLVER_ERROR)
 
-        if status in s.SOLUTION_PRESENT + [s.USER_LIMIT]:
+        if status in s.SOLUTION_PRESENT:
             opt_val = solution.info.obj_val + inverse_data[s.OFFSET]
             primal_vars = {
                 OSQP.VAR_ID:

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -17,6 +17,7 @@ class OSQP(QpSolver):
                   3: s.INFEASIBLE_INACCURATE,
                   -4: s.UNBOUNDED,
                   4: s.UNBOUNDED_INACCURATE,
+                  -6: s.USER_LIMIT,
                   -5: s.SOLVER_ERROR,           # Interrupted by user
                   -10: s.SOLVER_ERROR}          # Unsolved
 
@@ -33,7 +34,7 @@ class OSQP(QpSolver):
         # Map OSQP statuses back to CVXPY statuses
         status = self.STATUS_MAP.get(solution.info.status_val, s.SOLVER_ERROR)
 
-        if status in s.SOLUTION_PRESENT:
+        if status in s.SOLUTION_PRESENT + [s.USER_LIMIT]:
             opt_val = solution.info.obj_val + inverse_data[s.OFFSET]
             primal_vars = {
                 OSQP.VAR_ID:

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -27,30 +27,6 @@ class OSQP(QpSolver):
         import osqp
         osqp
 
-    def apply(self, problem):
-        """
-        Construct QP problem data stored in a dictionary.
-        The QP has the following form
-
-            minimize      1/2 x' P x + q' x
-            subject to    A x =  b
-                          F x <= g
-
-        """
-        problem, data, inv_data = self._prepare_data_and_inv_data(problem)
-
-        P, q, d, A, b = problem.apply_parameters()
-        inv_data[s.OFFSET] = d
-        data['n_eq'] = data[QpSolver.DIMS].zero
-        data['n_ineq'] = data[QpSolver.DIMS].nonpos
-
-        data[s.P] = P
-        data[s.Q] = q
-        data[s.A] = A
-        data[s.B] = -b
-
-        return data, inv_data
-
     def invert(self, solution, inverse_data):
         attr = {s.SOLVE_TIME: solution.info.run_time}
 
@@ -78,11 +54,11 @@ class OSQP(QpSolver):
         import osqp
         P = data[s.P]
         q = data[s.Q]
-        A = data[s.A]
-        uA = data[s.B]
+        A = sp.vstack([data[s.A], data[s.F]]).tocsc()
+        data['full_A'] = A
+        uA = np.concatenate((data[s.B], data[s.G]))
         data['u'] = uA
-        lA = np.concatenate([data[s.B][:data['n_eq']],
-                             -np.inf*np.ones(data['n_ineq'])])
+        lA = np.concatenate([data[s.B], -np.inf*np.ones(data[s.G].shape)])
         data['l'] = lA
 
         # Overwrite defaults eps_abs=eps_rel=1e-3, max_iter=4000

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -92,7 +92,6 @@ class QpSolver(Solver):
             F, g = sp.csr_matrix((0, n)), -np.array([])
 
         # Create dictionary with problem data
-        data = {}
         data[s.P] = sp.csc_matrix(P)
         data[s.Q] = q
         data[s.A] = sp.csc_matrix(A)

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -41,12 +41,12 @@ UNBOUNDED_INACCURATE = "unbounded_inaccurate"
 USER_LIMIT = "user_limit"
 SOLVER_ERROR = "solver_error"
 # Statuses that indicate a solution was found.
-SOLUTION_PRESENT = [OPTIMAL, OPTIMAL_INACCURATE]
+SOLUTION_PRESENT = [OPTIMAL, OPTIMAL_INACCURATE, USER_LIMIT]
 # Statuses that indicate the problem is infeasible or unbounded.
 INF_OR_UNB = [INFEASIBLE, INFEASIBLE_INACCURATE,
               UNBOUNDED, UNBOUNDED_INACCURATE]
 # Statuses that indicate an error.
-ERROR = [USER_LIMIT, SOLVER_ERROR]
+ERROR = [SOLVER_ERROR]
 
 # Solver names.
 CVXOPT = "CVXOPT"

--- a/cvxpy/tests/test_param_quad_prog.py
+++ b/cvxpy/tests/test_param_quad_prog.py
@@ -1,0 +1,72 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import math
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.defines import QP_SOLVERS, INSTALLED_SOLVERS
+from cvxpy.tests.base_test import BaseTest
+
+import numpy as np
+
+
+class TestParamQuadProg(BaseTest):
+
+    def setUp(self):
+        self.solvers = [x for x in QP_SOLVERS if x in INSTALLED_SOLVERS]
+
+    # Overridden method to assume lower accuracy.
+    def assertItemsAlmostEqual(self, a, b, places=2):
+        super(TestParamQuadProg, self).assertItemsAlmostEqual(a, b, places=places)
+
+    # Overridden method to assume lower accuracy.
+    def assertAlmostEqual(self, a, b, places=2):
+        super(TestParamQuadProg, self).assertAlmostEqual(a, b, places=places)
+
+    def test_qp_problem(self):
+        for solver in self.solvers:
+            m = 30
+            n = 20
+            A = np.random.randn(m, n)
+            b = np.random.randn(m)
+            x = cp.Variable(n)
+            gamma = cp.Parameter(nonneg=True)
+            gamma.value = .5
+            objective = cp.Minimize(cp.sum_squares(A @ x - b) + gamma * cp.norm(x, 1))
+            constraints = [0 <= x, x <= 1]
+
+            # Solve from scratch
+            problem = cp.Problem(objective, constraints)
+            problem.solve(solver=solver)
+            x_full = np.copy(x.value)
+
+            # Restore cached values
+            solving_chain = problem._cache.solving_chain
+            solver = problem._cache.solving_chain.solver
+            inverse_data = problem._cache.inverse_data
+            param_prog = problem._cache.param_prog
+
+            # Solve parametric
+            data, solver_inverse_data = solving_chain.solver.apply(param_prog)
+            inverse_data = inverse_data + [solver_inverse_data]
+            raw_solution = solver.solve_via_data(
+                    data, warm_start=False, verbose=False, solver_opts={})
+            problem.unpack_results(raw_solution, solving_chain, inverse_data)
+            x_param = np.copy(x.value)
+
+            self.assertItemsAlmostEqual(x_param, x_full)
+
+
+        # TODO: Add derivatives and adjoint tests

--- a/cvxpy/tests/test_param_quad_prog.py
+++ b/cvxpy/tests/test_param_quad_prog.py
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import math
-
 import cvxpy as cp
 from cvxpy.reductions.solvers.defines import QP_SOLVERS, INSTALLED_SOLVERS
 from cvxpy.tests.base_test import BaseTest
@@ -67,6 +65,5 @@ class TestParamQuadProg(BaseTest):
             x_param = np.copy(x.value)
 
             self.assertItemsAlmostEqual(x_param, x_full)
-
 
         # TODO: Add derivatives and adjoint tests


### PR DESCRIPTION
I have made a few fixes for the QP solvers.

These are quite standard:
- The `apply` function in the `QpSolver` class was rewriting the `data` dict and, therefore, deleting the `ParamQuadProg` element inside. This means that CVXPY was reparsing QPs all the times, also with parametric programs.

- I have deleted the `apply` function in `osqp_qpif.py` so that it uses the one defined in `QpSolver`

I would like to ask **your feedback** on this:

- Gurobi can return the solution if it hits the maximum time `TimeLimit`. I have assigned this case to the status `s.USER_LIMIT`. This situation happens when solving long mixed-integer programs: the solver has a feasible solution but it hasn't proven its optimality yet. At the moment, CVXPY just discards that solution and throws an error. With this PR Gurobi can return a feasible solution, if `solCount > 0`. 

- I did the same when OSQP hits the maximum time so that it returns the last ADMM iterate (this is the same as what is happening with SCS).