### PR TITLE
Change raw latex to math so equations display correctly

### DIFF
--- a/doc/source/examples/applications/ant_array_min_beamwidth.rst
+++ b/doc/source/examples/applications/ant_array_min_beamwidth.rst
@@ -37,7 +37,7 @@ performed by bisection, where the interval which contains the optimal
 value is bisected according to the result of the following feasibility
 problem:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
    \mbox{minimize}   &  0 \\
@@ -56,7 +56,7 @@ the antenna array configuration and specs.
 Once the optimal beamwidth is found, the solution :math:`w` is refined
 with the following optimization:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
    \mbox{minimize}   &  \|w\| \\

--- a/doc/source/examples/applications/clock_mesh.rst
+++ b/doc/source/examples/applications/clock_mesh.rst
@@ -27,7 +27,7 @@ the dissipated power is equal to :math:`\mathbf{1}^T C(x) \mathbf{1}`.
 Thus to minimize the dissipated power subject to a constraint in the
 widths and a constraint in the dominant time constant, we solve the SDP
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   & \mathbf{1}^T C(x) \mathbf{1}   \\

--- a/doc/source/examples/applications/consensus_opt.rst
+++ b/doc/source/examples/applications/consensus_opt.rst
@@ -5,7 +5,7 @@ Consensus optimization
 Suppose we have a convex optimization problem with :math:`N` terms in
 the objective
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll} \mbox{minimize} & \sum_{i=1}^N f_i(x)\\
    \end{array}
@@ -15,7 +15,7 @@ loss function for the :math:`i`\ th block of training data.
 
 We can convert this problem into consensus form
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll} \mbox{minimize} & \sum_{i=1}^N f_i(x_i)\\
    \mbox{subject to} & x_i = z
@@ -30,7 +30,7 @@ We can solve a problem in consensus form using the Alternating Direction
 Method of Multipliers (ADMM). Each iteration of ADMM reduces to the
 following updates:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{lll}
    % xbar, u parameters in prox.

--- a/doc/source/examples/applications/fault_detection.rst
+++ b/doc/source/examples/applications/fault_detection.rst
@@ -23,7 +23,7 @@ fault occurrences, with :math:`x_i = 1` indicating that fault :math:`i`
 has occurred. System performance is measured by :math:`m` sensors. The
 sensor output is
 
-.. raw:: latex
+.. math::
 
    \begin{equation}
    y = Ax + v = \sum_{i=1}^n a_i x_i + v,
@@ -49,7 +49,7 @@ To identify the faults, one reasonable approach is to choose
 :math:`x \in \lbrace 0,1 \rbrace^{n}` to minimize the negative
 log-likelihood function
 
-.. raw:: latex
+.. math::
 
    \begin{equation}
    \ell(x) = \frac{1}{2 \sigma^2} \|Ax-y\|_2^2 +  \log(1/p-1)\mathbf{1}^T x + c.
@@ -63,7 +63,7 @@ instead constrain :math:`x_i \in [0,1]`.
 
 The optimization problem
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
    \mbox{minimize} &  \|Ax-y\|_2^2 + 2 \sigma^2 \log(1/p-1)\mathbf{1}^T x\\
@@ -85,7 +85,7 @@ We'll generate an example with :math:`n = 2000` possible faults,
 We'll choose :math:`\sigma^2` so that the signal-to-noise ratio is 5.
 That is,
 
-.. raw:: latex
+.. math::
 
    \begin{equation}
    \sqrt{\frac{\mathbf{E}\|Ax \|^2_2}{\mathbf{E} \|v\|_2^2}} = 5.

--- a/doc/source/examples/applications/fir_chebychev_design.rst
+++ b/doc/source/examples/applications/fir_chebychev_design.rst
@@ -18,7 +18,7 @@ absolute error (Chebychev norm). This is a convex problem (after
 sampling it can be formulated as an SOCP), which may be written in the
 form:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   &  \max |H(\omega) - H_\mbox{des}(\omega)| 

--- a/doc/source/examples/applications/l1_trend_filter.rst
+++ b/doc/source/examples/applications/l1_trend_filter.rst
@@ -20,7 +20,7 @@ time series :math:`y`.
 
 The :math:`\ell_1` trend estimation problem can be formulated as
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   &  (1/2)||y-x||_2^2 + \lambda ||Dx||_1,

--- a/doc/source/examples/applications/max_entropy.rst
+++ b/doc/source/examples/applications/max_entropy.rst
@@ -10,7 +10,7 @@ Introduction
 
 Consider the linear inequality constrained entropy maximization problem:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{maximize}   & -\sum_{i=1}^n x_i \log(x_i) \\

--- a/doc/source/examples/applications/nba_ranking.rst
+++ b/doc/source/examples/applications/nba_ranking.rst
@@ -286,7 +286,7 @@ there is some scaling :math:`\tilde{w} = \alpha w` such that
 :math:`f_{\tilde{w}}(x^w_i, x^l_i) \geq 1` for all :math:`i`. This
 motivates the loss function which we'll use:
 
-.. raw:: latex
+.. math::
 
    \begin{equation}
    L(w) = \frac{1}{m}\sum_{i=1}^m \max \lbrace 1 - (x^w_i - x^l_i)^T w, 0 \rbrace.
@@ -302,7 +302,7 @@ used to prevent over-fitting.
 We use the ``fit(W,L,gamma)`` function defined below to solve the
 optimization problem
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
    \mbox{minimize} & L(w) + \gamma \| w \|_2,

