### PR TITLE
Cache auxiliary output for some solvers

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1127,18 +1127,25 @@ class SolverStats(object):
 
     Attributes
     ----------
+    solver_name : str
+        The name of the solver.
     solve_time : double
         The time (in seconds) it took for the solver to solve the problem.
     setup_time : double
         The time (in seconds) it took for the solver to setup the problem.
     num_iters : int
         The number of iterations the solver had to go through to find a solution.
+    extra_stats : object
+        Extra statistics specific to the solver; these statistics are typically
+        returned directly from the solver, without modification by CVXPY.
+        This object may be a dict, or a custom Python object.
     """
     def __init__(self, results_dict, solver_name):
         self.solver_name = solver_name
         self.solve_time = None
         self.setup_time = None
         self.num_iters = None
+        self.extra_stats = None
 
         if s.SOLVE_TIME in results_dict:
             self.solve_time = results_dict[s.SOLVE_TIME]
@@ -1146,6 +1153,8 @@ class SolverStats(object):
             self.setup_time = results_dict[s.SETUP_TIME]
         if s.NUM_ITERS in results_dict:
             self.num_iters = results_dict[s.NUM_ITERS]
+        if s.EXTRA_STATS in results_dict:
+            self.extra_stats = results_dict[s.EXTRA_STATS]
 
 
 class SizeMetrics(object):

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -138,8 +138,6 @@ class ECOS(ConicSolver):
                               cones, data[s.A], data[s.B],
                               verbose=verbose,
                               **solver_opts)
-        if solver_cache is not None:
-            solver_cache[self.name()] = solution["info"]
         return solution
 
     def invert(self, solution, inverse_data):
@@ -152,6 +150,7 @@ class ECOS(ConicSolver):
         attr[s.SOLVE_TIME] = solution["info"]["timing"]["tsolve"]
         attr[s.SETUP_TIME] = solution["info"]["timing"]["tsetup"]
         attr[s.NUM_ITERS] = solution["info"]["iter"]
+        attr[s.EXTRA_STATS] = solution
 
         if status in s.SOLUTION_PRESENT:
             primal_val = solution['info']['pcost']

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -138,6 +138,8 @@ class ECOS(ConicSolver):
                               cones, data[s.A], data[s.B],
                               verbose=verbose,
                               **solver_opts)
+        if solver_cache is not None:
+            solver_cache[self.name()] = solution["info"]
         return solution
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -103,6 +103,7 @@ class GUROBI(SCS):
         """Returns the solution to the original problem given the inverse_data.
         """
         status = solution['status']
+        attr = {s.EXTRA_STATS: solution['model']}
 
         primal_vars = None
         dual_vars = None
@@ -120,11 +121,11 @@ class GUROBI(SCS):
                     inverse_data[GUROBI.NEQ_CONSTR])
                 eq_dual.update(leq_dual)
                 dual_vars = eq_dual
-            return Solution(status, opt_val, primal_vars, dual_vars, {})
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status)
 
-        return Solution(status, opt_val, primal_vars, dual_vars, {})
+        return Solution(status, opt_val, primal_vars, dual_vars, attr)
 
     def solve_via_data(self, data, warm_start, verbose, solver_opts, solver_cache=None):
         """Returns the result of the call to the solver.
@@ -246,9 +247,8 @@ class GUROBI(SCS):
                                                  s.SOLVER_ERROR)
         if solution["status"] == s.SOLVER_ERROR and model.SolCount:
             solution["status"] = s.OPTIMAL_INACCURATE
+        solution["model"] = model
 
