### PR TITLE
Coeffs

### DIFF
--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -263,7 +263,7 @@ class CoeffExtractor(object):
                 cols[entry_offset:entry_offset + P_vals.size] = full_cols
                 entry_offset += P_vals.size
             gap_above += P_shape[0]
-            acc_height += P_height * P_shape[1]
+            acc_height += P_height * np.int64(P_shape[1])
 
         # Stitch together Ps and qs and constant.
         P = sp.coo_matrix((vals, (rows, cols)), shape=(acc_height, num_params))


### PR DESCRIPTION
I was getting the following error:
```
c:\develop\cvxpy\cvxpy\utilities\coeff_extractor.py:266: RuntimeWarning: overflow encountered in long_scalars
  acc_height += P_height * P_shape[1]
Traceback (most recent call last):
...
  File "c:\develop\cvxpy\cvxpy\problems\problem.py", line 396, in solve
    return solve_func(self, *args, **kwargs)
  File "c:\develop\cvxpy\cvxpy\problems\problem.py", line 745, in _solve
    solver, gp, enforce_dpp)
  File "c:\develop\cvxpy\cvxpy\problems\problem.py", line 525, in get_problem_data
    data, inverse_data = solving_chain.apply(self)
  File "c:\develop\cvxpy\cvxpy\reductions\chain.py", line 71, in apply
    problem, inv = r.apply(problem)
  File "c:\develop\cvxpy\cvxpy\reductions\qp2quad_form\qp_matrix_stuffing.py", line 263, in apply
    problem, extractor)
  File "c:\develop\cvxpy\cvxpy\reductions\qp2quad_form\qp_matrix_stuffing.py", line 247, in stuffed_objective
    params_to_P, params_to_q = extractor.quad_form(expr)
  File "c:\develop\cvxpy\cvxpy\utilities\coeff_extractor.py", line 269, in quad_form
    P = sp.coo_matrix((vals, (rows, cols)), shape=(acc_height, num_params))
  File "C:\Develop\Anaconda3\lib\site-packages\scipy\sparse\coo.py", line 156, in __init__
    self._shape = check_shape((M, N))
  File "C:\Develop\Anaconda3\lib\site-packages\scipy\sparse\sputils.py", line 286, in check_shape
    raise ValueError("'shape' elements cannot be negative")
ValueError: 'shape' elements cannot be negative
```

Which was caused by the overflow on the `acc_height` variable. Reason was that type returned by `ndarray.shape` is tuple of `np.int32`s. A quick fix was to change the type of one of the variables in product `acc_height += P_height * P_shape[1]` to `np.int64`. 

I suspect that this is only curing the symptom and not the original dissease but it fixed the issue in my case.