--- a/doc/source/examples/applications/nonneg_matrix_fact.rst
+++ b/doc/source/examples/applications/nonneg_matrix_fact.rst
@@ -12,7 +12,7 @@ Introduction
 We are given a matrix :math:`A \in \mathbf{\mbox{R}}^{m \times n}` and
 are interested in solving the problem:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   & \| A - YX \|_F \\

--- a/doc/source/examples/applications/robust_kalman.rst
+++ b/doc/source/examples/applications/robust_kalman.rst
@@ -17,7 +17,7 @@ A discrete-time linear dynamical system consists of a sequence of state
 vectors :math:`x_t \in \mathbf{R}^n`, indexed by time
 :math:`t \in \lbrace 0, \ldots, N-1 \rbrace` and dynamics equations
 
-.. raw:: latex
+.. math::
 
    \begin{align}
    x_{t+1} &= Ax_t + Bw_t\\
@@ -40,7 +40,7 @@ Kalman filtering
 A Kalman filter estimates :math:`x_t` by solving the optimization
 problem
 
-.. raw:: latex
+.. math:: 
 
    \begin{array}{ll}
    \mbox{minimize} & \sum_{t=0}^{N-1} \left( 
@@ -69,7 +69,7 @@ To handle outliers in :math:`v_t`, robust Kalman filtering replaces the
 quadratic cost with a Huber cost, which results in the convex
 optimization problem
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
    \mbox{minimize} & \sum_{t=0}^{N-1} \left( \|w_t\|^2_2 + \tau \phi_\rho(v_t) \right)\\

--- a/doc/source/examples/applications/sparse_solution.rst
+++ b/doc/source/examples/applications/sparse_solution.rst
@@ -21,7 +21,7 @@ satisfies these inequalities.
 The (standard) :math:`\ell_1`-norm heuristic for finding a sparse
 solution is:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   &  \|x\|_1 \\
@@ -31,7 +31,7 @@ solution is:
 The log-based heuristic is an iterative method for finding a sparse
 solution, by finding a local optimal point for the problem:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   &  \sum_i \log \left( \delta + \left|x_i\right| \right) \\
@@ -45,7 +45,7 @@ However, we can apply a heuristic in which we linearize the objective,
 solve, and re-iterate. This becomes a weighted :math:`\ell_1`-norm
 heuristic:
 
-.. raw:: latex
+.. math::
 
    \begin{array}{ll}
        \mbox{minimize}   &  \sum_i W_i \left|x_i\right| \\

--- a/doc/source/examples/derivatives/structured_prediction.rst
+++ b/doc/source/examples/derivatives/structured_prediction.rst
@@ -9,7 +9,7 @@ training dataset :math:`\mathcal D` contains :math:`N` input-output
 pairs :math:`(x, y)`, where :math:`x \in \reals^{n}_{++}` is an input
 and :math:`y \in \reals^{m}_{++}` is an outputs. The entries of each
 output :math:`y` are sorted in ascending order, meaning
-:math:`y_1 \leq y_2 \leq \cdots y_m`.
+:math:`y_1 \leq y_2 \leq \cdots \leq y_m`.
 
 Our regression model :math:`\phi : \reals^{n}_{++} \to \reals^{m}_{++}`
 takes as input a vector :math:`x \in \reals^{n}_{++}`, and solves an

--- a/doc/source/examples/dgp/power_control.rst
+++ b/doc/source/examples/dgp/power_control.rst
@@ -30,8 +30,8 @@ at receiver :math:`i` is :math:`\sigma_i`, and the signal to noise ratio
    S_i = \frac{G_{ii}P_i}{\sigma_i + \sum_{k \neq i} G_{ik}P_k}.
 
 The transmitters and receivers are constrained to have a minimum SINR
-:math:`S^{\text min}`, and the :math:`P_i` are bounded between
-:math:`P_i^{\text min}` and :math:`P_i^{\text max}`. This gives the
+:math:`S^{\text{min}}`, and the :math:`P_i` are bounded between
+:math:`P_i^{\text{min}}` and :math:`P_i^{\text{max}}`. This gives the
 problem
 
 .. math::
@@ -39,9 +39,9 @@ problem
 
    \begin{array}{ll}
    \mbox{minimize} & P_1 + \cdots + P_n \\
-   \mbox{subject to} & P_i^{\text min} \leq P_i \leq P_i^{\text max}, \\
-   & 1/S^{\text min} \geq \frac{\sigma_i + \sum_{k \neq i} G_{ik}P_k}{G_{ii}P_i}
-   \end{array}.
+   \mbox{subject to} & P_i^{\text{min}} \leq P_i \leq P_i^{\text{max}}, \\
+   & 1/S^{\text{min}} \geq \frac{\sigma_i + \sum_{k \neq i} G_{ik}P_k}{G_{ii}P_i}.
+   \end{array}
 
 .. code:: python
 


### PR DESCRIPTION
Hello! First and foremost: thank you for the great library.

Some equations seem to not display correctly in the examples, see [this page](https://www.cvxpy.org/examples/applications/robust_kalman.html) for an example

## Before

Here's what it looks like in Firefox:

![image](https://user-images.githubusercontent.com/10076072/83170365-b49fa280-a114-11ea-9249-f078a37f639c.png)


## After

Changing the lines to `.. math::` seems to do the trick:

![image](https://user-images.githubusercontent.com/10076072/83170423-cd0fbd00-a114-11ea-9a2c-20780258d589.png)


I also have a question. I see that the files below are identical:
```
./examples/notebooks/WWW/robust_kalman.ipynb
./doc/source/examples/applications/robust_kalman.rst
```

**Question.** Is the `.rst` the result of a manual export from the notebook, or is it automated? If it's not automated, I think it would be better to have the code in one place and automate this. 
