### PR TITLE
Change cone2cone unittest to reflect ECOS_BB change

### DIFF
--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -528,7 +528,6 @@ def mi_socp_1():
              norm(x,2) <= y[1]
              x[0] + x[1] + 3*x[2] >= 0.1
              y <= 5, y integer.
-    and solve with MOSEK.
     """
     x = cp.Variable(shape=(3,))
     y = cp.Variable(shape=(2,), integer=True)

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -304,25 +304,22 @@ class TestSlacks(BaseTest):
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
-    @unittest.skipUnless(INSTALLED_MI, 'No mixed-integer solver is installed.')
     def test_mi_lp_1(self):
         sth = STH.mi_lp_1()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine)
+            TestSlacks.simulate_chain(sth.prob, affine, solvr='ECOS_BB')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
-    @unittest.skipUnless([svr for svr in INSTALLED_MI if svr in MI_SOCP],
-                         'No mixed-integer SOCP solver is installed.')
     def test_mi_socp_1(self):
         sth = STH.mi_socp_1()
         for affine in TestSlacks.AFF_SOCP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine)
+            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS_BB')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
-    @unittest.skipUnless([svr for svr in INSTALLED_MI if svr in MI_SOCP],
-                         'No mixed-integer SOCP solver is installed.')
+    @unittest.skipUnless([svr for svr in INSTALLED_MI if svr in MI_SOCP and svr != 'ECOS_BB'],
+                         'No appropriate mixed-integer SOCP solver is installed.')
     def test_mi_socp_2(self):
         sth = STH.mi_socp_2()
         for affine in TestSlacks.AFF_SOCP_CASES:

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -307,7 +307,7 @@ class TestSlacks(BaseTest):
     def test_mi_lp_1(self):
         sth = STH.mi_lp_1()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solvr='ECOS_BB')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS_BB')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 


### PR DESCRIPTION
The unit tests previously had ``@skipunless`` decorators, which checked if an MI-SOCP solver is installed. Now that ECOS_BB is back, that list had to be explicitly updated to exclude ECOS_BB from a test where it gave an incorrect (suboptimal) solution. 

Excluding ECOS_BB does not indicate the cone2cone reduction is broken, since the test passes when other MI-SOCP solvers are installed.

My plan is to merge this PR once CI tests pass.