### PR TITLE
replace np.eye with sp.eye in qp2quadform

### DIFF
--- a/cvxpy/reductions/qp2quad_form/atom_canonicalizers/power_canon.py
+++ b/cvxpy/reductions/qp2quad_form/atom_canonicalizers/power_canon.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import numpy as np
+import scipy.sparse as sp
 
 from cvxpy.atoms.quad_form import SymbolicQuadForm
 from cvxpy.expressions.constants import Constant
@@ -32,9 +33,9 @@ def power_canon(expr, args):
         return affine_expr, []
     elif p == 2:
         if isinstance(affine_expr, Variable):
-            return SymbolicQuadForm(affine_expr, np.eye(affine_expr.size), expr), []
+            return SymbolicQuadForm(affine_expr, sp.eye(affine_expr.size), expr), []
         else:
             t = Variable(affine_expr.shape)
-            return SymbolicQuadForm(t, np.eye(t.size), expr), [affine_expr == t]
+            return SymbolicQuadForm(t, sp.eye(t.size), expr), [affine_expr == t]
     raise ValueError("non-constant quadratic forms can't be raised to a power "
                      "greater than 2.")


### PR DESCRIPTION
Replace a dense identity with a sparse one in `power_canon` for QPs.

