### PR TITLE
remove Eigen from include path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ canon = Extension(
              'cvxpy/cvxcore/python/cvxcore_wrap.cpp'],
     include_dirs=['cvxpy/cvxcore/src/',
                   'cvxpy/cvxcore/python/',
-                  'cvxpy/cvxcore/include/Eigen'],
+                  'cvxpy/cvxcore/include/'],
     extra_compile_args=['-O3'],
 )
 


### PR DESCRIPTION
I tried to do a clean build from src of cvxpy in a fresh Python 3.9 virtual environment using pyenv on Windows/WSL2+Debian 10.4.

I was receiving the following error (gcc/g++ = 8.3.0):
```
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Icvxpy/cvxcore/src/ -Icvxpy/cvxcore/python/ -Icvxpy/cvxcore/include/Eigen -I/home/jason/.pyenv/versions/3.9.0/envs/cvxpy_contrib/include -I/home/jason/.pyenv/versions/3.9.0/include/python3.9 -I/tmp/pip-build-env-ndldwnnq/overlay/lib/python3.9/site-packages/numpy/core/include -c cvxpy/cvxcore/python/cvxcore_wrap.cpp -o build/temp.linux-x86_64-3.9/cvxpy/cvxcore/python/cvxcore_wrap.o -O3
    In file included from /usr/include/c++/8/tuple:39,
                     from /usr/include/c++/8/functional:54,
                     from cvxpy/cvxcore/src/../include/Eigen/Core:153,
                     from cvxpy/cvxcore/src/Utils.hpp:20,
                     from cvxpy/cvxcore/src/LinOp.hpp:18,
                     from cvxpy/cvxcore/src/cvxcore.hpp:18,
                     from cvxpy/cvxcore/python/cvxcore_wrap.cpp:2807:
    cvxpy/cvxcore/include/Eigen/array:8:4: error: #error The Eigen/Array header does no longer exist in Eigen3. All that functionality has moved to Eigen/Core.
       #error The Eigen/Array header does no longer exist in Eigen3. All that functionality has moved to Eigen/Core.
        ^~~~~
```

After some investigation, the import chain eventually leads to `#include <array>`. However, since the Eigen directory is in the include path, its `array` file was being loaded _instead_ of the STL's, leading to the observed error. The solution is simply not to include the Eigen directory immediately in the path (see the 1 line change).

Making this change, the package built without issue in my environment and the unit tests also ran without issue.