### PR TITLE
Adding reciprocal product as a new convex atom

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -21,6 +21,7 @@ from cvxpy.atoms.geo_mean import geo_mean
 from cvxpy.atoms.gen_lambda_max import gen_lambda_max
 from cvxpy.atoms.gmatmul import gmatmul
 from cvxpy.atoms.harmonic_mean import harmonic_mean
+from cvxpy.atoms.inv_prod import inv_prod
 from cvxpy.atoms.lambda_max import lambda_max
 from cvxpy.atoms.lambda_min import lambda_min
 from cvxpy.atoms.lambda_sum_largest import lambda_sum_largest

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -231,9 +231,8 @@ class geo_mean(Atom):
     def numeric(self, values):
         values = np.array(values[0]).flatten()
         val = 1.0
-        w_tot = np.sum(self.w)
         for x, p in zip(values, self.w):
-            val *= x**float(p/w_tot)
+            val *= x**float(p)
         return val
 
     def _domain(self):

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -231,8 +231,9 @@ class geo_mean(Atom):
     def numeric(self, values):
         values = np.array(values[0]).flatten()
         val = 1.0
+        w_tot = np.sum(self.w)
         for x, p in zip(values, self.w):
-            val *= x**float(p)
+            val *= x**float(p/w_tot)
         return val
 
     def _domain(self):

--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -7,4 +7,4 @@ from cvxpy.atoms.elementwise.inv_pos import inv_pos
 def inv_prod(value):
     """The reciprocal of a product of the entries of a vector ``x``.
     """
-    return power(inv_pos(geo_mean(value)), len(value))
+    return power(inv_pos(geo_mean(value)), sum(value.shape))

--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -1,8 +1,22 @@
+"""
+Copyright, the CVXPY authors
 
-from cvxpy.expressions.expression import Expression
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 from cvxpy.atoms.geo_mean import geo_mean
 from cvxpy.atoms.elementwise.power import power
 from cvxpy.atoms.elementwise.inv_pos import inv_pos
+
 
 def inv_prod(value):
     """The reciprocal of a product of the entries of a vector ``x``.

--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -20,5 +20,19 @@ from cvxpy.atoms.elementwise.inv_pos import inv_pos
 
 def inv_prod(value):
     """The reciprocal of a product of the entries of a vector ``x``.
+
+    Parameters
+    ----------
+    x : Expression or numeric
+        The expression whose reciprocal product is to be computed. Must have
+        positive entries.
+
+    Returns
+    -------
+    Expression
+        .. math::
+            \\left(\\prod_{i=1}^n x_i\\right)^{-1},
+
+        where :math:`n` is the length of :math:`x`.
     """
     return power(inv_pos(geo_mean(value)), sum(value.shape))

--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -1,0 +1,10 @@
+
+from cvxpy.expressions.expression import Expression
+from cvxpy.atoms.geo_mean import geo_mean
+from cvxpy.atoms.elementwise.power import power
+from cvxpy.atoms.elementwise.inv_pos import inv_pos
+
+def inv_prod(value):
+    """The reciprocal of a product of the entries of a vector ``x``.
+    """
+    return power(inv_pos(geo_mean(value)), len(value))

--- a/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
@@ -50,6 +50,13 @@ harmonic_mean
 
 .. autofunction:: cvxpy.atoms.harmonic_mean.harmonic_mean
 
+.. _inv-prod:
+
+inv_prod
+-----------------------------------
+
+.. autofunction:: cvxpy.atoms.inv_prod.inv_prod
+
 .. _lambda-max:
 
 lambda_max

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -102,6 +102,14 @@ and returns a scalar.
      - |concave| concave
      - |incr| incr.
 
+   * - :ref:`inv_prod(x) <inv-prod>`
+     - :math:`(x_1\cdots x_n)^{-1}`
+     - :math:`x \in \mathbf{R}^n_+`
+     - |positive| positive
+     - |convex| convex
+     - |decr| decr.
+
+
    * - :ref:`lambda_max(X) <lambda-max>`
      - :math:`\lambda_{\max}(X)`
      - :math:`X \in \mathbf{S}^n`


### PR DESCRIPTION
Adding in the (somewhat surprising!) new atom `inv_prod` equal to

```
(Π x)⁻¹
```

for some vector `x`, as per @akshayka 's recommendation.