### PR TITLE
Big data bug fixes

### DIFF
--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -367,7 +367,7 @@ def get_problem_matrix(linOps,
     I = np.concatenate(I)
     J = np.concatenate(J)
     A = scipy.sparse.csc_matrix(
-        (V, (I, J)), shape=(constr_length*(var_length+1), param_size_plus_one))
+        (V, (I, J)), shape=(np.int64(constr_length)*np.int64(var_length+1), param_size_plus_one))
     return A
 
 

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -224,7 +224,7 @@ class ConicSolver(Solver):
             restructured_A.row = restructured_A.row.astype(np.int64)
             restructured_A.col = restructured_A.col.astype(np.int64)
             restructured_A = restructured_A.reshape(
-                restruct_mat.shape[0] * (problem.x.size + 1),
+                np.int64(restruct_mat.shape[0]) * (np.int64(problem.x.size) + 1),
                 problem.A.shape[1], order='F')
         else:
             restructured_A = problem.A

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -298,7 +298,7 @@ class MOSEK(ConicSolver):
         #   indicating that a function deals with PSD variables.
 
         task.appendvars(n)
-        task.putvarboundlist(np.arange(n, dtype=int),
+        task.putvarboundlist(np.arange(n, dtype=int64),
                              [mosek.boundkey.fr] * n, np.zeros(n), np.zeros(n))
         if psd_total_dims > 0:
             task.appendbarvars(dims[s.PSD_DIM])

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -298,7 +298,7 @@ class MOSEK(ConicSolver):
         #   indicating that a function deals with PSD variables.
 
         task.appendvars(n)
-        task.putvarboundlist(np.arange(n, dtype=int64),
+        task.putvarboundlist(np.arange(n, dtype=int),
                              [mosek.boundkey.fr] * n, np.zeros(n), np.zeros(n))
         if psd_total_dims > 0:
             task.appendbarvars(dims[s.PSD_DIM])


### PR DESCRIPTION
The larger optimization problems using the conic solver were being rejected due to a negative dimension. This arose from the int32 datatype being used. I changed a couple int32 data types to int64 data types so the overflows wouldn't occur. This completely fixed the problems and the solvers seem to be running without any other changes. This fix can definitely be implemented individually in other solvers but I will look through the code in the future to try and cast all int32 types to int64 types to avoid this problem.