### PR TITLE
Remove Gurobi conic interface bottleneck

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -103,7 +103,8 @@ class GUROBI(SCS):
         """Returns the solution to the original problem given the inverse_data.
         """
         status = solution['status']
-        attr = {s.EXTRA_STATS: solution['model']}
+        attr = {s.SOLVE_TIME: solution[s.SOLVE_TIME],
+                s.EXTRA_STATS: solution['model']}
 
         primal_vars = None
         dual_vars = None

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -212,9 +212,6 @@ class GUROBI(SCS):
             variables += new_vars
             soc_start += constr_len
 
-        gur_constrs = eq_constrs + ineq_constrs + new_leq_constrs + soc_constrs
-        model.update()
-
         # Set parameters
         # TODO user option to not compute duals.
         model.setParam("QCPDual", True)
@@ -234,16 +231,11 @@ class GUROBI(SCS):
             # Only add duals if not a MIP.
             # Not sure why we need to negate the following,
             # but need to in order to be consistent with other solvers.
+            vals = []
             if not (data[s.BOOL_IDX] or data[s.INT_IDX]):
-                vals = []
-                for lc in gur_constrs:
-                    if lc is not None:
-                        if isinstance(lc, gurobipy.QConstr):
-                            vals.append(lc.QCPi)
-                        else:
-                            vals.append(lc.Pi)
-                    else:
-                        vals.append(0)
+                lin_constrs = eq_constrs + ineq_constrs + new_leq_constrs
+                vals += model.getAttr('Pi', lin_constrs)
+                vals += model.getAttr('QCPi', soc_constrs)
                 solution["y"] = -np.array(vals)
                 solution[s.EQ_DUAL] = solution["y"][0:dims[s.EQ_DIM]]
                 solution[s.INEQ_DUAL] = solution["y"][dims[s.EQ_DIM]:]

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -23,7 +23,7 @@ from cvxpy.reductions.solvers.conic_solvers.scs_conif import (SCS,
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
-from scipy.sparse import dok_matrix
+import scipy.sparse as sp
 
 
 class GUROBI(SCS):
@@ -151,9 +151,7 @@ class GUROBI(SCS):
 
         c = data[s.C]
         b = data[s.B]
-        A = dok_matrix(data[s.A])
-        # Save the dok_matrix.
-        data[s.A] = A
+        A = sp.csr_matrix(data[s.A])
         dims = dims_to_solver_dict(data[s.DIMS])
 
         n = c.shape[0]
@@ -182,16 +180,24 @@ class GUROBI(SCS):
             )
         model.update()
 
-        eq_constrs = self.add_model_lin_constr(model, variables,
-                                               range(dims[s.EQ_DIM]),
-                                               gurobipy.GRB.EQUAL,
-                                               A, b)
         leq_start = dims[s.EQ_DIM]
         leq_end = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
-        ineq_constrs = self.add_model_lin_constr(model, variables,
-                                                 range(leq_start, leq_end),
-                                                 gurobipy.GRB.LESS_EQUAL,
-                                                 A, b)
+        if hasattr(model, 'addMConstrs'):
+            eq_constrs = model.addMConstrs(
+                A[:leq_start, :], None, gurobipy.GRB.EQUAL, b[:leq_start])
+            ineq_constrs = model.addMConstrs(
+                A[leq_start:leq_end, :], None, gurobipy.GRB.LESS_EQUAL, b[leq_start:leq_end])
+        else:
+            eq_constrs = self.add_model_lin_constr(model, variables,
+                                                   range(dims[s.EQ_DIM]),
+                                                   gurobipy.GRB.EQUAL,
+                                                   A, b)
+            ineq_constrs = self.add_model_lin_constr(model, variables,
+                                                     range(leq_start, leq_end),
+                                                     gurobipy.GRB.LESS_EQUAL,
+                                                     A, b)
+
+        # TODO: add all SOC constrs at once! Be careful with return values
         soc_start = leq_end
         soc_constrs = []
         new_leq_constrs = []
@@ -277,24 +283,16 @@ class GUROBI(SCS):
         list
             A list of constraints.
         """
-        import gurobipy
+        import gurobipy as gp
+
         constr = []
-        expr_list = {i: [] for i in rows}
-        for (i, j), c in mat.items():
-            v = variables[j]
-            try:
-                expr_list[i].append((c, v))
-            except Exception:
-                pass
         for i in rows:
-            # Ignore empty constraints.
-            if expr_list[i]:
-                expr = gurobipy.LinExpr(expr_list[i])
-                constr.append(
-                    model.addConstr(expr, ctype, vec[i])
-                )
-            else:
-                constr.append(None)
+            start = mat.indptr[i]
+            end = mat.indptr[i + 1]
+            x = [variables[j] for j in mat.indices[start:end]]
+            coeff = mat.data[start:end]
+            expr = gp.LinExpr(coeff, x)
+            constr.append(model.addLConstr(expr, ctype, vec[i]))
         return constr
 
     def add_model_soc_constr(self, model, variables,
@@ -319,45 +317,41 @@ class GUROBI(SCS):
         tuple
             A tuple of (QConstr, list of Constr, and list of variables).
         """