-        if solver_cache is not None:
-            solver_cache[self.name()] = model
         return solution
 
     def add_model_lin_constr(self, model, variables,

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -247,6 +247,8 @@ class GUROBI(SCS):
         if solution["status"] == s.SOLVER_ERROR and model.SolCount:
             solution["status"] = s.OPTIMAL_INACCURATE
 
+        if solver_cache is not None:
+            solver_cache[self.name()] = model
         return solution
 
     def add_model_lin_constr(self, model, variables,

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -248,6 +248,7 @@ class SCS(ConicSolver):
         attr[s.SOLVE_TIME] = solution["info"]["solveTime"]
         attr[s.SETUP_TIME] = solution["info"]["setupTime"]
         attr[s.NUM_ITERS] = solution["info"]["iter"]
+        attr[s.EXTRA_STATS] = solution
 
         if status in s.SOLUTION_PRESENT:
             primal_val = solution["info"]["pobj"]

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -56,7 +56,8 @@ class GUROBI(QpSolver):
 
         # Start populating attribute dictionary
         attr = {s.SOLVE_TIME: model.Runtime,
-                s.NUM_ITERS: model.BarIterCount}
+                s.NUM_ITERS: model.BarIterCount,
+                s.EXTRA_STATS: model}
 
         # Map GUROBI statuses back to CVXPY statuses
         status = self.STATUS_MAP.get(model.Status, s.SOLVER_ERROR)
@@ -202,8 +203,6 @@ class GUROBI(QpSolver):
         except Exception:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
 
-        if solver_cache is not None:
-            solver_cache[self.name()] = model
         results_dict["model"] = model
 
         return results_dict

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -202,6 +202,8 @@ class GUROBI(QpSolver):
         except Exception:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
 
+        if solver_cache is not None:
+            solver_cache[self.name()] = model
         results_dict["model"] = model
 
         return results_dict

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -30,6 +30,7 @@ class OSQP(QpSolver):
 
     def invert(self, solution, inverse_data):
         attr = {s.SOLVE_TIME: solution.info.run_time}
+        attr[s.EXTRA_STATS] = solution
 
         # Map OSQP statuses back to CVXPY statuses
         status = self.STATUS_MAP.get(solution.info.status_val, s.SOLVER_ERROR)

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -110,6 +110,7 @@ INEQ_DUAL = "ineq_dual"
 SOLVE_TIME = "solve_time"  # in seconds
 SETUP_TIME = "setup_time"  # in seconds
 NUM_ITERS = "num_iters"  # number of iterations
+EXTRA_STATS = "solver_specific_stats"
 
 # Keys for problem data dict.
 C = "c"

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -190,6 +190,24 @@ class TestProblem(BaseTest):
         self.assertGreater(stats.solve_time, 0)
         self.assertGreater(stats.setup_time, 0)
         self.assertGreater(stats.num_iters, 0)
+        self.assertIn('info', stats.extra_stats)
+
+        prob = Problem(cp.Minimize(cp.norm(self.x)), [self.x == 0])
+        prob.solve(solver=s.SCS)
+        stats = prob.solver_stats
+        self.assertGreater(stats.solve_time, 0)
+        self.assertGreater(stats.setup_time, 0)
+        self.assertGreater(stats.num_iters, 0)
+        self.assertIn('info', stats.extra_stats)
+
+        prob = Problem(cp.Minimize(cp.sum(self.x)), [self.x == 0])
+        prob.solve(solver=s.OSQP)
+        stats = prob.solver_stats
+        self.assertGreater(stats.solve_time, 0)
+        # We do not populate setup_time for OSQP (OSQP decomposes time
+        # into setup, solve, and polish; these are summed to obtain solve_time)
+        self.assertGreater(stats.num_iters, 0)
+        self.assertTrue(hasattr(stats.extra_stats, 'info'))
 
     def test_get_problem_data(self):
         """Test get_problem_data method.


### PR DESCRIPTION
We currently cache the OSQP/SCS results dicts in problem._solver_cache. This
is useful when debugging a call to solve. This
change also caches the ECOS results dict and the entire Gurobi model;
this makes it possible to inspect the solver's performance
programmatically, without looking at the verbose output.

We should implement similar changes for all solvers, in a future change. It might be
a good idea to expose cached solver information in a public API in a
future PR.