### PR TITLE
Add support for custom kkt solvers in cvxopt interface

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -22,7 +22,7 @@ from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.compr_matrix import compress_matrix
-from cvxpy.reductions.solvers.kktsolver import setup_kktsolver
+from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
 from cvxpy.expressions.constants.constant import smallest_eig_near_ref
 import scipy.sparse as sp
 import scipy
@@ -194,7 +194,7 @@ class CVXOPT(ECOS):
 
         # finalize the KKT solver.
         if isinstance(kktsolver, str) and kktsolver == s.ROBUST_KKTSOLVER:
-            kktsolver = setup_kktsolver(c, G, h, dims, A, b)
+            kktsolver = setup_ldl_factor(c, G, h, dims, A, b)
         elif not isinstance(kktsolver, str):
             kktsolver = kktsolver(c, G, h, dims, A, b)
 

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -23,7 +23,7 @@ from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.compr_matrix import compress_matrix
 from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
-from cvxpy.expressions.constants.constant import smallest_eig_near_ref
+from cvxpy.expressions.constants.constant import extremal_eig_near_ref
 import scipy.sparse as sp
 import scipy
 import numpy as np
@@ -283,7 +283,7 @@ class CVXOPT(ECOS):
                 data[s.A] = None
                 data[s.B] = None
                 return s.OPTIMAL
-        eig = smallest_eig_near_ref(gram, ref=TOL)
+        eig = extremal_eig_near_ref(gram, ref=TOL)
         if eig > TOL:
             return s.OPTIMAL
         #

--- a/cvxpy/reductions/solvers/kktsolver.py
+++ b/cvxpy/reductions/solvers/kktsolver.py
@@ -14,80 +14,84 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-"""
-THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
-DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
-"""
-
 # A custom KKT solver for CVXOPT that can handle redundant constraints.
 # Uses regularization and iterative refinement.
 
 # Regularization constant.
 REG_EPS = 1e-9
 
-# Returns a kktsolver for linear cone programs (or nonlinear if F is given).
 
-
-def get_kktsolver(G, dims, A, F=None):
-    if F is None:
-        factor = kkt_ldl(G, dims, A)
-
-        def kktsolver(W):
-            return factor(W)
-    else:
-        mnl, x0 = F()
-        factor = kkt_ldl(G, dims, A, mnl)
-
-        def kktsolver(x, z, W):
-            f, Df, H = F(x, z)
-            return factor(W, H, Df)
-    return kktsolver
-
-
-def kkt_ldl(G, dims, A, mnl=0):
+def setup_kktsolver(c, G, h, dims, A, b):
     """
-    Solution of KKT equations by a dense LDL factorization of the
-    3 x 3 system.
+    The meanings of arguments in this function are identical to those of the
+    function cvxopt.solvers.conelp. Refer to CVXOPT documentation
 
-    Returns a function that (1) computes the LDL factorization of
+        https://cvxopt.org/userguide/coneprog.html#linear-cone-programs
 
-        [ H           A'   GG'*W^{-1} ]
-        [ A           0    0          ],
-        [ W^{-T}*GG   0   -I          ]
+    for more information.
 
-    given H, Df, W, where GG = [Df; G], and (2) returns a function for
-    solving
+    Note: CVXOPT allows G and A to be passed as dense matrix objects. However,
+    this function will only ever be called with spmatrix objects. If creating
+    a custom kktsolver of your own, you need to conform to this sparse matrix
+    assumption.
+    """
+    factor = kkt_ldl(G, dims, A)
+    return factor
 
