### PR TITLE
addressing doc typo issue: dqcp typos #1083

### DIFF
--- a/doc/source/tutorial/dqcp/index.rst
+++ b/doc/source/tutorial/dqcp/index.rst
@@ -125,7 +125,7 @@ quasiconvex under DQCP if it is one of the following:
   decreasing in argument :math:`i` and :math:`e_i` is concave, or :math:`e_i`
   is affine.
 
-An expression quasiconcave under DQCP if it is one of the following:
+An expression is quasiconcave under DQCP if it is one of the following:
 
 - concave (under DCP);
 - a quasiconcave atom, applied to a variable or constant:


### PR DESCRIPTION
Just a simple addition of `is` to make the sentence more understandable

> An expression `is` quasiconcave under DQCP if it is one of the following

this PR addresses this issue https://github.com/cvxgrp/cvxpy/issues/1083