### PR TITLE
remove gurobi model update

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -328,7 +328,6 @@ class GUROBI(SCS):
                     lb=-gp.GRB.INFINITY,
                     ub=gp.GRB.INFINITY)
             ]
-        
 
         new_lin_constrs = []
         for i, row in enumerate(rows):

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -178,7 +178,6 @@ class GUROBI(SCS):
                     lb=-gurobipy.GRB.INFINITY,
                     ub=gurobipy.GRB.INFINITY)
             )
-        model.update()
 
         leq_start = dims[s.EQ_DIM]
         leq_end = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
@@ -329,7 +328,7 @@ class GUROBI(SCS):
                     lb=-gp.GRB.INFINITY,
                     ub=gp.GRB.INFINITY)
             ]
-        model.update()
+        
 
         new_lin_constrs = []
         for i, row in enumerate(rows):

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -119,7 +119,7 @@ class GUROBI(QpSolver):
                       ub={i: grb.GRB.INFINITY for i in range(n)},
                       lb={i: -grb.GRB.INFINITY for i in range(n)},
                       vtype=vtypes)
-        model.update()
+        
         x = np.array(model.getVars(), copy=False)
 
         if A.shape[0] > 0:
@@ -143,7 +143,6 @@ class GUROBI(QpSolver):
                     coeff = A.data[start:end]
                     expr = grb.LinExpr(coeff, variables)
                     model.addConstr(expr, grb.GRB.EQUAL, b[i])
-        model.update()
 
         if F.shape[0] > 0:
             if hasattr(model, 'addMConstrs'):
@@ -166,7 +165,6 @@ class GUROBI(QpSolver):
                     coeff = F.data[start:end]
                     expr = grb.LinExpr(coeff, variables)
                     model.addConstr(expr, grb.GRB.LESS_EQUAL, g[i])
-        model.update()
 
         # Define objective
         if hasattr(model, 'setMObjective'):
@@ -185,15 +183,12 @@ class GUROBI(QpSolver):
                              vars2=list(x[P.col]))
             obj.add(grb.LinExpr(q, x))  # Add linear part
             model.setObjective(obj)  # Set objective
-        model.update()
 
         # Set parameters
         model.setParam("QCPDual", True)
         for key, value in solver_opts.items():
             model.setParam(key, value)
 
-        # Update model
-        model.update()
 
         # Solve problem
         results_dict = {}

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -119,7 +119,7 @@ class GUROBI(QpSolver):
                       ub={i: grb.GRB.INFINITY for i in range(n)},
                       lb={i: -grb.GRB.INFINITY for i in range(n)},
                       vtype=vtypes)
-        
+
         x = np.array(model.getVars(), copy=False)
 
         if A.shape[0] > 0:
@@ -188,7 +188,6 @@ class GUROBI(QpSolver):
         model.setParam("QCPDual", True)
         for key, value in solver_opts.items():
             model.setParam(key, value)
-
 
         # Solve problem
         results_dict = {}


### PR DESCRIPTION
gurobi model update sends modification to the gurobi engine. 
When the engine is on a different machine, it causes additional traffic and longer optimization. 

I contacted gurobi support, and they said : 

> It is needed only in some specific cases such as, e.g., if you are working on a compute server or a cloud and want to retrieve specific information from different scenarios. For this you have to change the ScenarioNumber parameter and then call model.update() to make the server actually retrieve the scenario data. For "normal" MIP solving, you don't need to call model.update() when altering your mode