-        [ H     A'   GG'   ]   [ ux ]   [ bx ]
+
+def kkt_ldl(G, dims, A):
+    """
+    Returns a function handle "factor", which conforms to the CVXOPT
+    custom KKT solver specifications:
+
+        https://cvxopt.org/userguide/coneprog.html#exploiting-structure.
+
+    For convenience, we provide a short outline for how this function works.
+
+    First, we allocate workspace for use in "factor". The factor function is
+    called with data (H, W). Once called, the factor function computes an LDL
+    factorization of the 3 x 3 system:
+
+        [ H           A'   G'*W^{-1}  ]
+        [ A           0    0          ].
+        [ W^{-T}*G    0   -I          ]
+
+    Once that LDL factorization is computed, "factor" constructs another
+    inner function, called "solve". The solve function uses the newly
+    constructed LDL factorization to compute solutions to linear systems of
+    the form
+
+        [ H     A'   G'    ]   [ ux ]   [ bx ]
         [ A     0    0     ] * [ uy ] = [ by ].
-        [ GG    0   -W'*W  ]   [ uz ]   [ bz ]
+        [ G     0   -W'*W  ]   [ uz ]   [ bz ]
 
-    H is n x n,  A is p x n, Df is mnl x n, G is N x n where
-    N = dims['l'] + sum(dims['q']) + sum( k**2 for k in dims['s'] ).
+    The factor function concludes by returning a reference to the solve function.
+
+    Notes: In the 3 x 3 system, H is n x n, A is p x n, and G is N x n, where
+    N = dims['l'] + sum(dims['q']) + sum( k**2 for k in dims['s'] ). For cone
+    programs, H is the zero matrix.
     """
     from cvxopt import blas, lapack
     from cvxopt.base import matrix
     from cvxopt.misc import scale, pack, unpack
 
     p, n = A.size
-    ldK = n + p + mnl + dims['l'] + sum(dims['q']) + sum([int(k*(k+1)/2)
-                                                          for k in dims['s']])
+    ldK = n + p + dims['l'] + sum(dims['q']) + sum([int(k*(k+1)/2)
+                                                    for k in dims['s']])
     K = matrix(0.0, (ldK, ldK))
     ipiv = matrix(0, (ldK, 1))
     u = matrix(0.0, (ldK, 1))
-    g = matrix(0.0, (mnl + G.size[0], 1))
+    g = matrix(0.0, (G.size[0], 1))
 
-    def factor(W, H=None, Df=None):
+    def factor(W, H=None):
         blas.scal(0.0, K)
         if H is not None:
             K[:n, :n] = H
         K[n:n+p, :n] = A
         for k in range(n):
-            if mnl:
-                g[:mnl] = Df[:, k]
-            g[mnl:] = G[:, k]
+            g[:] = G[:, k]
             scale(g, W, trans='T', inverse='I')
-            pack(g, K, dims, mnl, offsety=k*ldK + n + p)
+            pack(g, K, dims, 0, offsety=k*ldK + n + p)
         K[(ldK+1)*(p+n):: ldK+1] = -1.0
         # Add positive regularization in 1x1 block and negative in 2x2 block.
         K[0: (ldK+1)*n: ldK+1] += REG_EPS
@@ -98,9 +102,9 @@ def kkt_ldl(G, dims, A, mnl=0):
 
             # Solve
             #
-            #     [ H          A'   GG'*W^{-1} ]   [ ux   ]   [ bx        ]
+            #     [ H          A'   G'*W^{-1}  ]   [ ux   ]   [ bx        ]
             #     [ A          0    0          ] * [ uy   [ = [ by        ]
-            #     [ W^{-T}*GG  0   -I          ]   [ W*uz ]   [ W^{-T}*bz ]
+            #     [ W^{-T}*G   0   -I          ]   [ W*uz ]   [ W^{-T}*bz ]
             #
             # and return ux, uy, W*uz.
             #
@@ -109,11 +113,11 @@ def kkt_ldl(G, dims, A, mnl=0):
             blas.copy(x, u)
             blas.copy(y, u, offsety=n)
             scale(z, W, trans='T', inverse='I')
-            pack(z, u, dims, mnl, offsety=n + p)
+            pack(z, u, dims, 0, offsety=n + p)
             lapack.sytrs(K, ipiv, u)
             blas.copy(u, x, n=n)
             blas.copy(u, y, offsetx=n, n=p)
-            unpack(u, z, dims, mnl, offsetx=n + p)
+            unpack(u, z, dims, 0, offsetx=n + p)
 
         return solve
 

--- a/cvxpy/reductions/solvers/kktsolver.py
+++ b/cvxpy/reductions/solvers/kktsolver.py
@@ -21,7 +21,7 @@ limitations under the License.
 REG_EPS = 1e-9
 
 
