### PR TITLE
Eval params early

### DIFF
--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -161,11 +161,11 @@ def construct_solving_chain(problem, candidates, gp=False, enforce_dpp=False):
     if not problem.is_dpp(dpp_context):
         if not enforce_dpp:
             warnings.warn(dpp_error_msg)
-            reductions += [EvalParams()]
+            reductions = [EvalParams()] + reductions
         else:
             raise DPPError(dpp_error_msg)
     elif any(param.is_complex() for param in problem.parameters()):
-        reductions += [EvalParams()]
+        reductions = [EvalParams()] + reductions
 
     # Conclude with matrix stuffing; choose one of the following paths:
     #   (1) QpMatrixStuffing --> [a QpSolver],

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -249,6 +249,40 @@ class TestDcp(BaseTest):
         problem = cp.Problem(objective, constraints)
         self.assertTrue(problem.is_dpp())
 
+    def test_non_dpp_powers(self):
+        s = cp.Parameter(1, nonneg=True)
+        x = cp.Variable(1)
+        obj = cp.Maximize(x+s)
+        cons = [x <= 1]
+        prob = cp.Problem(obj, cons)
+        s.value = np.array([1.])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            prob.solve(solver=cp.SCS)
+        np.testing.assert_almost_equal(prob.value, 2.)
+
+        s = cp.Parameter(1, nonneg=True)
+        x = cp.Variable(1)
+        obj = cp.Maximize(x+s**2)
+        cons = [x <= 1]
+        prob = cp.Problem(obj, cons)
+        s.value = np.array([1.])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            prob.solve(solver=cp.SCS)
+        np.testing.assert_almost_equal(prob.value, 2.)
+
+        s = cp.Parameter(1, nonneg=True)
+        x = cp.Variable(1)
+        obj = cp.Maximize(cp.multiply(x, s**2))
+        cons = [x <= 1]
+        prob = cp.Problem(obj, cons)
+        s.value = np.array([1.])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            prob.solve(solver=cp.SCS)
+        np.testing.assert_almost_equal(prob.value, 1.)
+
 
 class TestDgp(BaseTest):
     def test_basic_equality_constraint(self):


### PR DESCRIPTION
Canonicalizing (eg Dcp2Cone) non-DPP problems with params led to incorrect behavior

Fixes #1044