-        import gurobipy
-        # Assume first expression (i.e. t) is nonzero.
-        expr_list = {i: [] for i in rows}
-        for (i, j), c in mat.items():
-            v = variables[j]
-            try:
-                expr_list[i].append((c, v))
-            except Exception:
-                pass
-        lin_expr_list = [vec[i] - gurobipy.LinExpr(expr_list[i]) for i in rows]
+        import gurobipy as gp
 
         # Make a variable and equality constraint for each term.
         soc_vars = [
             model.addVar(
                 obj=0,
                 name="soc_t_%d" % rows[0],
-                vtype=gurobipy.GRB.CONTINUOUS,
+                vtype=gp.GRB.CONTINUOUS,
                 lb=0,
-                ub=gurobipy.GRB.INFINITY)
+                ub=gp.GRB.INFINITY)
         ]
         for i in rows[1:]:
             soc_vars += [
                 model.addVar(
                     obj=0,
                     name="soc_x_%d" % i,
-                    vtype=gurobipy.GRB.CONTINUOUS,
-                    lb=-gurobipy.GRB.INFINITY,
-                    ub=gurobipy.GRB.INFINITY)
+                    vtype=gp.GRB.CONTINUOUS,
+                    lb=-gp.GRB.INFINITY,
+                    ub=gp.GRB.INFINITY)
             ]
         model.update()
 
         new_lin_constrs = []
-        for i, _ in enumerate(lin_expr_list):
-            new_lin_constrs += [
-                model.addConstr(soc_vars[i] == lin_expr_list[i])
-            ]
+        for i, row in enumerate(rows):
+            start = mat.indptr[row]
+            end = mat.indptr[row + 1]
+            x = [variables[j] for j in mat.indices[start:end]]
+            coeff = -mat.data[start:end]
+            expr = gp.LinExpr(coeff, x)
+            expr.addConstant(vec[row])
+            new_lin_constrs.append(model.addLConstr(soc_vars[i], gp.GRB.EQUAL, expr))
 
         t_term = soc_vars[0]*soc_vars[0]
-        x_term = gurobipy.quicksum([var*var for var in soc_vars[1:]])
+        x_term = gp.QuadExpr()
+        x_term.addTerms(np.ones(len(rows) - 1), soc_vars[1:], soc_vars[1:])
         return (model.addQConstr(x_term <= t_term),
                 new_lin_constrs,
                 soc_vars)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -869,7 +869,7 @@ class TestGUROBI(BaseTest):
         StandardTestLPs.test_lp_2(solver='GUROBI')
 
     def test_gurobi_lp_3(self):
-        StandardTestLPs.test_lp_3(solver='GUROBI', DualReductions=0)
+        StandardTestLPs.test_lp_3(solver='GUROBI')
 
     def test_gurobi_lp_4(self):
         StandardTestLPs.test_lp_4(solver='GUROBI')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -869,7 +869,7 @@ class TestGUROBI(BaseTest):
         StandardTestLPs.test_lp_2(solver='GUROBI')
 
     def test_gurobi_lp_3(self):
-        StandardTestLPs.test_lp_3(solver='GUROBI')
+        StandardTestLPs.test_lp_3(solver='GUROBI', DualReductions=0)
 
     def test_gurobi_lp_4(self):
         StandardTestLPs.test_lp_4(solver='GUROBI')


### PR DESCRIPTION
The conic interface to Gurobi processes the linear constraints through a DOK sparse matrix, which can easily induce a big overhead.   Consider the following example:
```
import numpy as np                                                              
import scipy as sp                                                              
import cvxpy as cp                                                              
import time                                                                     
                                                                                
m = 500                                                                         
n = 5000                                                                        
b = np.random.rand(m)                                                           
for d in np.linspace(0.1, 0.8, 3):                                              
    A = sp.sparse.random(m, n, density=d)                                       
    start_time = time.time()                                                    
    n = A.shape[1]                                                              
    x = cp.Variable(n)                                                          
    # Force routing through the conic interface, and make problem               
    # infeasible so that solve time is practically zero.                        
    prob = cp.Problem(cp.Minimize(0),                                           
            [A @ x >= b, x >= 0, cp.sum_squares(x) <= 3.14, x <= -1])           
    prob.solve(solver='GUROBI', verbose=False)                                  
    print("m={:5d} n={:4d} d={:4.2f}: time={:4.1f}".format(                     
        m, n, d, time.time() - start_time))
```

On my local machine I find for current upstream master:
```
m=  500 n=5000 d=0.10: time= 6.2
m=  500 n=5000 d=0.45: time=26.2
m=  500 n=5000 d=0.80: time=45.7
```

In this PR the data is processed in CSR format (similar to the QP interface), and I get:
```
m=  500 n=5000 d=0.10: time= 0.8
m=  500 n=5000 d=0.45: time= 2.9
m=  500 n=5000 d=0.80: time= 5.1
```