-def setup_kktsolver(c, G, h, dims, A, b):
+def setup_ldl_factor(c, G, h, dims, A, b):
     """
     The meanings of arguments in this function are identical to those of the
     function cvxopt.solvers.conelp. Refer to CVXOPT documentation

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -210,6 +210,30 @@ def lp_4():
     return sth
 
 
+def lp_5():
+    # a problem with redundant equality constraints.
+    #
+    # 10 variables, 6 equality constraints A @ x == b (two redundant)
+    x0 = np.array([0, 1, 0, 2, 0, 4, 0, 5, 6, 7])
+    mu0 = np.array([-2, -1, 0, 1, 2, 3.5])
+    np.random.seed(0)
+    A_min = np.random.randn(4, 10)
+    A_red = A_min.T @ np.random.rand(4, 2)
+    A_red = A_red.T
+    A = np.vstack((A_min, A_red))
+    b = A @ x0  # x0 is primal feasible
+    c = A.T @ mu0  # mu0 is dual-feasible
+    c[[0, 2, 4, 6]] += np.random.rand(4)
+    # ^  c >= A.T @ mu0 exhibits complementary slackness with respect to x0
+    #    Therefore (x0, mu0) are primal-dual optimal for ...
+    x = cp.Variable(10)
+    objective = (cp.Minimize(c @ x), c @ x0)
+    var_pairs = [(x, x0)]
+    con_pairs = [(x >= 0, None), (A @ x == b, None)]
+    sth = SolverTestHelper(objective, var_pairs, con_pairs)
+    return sth
+
+
 def socp_0():
     x = cp.Variable(shape=(2,))
     obj_pair = (cp.Minimize(cp.norm(x, 2) + 1), 1)
@@ -547,6 +571,15 @@ class StandardTestLPs(object):
         sth = lp_4()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
+
+    @staticmethod
+    def test_lp_5(solver, places=4, **kwargs):
+        sth = lp_5()
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.check_primal_feasibility(places)
+        sth.check_complementarity(places)
+        sth.check_dual_domains(places)
 
     @staticmethod
     def test_mi_lp_0(solver, places=4, **kwargs):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -73,6 +73,9 @@ class TestECOS(BaseTest):
     def test_ecos_lp_4(self):
         StandardTestLPs.test_lp_4(solver='ECOS')
 
+    def test_ecos_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='ECOS')
+
     def test_ecos_socp_0(self):
         StandardTestSOCPs.test_socp_0(solver='ECOS')
 
@@ -322,6 +325,9 @@ class TestSCS(BaseTest):
     def test_scs_lp_4(self):
         StandardTestLPs.test_lp_4(solver='SCS')
 
+    def test_scs_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='SCS')
+
     def test_scs_socp_1(self):
         StandardTestSOCPs.test_socp_1(solver='SCS')
 
@@ -361,6 +367,9 @@ class TestMosek(unittest.TestCase):
 
     def test_mosek_lp_4(self):
         StandardTestLPs.test_lp_4(solver='MOSEK')
+
+    def test_mosek_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='MOSEK')
 
     def test_mosek_socp_0(self):
         StandardTestSOCPs.test_socp_0(solver='MOSEK')
@@ -454,7 +463,6 @@ class TestCVXOPT(BaseTest):
     def test_cvxopt_options(self):
         """Test that all the CVXOPT solver options work.
         """
-        # TODO race condition when changing these values.
         # 'maxiters'
         # maximum number of iterations (default: 100).
         # 'abstol'
@@ -467,15 +475,23 @@ class TestCVXOPT(BaseTest):
         # number of iterative refinement steps when solving KKT equations
         # (default: 0 if the problem has no second-order cone
         #  or matrix inequality constraints; 1 otherwise).
-        if cp.CVXOPT in INSTALLED_SOLVERS:
-            EPS = 1e-7
-            prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1) + 1.0), [self.x == 0])
-            for i in range(2):
-                prob.solve(solver=cp.CVXOPT, feastol=EPS, abstol=EPS, reltol=EPS,
-                           max_iters=20, verbose=True, kktsolver="chol",
-                           refinement=2, warm_start=True)
-            self.assertAlmostEqual(prob.value, 1.0)
-            self.assertItemsAlmostEqual(self.x.value, [0, 0])
+        EPS = 1e-7
+        prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1) + 1.0), [self.x == 0])
+        prob.solve(solver=cp.CVXOPT, feastol=EPS, abstol=EPS, reltol=EPS,
+                   max_iters=20, verbose=True, kktsolver='chol', refinement=2)
+        self.assertAlmostEqual(prob.value, 1.0)
+        self.assertItemsAlmostEqual(self.x.value, [0, 0])
+
+        msg = 'This setup-factor function was called.'
+
+        def setup_dummy_factor(c, G, h, dims, A, b):
+            # see cvxpy/reductions/solvers/kktsolver.py for an actual implementation
+            # of a setup-factor function.
+            raise NotImplementedError(msg)
+
+        with self.assertRaises(NotImplementedError) as nix:
+            prob.solve(solver='CVXOPT', kktsolver=setup_dummy_factor)
+        self.assertEqual(msg, str(nix.exception))
 
     def test_cvxopt_lp_0(self):
         StandardTestLPs.test_lp_0(solver='CVXOPT')
@@ -490,10 +506,12 @@ class TestCVXOPT(BaseTest):
         StandardTestLPs.test_lp_3(solver='CVXOPT')
 
     def test_cvxopt_lp_4(self):
-        # default settings
         StandardTestLPs.test_lp_4(solver='CVXOPT')
-        # without a CVXPY-based presolve
-        StandardTestLPs.test_lp_4(solver='CVXOPT', kktsolver='robust')
+
+    def test_cvxopt_lp_5(self):
+        from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
+        StandardTestLPs.test_lp_5(solver='CVXOPT', kktsolver=setup_ldl_factor)
+        StandardTestLPs.test_lp_5(solver='CVXOPT', kktsolver='chol')
 
     def test_cvxopt_socp_0(self):
         StandardTestSOCPs.test_socp_0(solver='CVXOPT')
@@ -569,6 +587,9 @@ class TestCBC(BaseTest):
     def test_cbc_lp_4(self):
         StandardTestLPs.test_lp_4(solver='CBC')
 
+    def test_cbc_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='CBC')
+
     def test_cbc_mi_lp_0(self):
         StandardTestLPs.test_mi_lp_0(solver='CBC')
 
@@ -596,6 +617,9 @@ class TestGLPK(unittest.TestCase):
 
     def test_glpk_lp_4(self):
         StandardTestLPs.test_lp_4(solver='GLPK')
+
+    def test_glpk_lk_5(self):
+        StandardTestLPs.test_lp_5(solver='GLPK')
 
     def test_glpk_mi_lp_0(self):
         StandardTestLPs.test_mi_lp_0(solver='GLPK_MI')
@@ -737,6 +761,9 @@ class TestCPLEX(BaseTest):
     def test_cplex_lp_4(self):
         StandardTestLPs.test_lp_4(solver='CPLEX')
 
+    def test_cplex_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='CPLEX')
+
     def test_cplex_socp_0(self):
         StandardTestSOCPs.test_socp_0(solver='CPLEX')
 
@@ -874,6 +901,9 @@ class TestGUROBI(BaseTest):
     def test_gurobi_lp_4(self):
         StandardTestLPs.test_lp_4(solver='GUROBI')
 
+    def test_gurobi_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='GUROBI')
+
     def test_gurobi_socp_0(self):
         StandardTestSOCPs.test_socp_0(solver='GUROBI')
 
@@ -965,6 +995,9 @@ class TestNAG(unittest.TestCase):
 
     def test_nag_lp_4(self):
         StandardTestLPs.test_lp_4(solver='NAG')
+
+    def test_nag_lp_5(self):
+        StandardTestLPs.test_lp_5(solver='NAG')
 
     def test_nag_socp_0(self):
         StandardTestSOCPs.test_socp_0(solver='NAG')

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -14,7 +14,7 @@ If you've found a bug in CVXPY or have a feature request,
 create an issue on the `CVXPY Github issue tracker <https://github.com/cvxgrp/cvxpy/issues>`_.
 
 Where can I learn more about convex optimization?
---------------------------------------------------
+-------------------------------------------------
 The book `Convex Optimization <http://web.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe is available for free online and has extensive background on convex optimization.
 To learn more about disciplined convex programming,
 visit the `DCP tutorial website <http://dcp.stanford.edu/>`_.
@@ -80,15 +80,15 @@ Can I use SciPy sparse matrices with CVXPY?
 Yes, they are fully supported.
 
 How do I constrain a CVXPY matrix expression to be positive semidefinite?
-------------------------------------------------------------------------------
+-------------------------------------------------------------------------
 See :ref:`Advanced Features <advanced>`.
 
 How do I create variables with special properties, such as boolean or symmetric variables?
--------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------
 See :ref:`Advanced Features <advanced>`.
 
 How do I create a variable that has multiple special properties, such as boolean and symmetric?
----------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------
 Create one variable with each desired property, and then set them all equal by adding equality constraints.
 
 How do I create variables with more than 2 dimensions?
@@ -97,7 +97,7 @@ You must mimic the extra dimensions using a dict,
 as described in `this Github issue <https://github.com/cvxgrp/cvxpy/issues/198>`__.
 
 Why does it take so long to compile my Problem?
-----------------------------------------------
+-----------------------------------------------
 In general, you should vectorize CVXPY expressions whenever possible if you
 care about performance (e.g., write A * x == b instead of a_i  * x == b_i for
 every row a_i of A). Consult this `IPython notebook <https://github.com/cvxgrp/cvxpy/blob/1.0/examples/notebooks/building_models_with_fast_compile_times.ipynb>`_ for details.

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -729,9 +729,23 @@ For others see `OSQP documentation <http://osqp.org/docs/interfaces/solver_setti
     number of iterative refinement steps after solving KKT system (default: 1).
 
 ``'kktsolver'``
-    The KKT solver used. The default, "chol", does a Cholesky factorization with preprocessing to make A and [A; G] full rank.
-    The "robust" solver does an LDL factorization without preprocessing.
-    It is slower, but more robust.
+    Controls the method used to solve systems of linear equations at each step of CVXOPT's
+    interior-point algorithm. This parameter can be a string (with one of several values),
+    or a function handle.
+
+    KKT solvers built-in to CVXOPT can be specified by strings  'ldl', 'ldl2', 'qr', 'chol',
+    and 'chol2'. If 'chol' is chosen, then CVXPY will perform an additional presolve
+    procedure to eliminate redundant constraints. You can also set ``kktsolver='robust'``.
+    The 'robust' solver is implemented in python, and is part of CVXPY source code; the
+    'robust' solver doesn't require a presolve phase to eliminate redundant constraints,
+    however it can be slower than 'chol'.
+
+    Finally, there is an option to pass a function handle for the ``kktsolver`` argument.
+    Passing a KKT solver based on a function handle allows you to take complete control of
+    solving the linear systems encountered in CVXOPT's interior-point algorithm. The API for
+    KKT solvers of this form is a small wrapper around CVXOPT's API for function-handle KKT
+    solvers. The precise API that CVXPY users are held to is described in the CVXPY source
+    code: cvxpy/reductions/solvers/kktsolver.py
 
 `SCS`_ options:
 


### PR DESCRIPTION
CVXOPT lets users pass a function handle which implements an algorithm to solve linearized KKT systems. This PR exposes that functionality to CVXPY users, and resolves #1042.

Under this PR, a user can now select a KKT solver by specifying one of six strings, or a custom function handle.
 * The strings correspond to five cvxopt built-in solvers, and the "robust" solver which is part of the cvxpy source code.
 * Users are directed to a specific part of cvxpy source code to determine how to implement a KKT solver of their own.

This functionality is only really relevant when a user is confident that a given cvxpy formulation leads to a suitably structured cone program. So from a practical perspective, I wouldn't recommend using this feature with nonlinear cvxpy atoms. If someone wants to take advantage of this feature for nonlinear convex optimization problems, they should formulate their problem directly as a cone program (e.g. with SOC constraints, Schur complements, etc...).

Remarks related to the main purpose of this PR
 1. I haven't added dedicated tests for this, however, I've slightly changed how cvxpy formulates its custom robust KKT solver. By doing this, the existing tests for cvxopt act as tests for the new proposed API. I'm happy to add more tests if anyone thinks that's a good idea.
 2. It might make sense to remove redundant constraints when using any one of the five CVXOPT solvers. Right now, the cvxpy interface to cvxopt only applies a presolve procedure when using cvxopt's ``chol`` KKT solver.

Changes incidental to this PR
 * Eigenvalue computation in ``Constant`` expressions was being performed with an incorrect call to [scipy.sparse.linalg.eigsh](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html#scipy.sparse.linalg.eigsh). Without the changes made here, the attribute ``A._bottom_eig`` of a Constant ``A`` was actually being set to the *maximum* eigenvalue when ``A`` is a symmetric PSD matrix which is exactly singular. At the time of first making this PR I'm not sure if my changes here are the best way to proceed. I'll investigate this further, and indicate when this part of the PR is ready for code review.
 * Formatting of an ``.rst`` file in web documentation.