### PR TITLE
Replace nose with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then CXX=g++; fi
 install: source continuous_integration/Travis/install_dependencies.sh
 script:
-  - bash continuous_integration/Travis/test_script.sh
   - flake8 .
+  - bash continuous_integration/Travis/test_script.sh
 after_success:
   - if [[ "$COVERAGE" == "true" ]]; then coveralls; fi
 deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,36 +97,36 @@ framework for our tests. Tests are organized into classes, which inherit from
 test.
 
 ## Running unit tests
-We use `nose` to run our unit tests, which you can install with `pip install nose`.
+We use `pytest` to run our unit tests, which you can install with `pip install pytest`.
 To run all unit tests, `cd` into `cvxpy/tests` and run the following command:
 
 ```
-nosetests
+pytest
 ````
 
 To run tests in a specific file (e.g., `test_dgp.py`), use
 
 ```
-nosetests test_dgp.py
+pytest test_dgp.py
 ```
 
 To run a specific test method (e.g., `TestDgp.test_product`), use
 
 ```
-nosetests test_dgp.py:TestDgp.test_product
+pytest test_dgp.py::TestDgp::test_product
 ```
 
 Please make sure that your change doesn't cause any of the unit tests to fail.
 
-`nosetests` suppresses stdout by default. To see stdout, pass the `-s` flag
-to `nosetests`.
+`pytest` suppresses stdout by default. To see stdout, pass the `-s` flag
+to `pytest`.
 
 ## Benchmarks
 CVXPY has a few benchmarks in `cvxpy/tests/test_benchmarks.py`, which test
 the time to canonicalize problems. Please run
 
 ```
-nosetests -s test_benchmarks.py
+pytest -s test_benchmarks.py
 ```
 
 with and without your change, to make sure no performance regressions are

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,8 @@ build: false
 test_script:
     - "conda activate testenv"
     - "conda env list"
-    - "nosetests cvxpy"
+    - "pytest cvxpy/tests"
+    - "pytest cvxpy/performance_tests"
 
 deploy_script:
     - "powershell continuous_integration\\AppVeyor\\deploy_windows.ps1"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
 
 test:
   requires:
-    - nose
+    - pytest
 
   # Python imports
   imports:
@@ -66,7 +66,8 @@ test:
     - cvxpy.cvxcore.python
 
   commands:
-    - nosetests cvxpy
+    - pytest cvxpy/tests
+    - pytest cvxpy/performance_tests
 
 about:
   home: http://github.com/cvxgrp/cvxpy/

--- a/continuous_integration/AppVeyor/configure_conda_and_install_cvxpy.ps1
+++ b/continuous_integration/AppVeyor/configure_conda_and_install_cvxpy.ps1
@@ -1,6 +1,6 @@
 conda config --add channels conda-forge
 conda config --add channels oxfordcontrol
-conda create -n testenv --yes python=$env:PYTHON_VERSION mkl=2018.0.3 pip nose numpy scipy
+conda create -n testenv --yes python=$env:PYTHON_VERSION mkl=2018.0.3 pip pytest numpy scipy
 conda activate testenv
 "python=$env:PYTHON_VERSION" | Out-File C:\conda\envs\testenv\conda-meta\pinned -encoding ascii
 conda install --yes lapack ecos multiprocess

--- a/continuous_integration/Travis/install_dependencies.sh
+++ b/continuous_integration/Travis/install_dependencies.sh
@@ -19,7 +19,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         conda update --yes conda
         # Configure the conda environment and put it in the path using the
         # provided versions
-        conda create -n testenv --yes python=$PYTHON_VERSION mkl pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION mkl pip pytest \
                 numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
         source activate testenv
         PIN_FILE=/home/travis/miniconda3/envs/testenv/conda-meta/pinned
@@ -44,7 +44,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         conda update --yes conda
         # Configure the conda environment and put it in the path using the
         # provided versions
-        conda create -n testenv --yes python=$PYTHON_VERSION mkl pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION mkl pip pytest \
               numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
         source activate testenv
         PIN_FILE=/Users/travis/miniconda3/envs/testenv/conda-meta/pinned

--- a/continuous_integration/Travis/test_script.sh
+++ b/continuous_integration/Travis/test_script.sh
@@ -18,4 +18,6 @@ if [[ "$COVERAGE" == "true" ]]; then
 else
     export WITH_COVERAGE=""
 fi
-nosetests $WITH_COVERAGE cvxpy
+
+pytest $WITH_COVERAGE cvxpy/tests
+pytest $WITH_COVERAGE cvxpy/performance_tests

--- a/continuous_integration/appveyor_install.ps1
+++ b/continuous_integration/appveyor_install.ps1
@@ -20,7 +20,7 @@ echo $env:PATH
 
 # Configure miniconda
 
-conda create -n $env:ENV_NAME --yes python=$env:PYTHON_VERSION mkl=2018.0.3 pip nose numpy scipy
+conda create -n $env:ENV_NAME --yes python=$env:PYTHON_VERSION mkl=2018.0.3 pip pytest numpy scipy
 activate $env:ENV_NAME
 # The conda activation doesn't work well from PowerShell.
 # We need to update environment variables.
@@ -32,7 +32,6 @@ conda install -c anaconda --yes flake8
 pip install scs<=2.0
 
 # Install cvxpy
-
 python setup.py install
 
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 import scipy.linalg as la
-from nose.tools import assert_raises
+import pytest
 
 import cvxpy as cp
 from cvxpy.error import SolverError
@@ -1208,7 +1208,7 @@ class TestSCIP(unittest.TestCase):
         prob = self.get_simple_problem()
         # Since an invalid NON-scip param is passed, an error is expected
         # to be raised when calling solve.
-        with assert_raises(KeyError) as ke:
+        with pytest.raises(KeyError) as ke:
             prob.solve(solver="SCIP", a="what?")
             exc = "One or more solver params in ['a'] are not valid: 'Not a valid parameter name'"
             assert ke.exception == exc
@@ -1217,7 +1217,7 @@ class TestSCIP(unittest.TestCase):
         prob = self.get_simple_problem()
         # Since an invalid SCIP param is passed, an error is expected
         # to be raised when calling solve.
-        with assert_raises(KeyError) as ke:
+        with pytest.raises(KeyError) as ke:
             prob.solve(solver="SCIP", scip_params={"a": "what?"})
             exc = "One or more scip params in ['a'] are not valid: 'Not a valid parameter name'"
             assert ke.exception == exc

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -28,6 +28,7 @@ import numpy as np
 import numpy.linalg as LA
 import math
 import itertools
+import pytest
 
 ROBUST_CVXOPT = "robust_cvxopt"
 SOLVER_TO_TOL = {SCS: 1e-2,
@@ -48,8 +49,11 @@ if MOSEK in INSTALLED_SOLVERS:
 v_np = np.array([-1., 2, -2]).T
 
 # Defined here to be used in KNOWN_SOLVER_ERRORS
-log_sum_exp_axis_0 = lambda x: cp.log_sum_exp(x, axis=0, keepdims=True) # noqa E371
-log_sum_exp_axis_1 = lambda x: cp.log_sum_exp(x, axis=1) # noqa E371
+
+
+def log_sum_exp_axis_0(x): return cp.log_sum_exp(x, axis=0, keepdims=True)  # noqa E371
+def log_sum_exp_axis_1(x): return cp.log_sum_exp(x, axis=1)  # noqa E371
+
 
 # Atom, solver pairs known to fail.
 KNOWN_SOLVER_ERRORS = [
@@ -59,219 +63,219 @@ KNOWN_SOLVER_ERRORS = [
     (cp.kl_div, CVXOPT),
 ]
 
-atoms = [
-    ([
-        (cp.abs, (2, 2), [[[-5, 2], [-3, 1]]],
-            Constant([[5, 2], [3, 1]])),
-        (lambda x: cp.cumsum(x, axis=1), (2, 2), [[[-5, 2], [-3, 1]]],
-            Constant([[-5, 2], [-8, 3]])),
-        (lambda x: cp.cumsum(x, axis=0), (2, 2), [[[-5, 2], [-3, 1]]],
-            Constant([[-5, -3], [-3, -2]])),
-        (lambda x: cp.cummax(x, axis=1), (2, 2), [[[-5, 2], [-3, 1]]],
-            Constant([[-5, 2], [-3, 2]])),
-        (lambda x: cp.cummax(x, axis=0), (2, 2), [[[-5, 2], [-3, 1]]],
-            Constant([[-5, 2], [-3, 1]])),
-        (cp.diag, (2,), [[[-5, 2], [-3, 1]]], Constant([-5, 1])),
-        (cp.diag, (2, 2), [[-5, 1]], Constant([[-5, 0], [0, 1]])),
-        (cp.exp, (2, 2), [[[1, 0], [2, -1]]],
-            Constant([[math.e, 1], [math.e**2, 1.0/math.e]])),
-        (cp.huber, (2, 2), [[[0.5, -1.5], [4, 0]]],
-            Constant([[0.25, 2], [7, 0]])),
-        (lambda x: cp.huber(x, 2.5), (2, 2), [[[0.5, -1.5], [4, 0]]],
-         Constant([[0.25, 2.25], [13.75, 0]])),
-        (cp.inv_pos, (2, 2), [[[1, 2], [3, 4]]],
-            Constant([[1, 1.0/2], [1.0/3, 1.0/4]])),
-        (lambda x: (x + Constant(0))**-1, (2, 2), [[[1, 2], [3, 4]]],
-            Constant([[1, 1.0/2], [1.0/3, 1.0/4]])),
-        (cp.kl_div, tuple(), [math.e, 1], Constant([1])),
-        (cp.kl_div, tuple(), [math.e, math.e], Constant([0])),
-        (cp.kl_div, (2,), [[math.e, 1], 1], Constant([1, 0])),
-        (lambda x: cp.kron(np.array([[1, 2], [3, 4]]), x), (4, 4), [np.array([[5, 6], [7, 8]])],
-            Constant(np.kron(np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]])))),
-        (cp.lambda_max, tuple(), [[[2, 0], [0, 1]]], Constant([2])),
-        (cp.lambda_max, tuple(), [[[2, 0, 0], [0, 3, 0], [0, 0, 1]]], Constant([3])),
+atoms_minimize = [
+    (cp.abs, (2, 2), [[[-5, 2], [-3, 1]]],
+     Constant([[5, 2], [3, 1]])),
+    (lambda x: cp.cumsum(x, axis=1), (2, 2), [[[-5, 2], [-3, 1]]],
+     Constant([[-5, 2], [-8, 3]])),
+    (lambda x: cp.cumsum(x, axis=0), (2, 2), [[[-5, 2], [-3, 1]]],
+     Constant([[-5, -3], [-3, -2]])),
+    (lambda x: cp.cummax(x, axis=1), (2, 2), [[[-5, 2], [-3, 1]]],
+     Constant([[-5, 2], [-3, 2]])),
+    (lambda x: cp.cummax(x, axis=0), (2, 2), [[[-5, 2], [-3, 1]]],
+     Constant([[-5, 2], [-3, 1]])),
+    (cp.diag, (2,), [[[-5, 2], [-3, 1]]], Constant([-5, 1])),
+    (cp.diag, (2, 2), [[-5, 1]], Constant([[-5, 0], [0, 1]])),
+    (cp.exp, (2, 2), [[[1, 0], [2, -1]]],
+     Constant([[math.e, 1], [math.e**2, 1.0 / math.e]])),
+    (cp.huber, (2, 2), [[[0.5, -1.5], [4, 0]]],
+     Constant([[0.25, 2], [7, 0]])),
+    (lambda x: cp.huber(x, 2.5), (2, 2), [[[0.5, -1.5], [4, 0]]],
+     Constant([[0.25, 2.25], [13.75, 0]])),
+    (cp.inv_pos, (2, 2), [[[1, 2], [3, 4]]],
+     Constant([[1, 1.0 / 2], [1.0 / 3, 1.0 / 4]])),
+    (lambda x: (x + Constant(0))**-1, (2, 2), [[[1, 2], [3, 4]]],
+     Constant([[1, 1.0 / 2], [1.0 / 3, 1.0 / 4]])),
+    (cp.kl_div, tuple(), [math.e, 1], Constant([1])),
+    (cp.kl_div, tuple(), [math.e, math.e], Constant([0])),
+    (cp.kl_div, (2,), [[math.e, 1], 1], Constant([1, 0])),
+    (lambda x: cp.kron(np.array([[1, 2], [3, 4]]), x), (4, 4), [np.array([[5, 6], [7, 8]])],
+     Constant(np.kron(np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]])))),
+    (cp.lambda_max, tuple(), [[[2, 0], [0, 1]]], Constant([2])),
+    (cp.lambda_max, tuple(), [[[2, 0, 0], [0, 3, 0], [0, 0, 1]]], Constant([3])),
 
-        (cp.lambda_max, tuple(), [[[5, 7], [7, -3]]], Constant([9.06225775])),
-        (lambda x: cp.lambda_sum_largest(x, 2), tuple(),
-         [[[1, 2, 3], [2, 4, 5], [3, 5, 6]]], Constant([11.51572947])),
-        (cp.log_sum_exp, tuple(), [[[5, 7], [0, -3]]], Constant([7.1277708268])),
-        (log_sum_exp_axis_0, (1, 2),
-         [[[5, 7, 1], [0, -3, 6]]], Constant([[7.12910890], [6.00259878]])),
-        (log_sum_exp_axis_1, (3,),
-         [[[5, 7, 1], [0, -3, 6]]], Constant([5.00671535, 7.0000454, 6.0067153])),
-        (cp.logistic, (2, 2),
-         [
-             [[math.log(5), math.log(7)],
-              [0,           math.log(0.3)]]],
-         Constant(
-             [[math.log(6), math.log(8)],
-              [math.log(2), math.log(1.3)]])),
-        (cp.matrix_frac, tuple(), [[1, 2, 3],
-                                   [[1, 0, 0],
-                                    [0, 1, 0],
-                                    [0, 0, 1]]], Constant([14])),
-        (cp.matrix_frac, tuple(), [[1, 2, 3],
-                                   [[67, 78, 90],
-                                    [78, 94, 108],
-                                    [90, 108, 127]]], Constant([0.46557377049180271])),
-        (cp.matrix_frac, tuple(), [[[1, 2, 3],
-                                    [4, 5, 6]],
-                                   [[67, 78, 90],
-                                    [78, 94, 108],
-                                    [90, 108, 127]]], Constant([0.768852459016])),
-        (cp.maximum, (2,), [[-5, 2], [-3, 1], 0, [-1, 2]], Constant([0, 2])),
-        (cp.maximum, (2, 2), [[[-5, 2], [-3, 1]], 0, [[5, 4], [-1, 2]]],
-            Constant([[5, 4], [0, 2]])),
-        (cp.max, tuple(), [[[-5, 2], [-3, 1]]], Constant([2])),
-        (cp.max, tuple(), [[-5, -10]], Constant([-5])),
-        (lambda x: cp.max(x, axis=0, keepdims=True), (1, 2),
-         [[[-5, 2], [-3, 1]]], Constant([[2], [1]])),
-        (lambda x: cp.max(x, axis=1), (2,), [[[-5, 2], [-3, 1]]], Constant([-3, 2])),
-        (lambda x: cp.norm(x, 2), tuple(), [v_np], Constant([3])),
-        (lambda x: cp.norm(x, "fro"), tuple(), [[[-1, 2], [3, -4]]],
-            Constant([5.47722557])),
-        (lambda x: cp.norm(x, 1), tuple(), [v_np], Constant([5])),
-        (lambda x: cp.norm(x, 1), tuple(), [[[-1, 2], [3, -4]]],
-            Constant([10])),
-        (lambda x: cp.norm(x, "inf"), tuple(), [v_np], Constant([2])),
-        (lambda x: cp.norm(x, "inf"), tuple(), [[[-1, 2], [3, -4]]],
-            Constant([4])),
-        (lambda x: cp.norm(x, "nuc"), tuple(), [[[2, 0], [0, 1]]], Constant([3])),
-        (lambda x: cp.norm(x, "nuc"), tuple(), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]],
-            Constant([23.173260452512931])),
-        (lambda x: cp.norm(x, "nuc"), tuple(), [[[3, 4, 5], [6, 7, 8]]],
-            Constant([14.618376738088918])),
-        (lambda x: cp.sum_largest(cp.abs(x), 3), tuple(), [[1, 2, 3, -4, -5]], Constant([5+4+3])),
-        (lambda x: cp.mixed_norm(x, 1, 1), tuple(), [[[1, 2], [3, 4], [5, 6]]],
-            Constant([21])),
-        (lambda x: cp.mixed_norm(x, 1, 1), tuple(), [[[1, 2, 3], [4, 5, 6]]],
-            Constant([21])),
-        # (lambda x: mixed_norm(x, 2, 1), tuple(), [[[3, 1], [4, math.sqrt(3)]]],
-        #     Constant([7])),
-        (lambda x: cp.mixed_norm(x, 1, 'inf'), tuple(), [[[1, 4], [5, 6]]],
-            Constant([10])),
+    (cp.lambda_max, tuple(), [[[5, 7], [7, -3]]], Constant([9.06225775])),
+    (lambda x: cp.lambda_sum_largest(x, 2), tuple(),
+     [[[1, 2, 3], [2, 4, 5], [3, 5, 6]]], Constant([11.51572947])),
+    (cp.log_sum_exp, tuple(), [[[5, 7], [0, -3]]], Constant([7.1277708268])),
+    (log_sum_exp_axis_0, (1, 2),
+     [[[5, 7, 1], [0, -3, 6]]], Constant([[7.12910890], [6.00259878]])),
+    (log_sum_exp_axis_1, (3,),
+     [[[5, 7, 1], [0, -3, 6]]], Constant([5.00671535, 7.0000454, 6.0067153])),
+    (cp.logistic, (2, 2),
+     [
+        [[math.log(5), math.log(7)],
+         [0, math.log(0.3)]]],
+     Constant(
+        [[math.log(6), math.log(8)],
+         [math.log(2), math.log(1.3)]])),
+    (cp.matrix_frac, tuple(), [[1, 2, 3],
+                               [[1, 0, 0],
+                                [0, 1, 0],
+                                [0, 0, 1]]], Constant([14])),
+    (cp.matrix_frac, tuple(), [[1, 2, 3],
+                               [[67, 78, 90],
+                                [78, 94, 108],
+                                [90, 108, 127]]], Constant([0.46557377049180271])),
+    (cp.matrix_frac, tuple(), [[[1, 2, 3],
+                                [4, 5, 6]],
+                               [[67, 78, 90],
+                                [78, 94, 108],
+                                [90, 108, 127]]], Constant([0.768852459016])),
+    (cp.maximum, (2,), [[-5, 2], [-3, 1], 0, [-1, 2]], Constant([0, 2])),
+    (cp.maximum, (2, 2), [[[-5, 2], [-3, 1]], 0, [[5, 4], [-1, 2]]],
+     Constant([[5, 4], [0, 2]])),
+    (cp.max, tuple(), [[[-5, 2], [-3, 1]]], Constant([2])),
+    (cp.max, tuple(), [[-5, -10]], Constant([-5])),
+    (lambda x: cp.max(x, axis=0, keepdims=True), (1, 2),
+     [[[-5, 2], [-3, 1]]], Constant([[2], [1]])),
+    (lambda x: cp.max(x, axis=1), (2,), [[[-5, 2], [-3, 1]]], Constant([-3, 2])),
+    (lambda x: cp.norm(x, 2), tuple(), [v_np], Constant([3])),
+    (lambda x: cp.norm(x, "fro"), tuple(), [[[-1, 2], [3, -4]]],
+     Constant([5.47722557])),
+    (lambda x: cp.norm(x, 1), tuple(), [v_np], Constant([5])),
+    (lambda x: cp.norm(x, 1), tuple(), [[[-1, 2], [3, -4]]],
+     Constant([10])),
+    (lambda x: cp.norm(x, "inf"), tuple(), [v_np], Constant([2])),
+    (lambda x: cp.norm(x, "inf"), tuple(), [[[-1, 2], [3, -4]]],
+     Constant([4])),
+    (lambda x: cp.norm(x, "nuc"), tuple(), [[[2, 0], [0, 1]]], Constant([3])),
+    (lambda x: cp.norm(x, "nuc"), tuple(), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]],
+     Constant([23.173260452512931])),
+    (lambda x: cp.norm(x, "nuc"), tuple(), [[[3, 4, 5], [6, 7, 8]]],
+     Constant([14.618376738088918])),
+    (lambda x: cp.sum_largest(cp.abs(x), 3), tuple(), [[1, 2, 3, -4, -5]], Constant([5 + 4 + 3])),
+    (lambda x: cp.mixed_norm(x, 1, 1), tuple(), [[[1, 2], [3, 4], [5, 6]]],
+     Constant([21])),
+    (lambda x: cp.mixed_norm(x, 1, 1), tuple(), [[[1, 2, 3], [4, 5, 6]]],
+     Constant([21])),
+    # (lambda x: mixed_norm(x, 2, 1), tuple(), [[[3, 1], [4, math.sqrt(3)]]],
+    #     Constant([7])),
+    (lambda x: cp.mixed_norm(x, 1, 'inf'), tuple(), [[[1, 4], [5, 6]]],
+     Constant([10])),
 
-        (cp.pnorm, tuple(), [[1, 2, 3]], Constant([3.7416573867739413])),
-        (lambda x: cp.pnorm(x, 1), tuple(), [[1.1, 2, -3]], Constant([6.1])),
-        (lambda x: cp.pnorm(x, 2), tuple(), [[1.1, 2, -3]], Constant([3.7696153649941531])),
-        (lambda x: cp.pnorm(x, 2, axis=0), (2,),
-         [[[1, 2], [3, 4]]], Constant([math.sqrt(5), 5.]).T),
-        (lambda x: cp.pnorm(x, 2, axis=1), (2,),
-         [[[1, 2], [4, 5]]], Constant([math.sqrt(17), math.sqrt(29)])),
-        (lambda x: cp.pnorm(x, 'inf'), tuple(), [[1.1, 2, -3]], Constant([3])),
-        (lambda x: cp.pnorm(x, 3), tuple(), [[1.1, 2, -3]], Constant([3.3120161866074733])),
-        (lambda x: cp.pnorm(x, 5.6), tuple(), [[1.1, 2, -3]], Constant([3.0548953718931089])),
-        (lambda x: cp.pnorm(x, 1.2), tuple(),
-         [[[1, 2, 3], [4, 5, 6]]], Constant([15.971021676279573])),
+    (cp.pnorm, tuple(), [[1, 2, 3]], Constant([3.7416573867739413])),
+    (lambda x: cp.pnorm(x, 1), tuple(), [[1.1, 2, -3]], Constant([6.1])),
+    (lambda x: cp.pnorm(x, 2), tuple(), [[1.1, 2, -3]], Constant([3.7696153649941531])),
+    (lambda x: cp.pnorm(x, 2, axis=0), (2,),
+     [[[1, 2], [3, 4]]], Constant([math.sqrt(5), 5.]).T),
+    (lambda x: cp.pnorm(x, 2, axis=1), (2,),
+     [[[1, 2], [4, 5]]], Constant([math.sqrt(17), math.sqrt(29)])),
+    (lambda x: cp.pnorm(x, 'inf'), tuple(), [[1.1, 2, -3]], Constant([3])),
+    (lambda x: cp.pnorm(x, 3), tuple(), [[1.1, 2, -3]], Constant([3.3120161866074733])),
+    (lambda x: cp.pnorm(x, 5.6), tuple(), [[1.1, 2, -3]], Constant([3.0548953718931089])),
+    (lambda x: cp.pnorm(x, 1.2), tuple(),
+     [[[1, 2, 3], [4, 5, 6]]], Constant([15.971021676279573])),
 
-        (cp.pos, tuple(), [8], Constant([8])),
-        (cp.pos, (2,), [[-3, 2]], Constant([0, 2])),
-        (cp.neg, (2,), [[-3, 3]], Constant([3, 0])),
+    (cp.pos, tuple(), [8], Constant([8])),
+    (cp.pos, (2,), [[-3, 2]], Constant([0, 2])),
+    (cp.neg, (2,), [[-3, 3]], Constant([3, 0])),
 
 
-        (lambda x: cp.power(x, 1), tuple(), [7.45], Constant([7.45])),
-        (lambda x: cp.power(x, 2), tuple(), [7.45], Constant([55.502500000000005])),
-        (lambda x: cp.power(x, -1), tuple(), [7.45], Constant([0.1342281879194631])),
-        (lambda x: cp.power(x, -.7), tuple(), [7.45], Constant([0.24518314363015764])),
-        (lambda x: cp.power(x, -1.34), tuple(), [7.45], Constant([0.06781263100321579])),
-        (lambda x: cp.power(x, 1.34), tuple(), [7.45], Constant([14.746515290825071])),
+    (lambda x: cp.power(x, 1), tuple(), [7.45], Constant([7.45])),
+    (lambda x: cp.power(x, 2), tuple(), [7.45], Constant([55.502500000000005])),
+    (lambda x: cp.power(x, -1), tuple(), [7.45], Constant([0.1342281879194631])),
+    (lambda x: cp.power(x, -.7), tuple(), [7.45], Constant([0.24518314363015764])),
+    (lambda x: cp.power(x, -1.34), tuple(), [7.45], Constant([0.06781263100321579])),
+    (lambda x: cp.power(x, 1.34), tuple(), [7.45], Constant([14.746515290825071])),
 
-        (cp.quad_over_lin, tuple(), [[[-1, 2, -2], [-1, 2, -2]], 2], Constant([2*4.5])),
-        (cp.quad_over_lin, tuple(), [v_np, 2], Constant([4.5])),
-        (lambda x: cp.norm(x, 2), tuple(), [[[2, 0], [0, 1]]], Constant([2])),
-        (lambda x: cp.norm(x, 2), tuple(),
-         [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([22.368559552680377])),
-        (lambda x: cp.scalene(x, 2, 3), (2, 2), [[[-5, 2], [-3, 1]]], Constant([[15, 4], [9, 2]])),
-        (cp.square, (2, 2), [[[-5, 2], [-3, 1]]], Constant([[25, 4], [9, 1]])),
-        (cp.sum, tuple(), [[[-5, 2], [-3, 1]]], Constant(-5)),
-        (lambda x: cp.sum(x, axis=0), (2,), [[[-5, 2], [-3, 1]]], Constant([-3, -2])),
-        (lambda x: cp.sum(x, axis=1), (2,), [[[-5, 2], [-3, 1]]], Constant([-8, 3])),
-        (lambda x: (x + Constant(0))**2, (2, 2), [[[-5, 2], [-3, 1]]], Constant([[25, 4], [9, 1]])),
-        (lambda x: cp.sum_largest(x, 3), tuple(), [[1, 2, 3, 4, 5]], Constant([5+4+3])),
-        (lambda x: cp.sum_largest(x, 3), tuple(),
-         [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([9+10+11])),
-        (cp.sum_squares, tuple(), [[[-1, 2], [3, -4]]], Constant([30])),
-        (cp.trace, tuple(), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([3 + 7 + 11])),
-        (cp.trace, tuple(), [[[-5, 2], [-3, 1]]], Constant([-5 + 1])),
-        (cp.tv, tuple(), [[1, -1, 2]], Constant([5])),
-        (cp.tv, tuple(), [[1, -1, 2]], Constant([5])),
-        (cp.tv, tuple(), [[[-5, 2], [-3, 1]]], Constant([math.sqrt(53)])),
-        (cp.tv, tuple(), [[[-5, 2], [-3, 1]], [[6, 5], [-4, 3]], [[8, 0], [15, 9]]],
-            Constant([LA.norm([7, -1, -8, 2, -10, 7])])),
-        (cp.tv, tuple(), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([4*math.sqrt(10)])),
-        (cp.upper_tri, (3,), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([6, 9, 10])),
-        # # Advanced indexing.
-        (lambda x: x[[1, 2], [0, 2]], (2,),
-         [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([4, 11])),
-        (lambda x: x[[1, 2]], (2, 2), [[[3, 4, 5], [6, 7, 8]]], Constant([[4, 5], [7, 8]])),
-        (lambda x: x[np.array([[3, 4, 5], [6, 7, 8]]).T % 2 == 0], (2,), [[[3, 4, 5], [6, 7, 8]]],
-         Constant([6, 4, 8])),
-        (lambda x: x[2:0:-1], (2,), [[3, 4, 5]], Constant([5, 4])),
-        (lambda x: x[2::-1], (3,), [[3, 4, 5]], Constant([5, 4, 3])),
-        (lambda x: x[3:0:-1], (2,), [[3, 4, 5]], Constant([5, 4])),
-        (lambda x: x[3::-1], (3,), [[3, 4, 5]], Constant([5, 4, 3])),
-    ], cp.Minimize),
-    ([
-        (cp.entr, (2, 2), [[[1, math.e], [math.e**2, 1.0/math.e]]],
-         Constant([[0, -math.e], [-2*math.e**2, 1.0/math.e]])),
-        (cp.log_det, tuple(),
-         [[[20, 8, 5, 2],
-           [8, 16, 2, 4],
-           [5, 2, 5, 2],
-           [2, 4, 2, 4]]], Constant([7.7424020218157814])),
-        (cp.geo_mean, tuple(), [[4, 1]], Constant([2])),
-        (cp.geo_mean, tuple(), [[0.01, 7]], Constant([0.2645751311064591])),
-        (cp.geo_mean, tuple(), [[63, 7]], Constant([21])),
-        (cp.geo_mean, tuple(), [[1, 10]], Constant([math.sqrt(10)])),
-        (lambda x: cp.geo_mean(x, [1, 1]), tuple(), [[1, 10]], Constant([math.sqrt(10)])),
-        (lambda x: cp.geo_mean(x, [.4, .8, 4.9]), tuple(),
-         [[.5, 1.8, 17]], Constant([10.04921378316062])),
-        (cp.harmonic_mean, tuple(), [[1, 2, 3]], Constant([1.6363636363636365])),
-        (cp.harmonic_mean, tuple(), [[2.5, 2.5, 2.5, 2.5]], Constant([2.5])),
-        (cp.harmonic_mean, tuple(), [[0, 1, 2]], Constant([0])),
+    (cp.quad_over_lin, tuple(), [[[-1, 2, -2], [-1, 2, -2]], 2], Constant([2 * 4.5])),
+    (cp.quad_over_lin, tuple(), [v_np, 2], Constant([4.5])),
+    (lambda x: cp.norm(x, 2), tuple(), [[[2, 0], [0, 1]]], Constant([2])),
+    (lambda x: cp.norm(x, 2), tuple(),
+     [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([22.368559552680377])),
+    (lambda x: cp.scalene(x, 2, 3), (2, 2), [[[-5, 2], [-3, 1]]], Constant([[15, 4], [9, 2]])),
+    (cp.square, (2, 2), [[[-5, 2], [-3, 1]]], Constant([[25, 4], [9, 1]])),
+    (cp.sum, tuple(), [[[-5, 2], [-3, 1]]], Constant(-5)),
+    (lambda x: cp.sum(x, axis=0), (2,), [[[-5, 2], [-3, 1]]], Constant([-3, -2])),
+    (lambda x: cp.sum(x, axis=1), (2,), [[[-5, 2], [-3, 1]]], Constant([-8, 3])),
+    (lambda x: (x + Constant(0))**2, (2, 2), [[[-5, 2], [-3, 1]]], Constant([[25, 4], [9, 1]])),
+    (lambda x: cp.sum_largest(x, 3), tuple(), [[1, 2, 3, 4, 5]], Constant([5 + 4 + 3])),
+    (lambda x: cp.sum_largest(x, 3), tuple(),
+     [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([9 + 10 + 11])),
+    (cp.sum_squares, tuple(), [[[-1, 2], [3, -4]]], Constant([30])),
+    (cp.trace, tuple(), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([3 + 7 + 11])),
+    (cp.trace, tuple(), [[[-5, 2], [-3, 1]]], Constant([-5 + 1])),
+    (cp.tv, tuple(), [[1, -1, 2]], Constant([5])),
+    (cp.tv, tuple(), [[1, -1, 2]], Constant([5])),
+    (cp.tv, tuple(), [[[-5, 2], [-3, 1]]], Constant([math.sqrt(53)])),
+    (cp.tv, tuple(), [[[-5, 2], [-3, 1]], [[6, 5], [-4, 3]], [[8, 0], [15, 9]]],
+     Constant([LA.norm([7, -1, -8, 2, -10, 7])])),
+    (cp.tv, tuple(), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([4 * math.sqrt(10)])),
+    (cp.upper_tri, (3,), [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([6, 9, 10])),
+    # # Advanced indexing.
+    (lambda x: x[[1, 2], [0, 2]], (2,),
+     [[[3, 4, 5], [6, 7, 8], [9, 10, 11]]], Constant([4, 11])),
+    (lambda x: x[[1, 2]], (2, 2), [[[3, 4, 5], [6, 7, 8]]], Constant([[4, 5], [7, 8]])),
+    (lambda x: x[np.array([[3, 4, 5], [6, 7, 8]]).T % 2 == 0], (2,), [[[3, 4, 5], [6, 7, 8]]],
+     Constant([6, 4, 8])),
+    (lambda x: x[2:0:-1], (2,), [[3, 4, 5]], Constant([5, 4])),
+    (lambda x: x[2::-1], (3,), [[3, 4, 5]], Constant([5, 4, 3])),
+    (lambda x: x[3:0:-1], (2,), [[3, 4, 5]], Constant([5, 4])),
+    (lambda x: x[3::-1], (3,), [[3, 4, 5]], Constant([5, 4, 3])),
 
-        (lambda x: cp.diff(x, 0), (3,), [[1, 2, 3]], Constant([1, 2, 3])),
-        (cp.diff, (2,), [[1, 2, 3]], Constant([1, 1])),
-        (cp.diff, tuple(), [[1.1, 2.3]], Constant([1.2])),
-        (lambda x: cp.diff(x, 2), tuple(), [[1, 2, 3]], Constant([0])),
-        (cp.diff, (3,), [[2.1, 1, 4.5, -.1]], Constant([-1.1, 3.5, -4.6])),
-        (lambda x: cp.diff(x, 2), (2,), [[2.1, 1, 4.5, -.1]], Constant([4.6, -8.1])),
-        (lambda x: cp.diff(x, 1, axis=0), (1, 2), [np.array([[-5, -3], [2, 1]])],
-            Constant([[7], [4]])),
-        (lambda x: cp.diff(x, 1, axis=1), (2, 1), [np.array([[-5, -3], [2, 1]])],
-            Constant([[2, -1]])),
+]
 
-        (lambda x: cp.pnorm(x, .5), tuple(), [[1.1, 2, .1]], Constant([7.724231543909264])),
-        (lambda x: cp.pnorm(x, -.4), tuple(), [[1.1, 2, .1]], Constant([0.02713620334])),
-        (lambda x: cp.pnorm(x, -1), tuple(), [[1.1, 2, .1]], Constant([0.0876494023904])),
-        (lambda x: cp.pnorm(x, -2.3), tuple(), [[1.1, 2, .1]], Constant([0.099781528576])),
 
-        (cp.lambda_min, tuple(), [[[2, 0], [0, 1]]], Constant([1])),
-        (cp.lambda_min, tuple(), [[[5, 7], [7, -3]]], Constant([-7.06225775])),
-        (lambda x: cp.lambda_sum_smallest(x, 2), tuple(),
-         [[[1, 2, 3], [2, 4, 5], [3, 5, 6]]], Constant([-0.34481428])),
-        (cp.log, (2, 2), [[[1, math.e], [math.e**2, 1.0/math.e]]], Constant([[0, 1], [2, -1]])),
-        (cp.log1p, (2, 2), [[[0, math.e-1],
-                             [math.e**2-1, 1.0/math.e-1]]], Constant([[0, 1], [2, -1]])),
-        (cp.minimum, (2,), [[-5, 2], [-3, 1], 0, [1, 2]], Constant([-5, 0])),
-        (cp.minimum, (2, 2), [[[-5, 2], [-3, -1]],
-                              0,
-                              [[5, 4], [-1, 2]]], Constant([[-5, 0], [-3, -1]])),
-        (cp.min, tuple(), [[[-5, 2], [-3, 1]]], Constant([-5])),
-        (cp.min, tuple(), [[-5, -10]], Constant([-10])),
-        (lambda x: x**0.25, tuple(), [7.45], Constant([7.45**0.25])),
-        (lambda x: x**0.32, (2,), [[7.45, 3.9]], Constant(np.power(np.array([7.45, 3.9]), 0.32))),
-        (lambda x: x**0.9, (2, 2),  [[[7.45, 2.2],
-                                      [4, 7]]], Constant(np.power(np.array([[7.45, 2.2],
-                                                                            [4, 7]]).T, 0.9))),
-        (cp.sqrt, (2, 2), [[[2, 4], [16, 1]]], Constant([[1.414213562373095, 2], [4, 1]])),
-        (lambda x: cp.sum_smallest(x, 3), tuple(), [[-1, 2, 3, 4, 5]], Constant([-1+2+3])),
-        (lambda x: cp.sum_smallest(x, 4), tuple(),
-         [[[-3, -4, 5], [6, 7, 8], [9, 10, 11]]], Constant([-3-4+5+6])),
-        (lambda x: (x + Constant(0))**0.5, (2, 2),
-         [[[2, 4], [16, 1]]], Constant([[1.414213562373095, 2], [4, 1]])),
-    ],
-        cp.Maximize),
+atoms_maximize = [
+    (cp.entr, (2, 2), [[[1, math.e], [math.e**2, 1.0 / math.e]]],
+     Constant([[0, -math.e], [-2 * math.e**2, 1.0 / math.e]])),
+    (cp.log_det, tuple(),
+     [[[20, 8, 5, 2],
+       [8, 16, 2, 4],
+       [5, 2, 5, 2],
+       [2, 4, 2, 4]]], Constant([7.7424020218157814])),
+    (cp.geo_mean, tuple(), [[4, 1]], Constant([2])),
+    (cp.geo_mean, tuple(), [[0.01, 7]], Constant([0.2645751311064591])),
+    (cp.geo_mean, tuple(), [[63, 7]], Constant([21])),
+    (cp.geo_mean, tuple(), [[1, 10]], Constant([math.sqrt(10)])),
+    (lambda x: cp.geo_mean(x, [1, 1]), tuple(), [[1, 10]], Constant([math.sqrt(10)])),
+    (lambda x: cp.geo_mean(x, [.4, .8, 4.9]), tuple(),
+     [[.5, 1.8, 17]], Constant([10.04921378316062])),
+    (cp.harmonic_mean, tuple(), [[1, 2, 3]], Constant([1.6363636363636365])),
+    (cp.harmonic_mean, tuple(), [[2.5, 2.5, 2.5, 2.5]], Constant([2.5])),
+    (cp.harmonic_mean, tuple(), [[0, 1, 2]], Constant([0])),
+
+    (lambda x: cp.diff(x, 0), (3,), [[1, 2, 3]], Constant([1, 2, 3])),
+    (cp.diff, (2,), [[1, 2, 3]], Constant([1, 1])),
+    (cp.diff, tuple(), [[1.1, 2.3]], Constant([1.2])),
+    (lambda x: cp.diff(x, 2), tuple(), [[1, 2, 3]], Constant([0])),
+    (cp.diff, (3,), [[2.1, 1, 4.5, -.1]], Constant([-1.1, 3.5, -4.6])),
+    (lambda x: cp.diff(x, 2), (2,), [[2.1, 1, 4.5, -.1]], Constant([4.6, -8.1])),
+    (lambda x: cp.diff(x, 1, axis=0), (1, 2), [np.array([[-5, -3], [2, 1]])],
+     Constant([[7], [4]])),
+    (lambda x: cp.diff(x, 1, axis=1), (2, 1), [np.array([[-5, -3], [2, 1]])],
+     Constant([[2, -1]])),
+
+    (lambda x: cp.pnorm(x, .5), tuple(), [[1.1, 2, .1]], Constant([7.724231543909264])),
+    (lambda x: cp.pnorm(x, -.4), tuple(), [[1.1, 2, .1]], Constant([0.02713620334])),
+    (lambda x: cp.pnorm(x, -1), tuple(), [[1.1, 2, .1]], Constant([0.0876494023904])),
+    (lambda x: cp.pnorm(x, -2.3), tuple(), [[1.1, 2, .1]], Constant([0.099781528576])),
+
+    (cp.lambda_min, tuple(), [[[2, 0], [0, 1]]], Constant([1])),
+    (cp.lambda_min, tuple(), [[[5, 7], [7, -3]]], Constant([-7.06225775])),
+    (lambda x: cp.lambda_sum_smallest(x, 2), tuple(),
+     [[[1, 2, 3], [2, 4, 5], [3, 5, 6]]], Constant([-0.34481428])),
+    (cp.log, (2, 2), [[[1, math.e], [math.e**2, 1.0 / math.e]]], Constant([[0, 1], [2, -1]])),
+    (cp.log1p, (2, 2), [[[0, math.e - 1],
+                         [math.e**2 - 1, 1.0 / math.e - 1]]], Constant([[0, 1], [2, -1]])),
+    (cp.minimum, (2,), [[-5, 2], [-3, 1], 0, [1, 2]], Constant([-5, 0])),
+    (cp.minimum, (2, 2), [[[-5, 2], [-3, -1]],
+                          0,
+                          [[5, 4], [-1, 2]]], Constant([[-5, 0], [-3, -1]])),
+    (cp.min, tuple(), [[[-5, 2], [-3, 1]]], Constant([-5])),
+    (cp.min, tuple(), [[-5, -10]], Constant([-10])),
+    (lambda x: x**0.25, tuple(), [7.45], Constant([7.45**0.25])),
+    (lambda x: x**0.32, (2,), [[7.45, 3.9]], Constant(np.power(np.array([7.45, 3.9]), 0.32))),
+    (lambda x: x**0.9, (2, 2), [[[7.45, 2.2],
+                                 [4, 7]]], Constant(np.power(np.array([[7.45, 2.2],
+                                                                       [4, 7]]).T, 0.9))),
+    (cp.sqrt, (2, 2), [[[2, 4], [16, 1]]], Constant([[1.414213562373095, 2], [4, 1]])),
+    (lambda x: cp.sum_smallest(x, 3), tuple(), [[-1, 2, 3, 4, 5]], Constant([-1 + 2 + 3])),
+    (lambda x: cp.sum_smallest(x, 4), tuple(),
+     [[[-3, -4, 5], [6, 7, 8], [9, 10, 11]]], Constant([-3 - 4 + 5 + 6])),
+    (lambda x: (x + Constant(0))**0.5, (2, 2),
+     [[[2, 4], [16, 1]]], Constant([[1.414213562373095, 2], [4, 1]])),
 ]
 
 
@@ -317,7 +321,7 @@ def run_atom(atom, problem, obj_val, solver, verbose=False):
         if verbose:
             print(result)
             print(obj_val)
-        assert(-tolerance <= (result - obj_val)/(1+np.abs(obj_val)) <= tolerance)
+        assert(-tolerance <= (result - obj_val) / (1 + np.abs(obj_val)) <= tolerance)
 
 
 def get_indices(size):
@@ -331,46 +335,42 @@ def get_indices(size):
         return itertools.product(range(size[0]), range(size[1]))
 
 
-def test_constant_atoms():
-    for atom_list, objective_type in atoms:
-        for atom, size, args, obj_val in atom_list:
-            for indexer in get_indices(size):
-                for solver in SOLVERS_TO_TRY:
-                    # Atoms with Constant arguments.
-                    prob_val = obj_val[indexer].value
-                    const_args = [Constant(arg) for arg in args]
-                    problem = Problem(
-                        objective_type(atom(*const_args)[indexer]))
-                    yield (run_atom,
-                           atom,
-                           problem,
-                           prob_val,
-                           solver)
-                    # Atoms with Variable arguments.
-                    variables = []
-                    constraints = []
-                    for idx, expr in enumerate(args):
-                        variables.append(Variable(intf.shape(expr)))
-                        constraints.append(variables[-1] == expr)
-                    objective = objective_type(atom(*variables)[indexer])
-                    new_obj_val = prob_val
-                    if objective_type == cp.Maximize:
-                        objective = -objective
-                        new_obj_val = -new_obj_val
-                    problem = Problem(objective, constraints)
-                    yield (run_atom,
-                           atom,
-                           problem,
-                           new_obj_val,
-                           solver)
-                    # Atoms with Parameter arguments.
-                    parameters = []
-                    for expr in args:
-                        parameters.append(Parameter(intf.shape(expr)))
-                        parameters[-1].value = intf.DEFAULT_INTF.const_to_matrix(expr)
-                    objective = objective_type(atom(*parameters)[indexer])
-                    yield (run_atom,
-                           atom,
-                           Problem(objective),
-                           prob_val,
-                           solver)
+atoms_minimize = [(a, cp.Minimize) for a in atoms_minimize]
+atoms_maximize = [(a, cp.Maximize) for a in atoms_maximize]
+
+
+@pytest.mark.parametrize("atom_info, objective_type", atoms_minimize + atoms_maximize)
+def test_constant_atoms(atom_info, objective_type):
+
+    atom, size, args, obj_val = atom_info
+
+    for indexer in get_indices(size):
+        for solver in SOLVERS_TO_TRY:
+            # Atoms with Constant arguments.
+            prob_val = obj_val[indexer].value
+            const_args = [Constant(arg) for arg in args]
+            problem = Problem(
+                objective_type(atom(*const_args)[indexer]))
+            run_atom(atom, problem, prob_val, solver)
+
+            # Atoms with Variable arguments.
+            variables = []
+            constraints = []
+            for idx, expr in enumerate(args):
+                variables.append(Variable(intf.shape(expr)))
+                constraints.append(variables[-1] == expr)
+            objective = objective_type(atom(*variables)[indexer])
+            new_obj_val = prob_val
+            if objective_type == cp.Maximize:
+                objective = -objective
+                new_obj_val = -new_obj_val
+            problem = Problem(objective, constraints)
+            run_atom(atom, problem, new_obj_val, solver)
+
+            # Atoms with Parameter arguments.
+            parameters = []
+            for expr in args:
+                parameters.append(Parameter(intf.shape(expr)))
+                parameters[-1].value = intf.DEFAULT_INTF.const_to_matrix(expr)
+            objective = objective_type(atom(*parameters)[indexer])
+            run_atom(atom, Problem(objective), prob_val, solver)

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -49,7 +49,7 @@ class TestNonOptimal(BaseTest):
                 Q = np.dot(E, np.dot(Q, E.T))
                 observed_rank = np.linalg.matrix_rank(Q)
                 desired_rank = n-1
-                yield assert_equal, observed_rank, desired_rank
+                assert_equal(observed_rank, desired_rank)
 
                 for action in 'minimize', 'maximize':
 
@@ -67,7 +67,7 @@ class TestNonOptimal(BaseTest):
                     p.solve()
 
                     # check that cvxpy found the right answer
-                    xopt = x.value.A.flatten()
+                    xopt = x.value.flatten()
                     yopt = np.dot(xopt, np.dot(Q, xopt))
                     assert_allclose(yopt, 0, atol=1e-3)
                     assert_allclose(xopt, v, atol=1e-3)

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -143,29 +143,29 @@ test.
 
 Running unit tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-We use ``nose`` to run our unit tests, which you can install with ``pip install nose``.
+We use ``pytest`` to run our unit tests, which you can install with ``pip install pytest``.
 To run all unit tests, ``cd`` into ``cvxpy/tests`` and run the following command:
 
   ::
 
-    nosetests
+    pytest
 
 To run tests in a specific file (e.g., ``test_dgp.py``), use
 
   ::
 
-    nosetests test_dgp.py
+    pytest test_dgp.py
 
 To run a specific test method (e.g., ``TestDgp.test_product``), use
 
   ::
 
-    nosetests test_dgp.py:TestDgp.test_product
+    pytest test_dgp.py::TestDgp::test_product
 
 Please make sure that your change doesn't cause any of the unit tests to fail.
 
-``nosetests`` suppresses stdout by default. To see stdout, pass the ``-s`` flag
-to ``nosetests``.
+``pytest`` suppresses stdout by default. To see stdout, pass the ``-s`` flag
+to ``pytest``.
 
 .. _contrib_run_benchmarks:
 
@@ -176,7 +176,7 @@ the time to canonicalize problems. Please run
 
   ::
 
-    nosetests -s test_benchmarks.py
+    pytest -s test_benchmarks.py
 
 with and without your change, to make sure no performance regressions are
 introduced. If you are making a code contribution, please include the output of

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -24,11 +24,11 @@ pip
 
       pip install cvxpy
 
-2. Test the installation with ``nose``.
+2. Test the installation with ``pytest``.
   ::
 
-      pip install nose
-      nosetests cvxpy
+      pip install pytest
+      pytest cvxpy/tests
 
 .. _conda-installation:
 
@@ -54,11 +54,11 @@ conda
 
       conda install -c conda-forge cvxpy
 
-4. Test the installation with ``nose``.
+4. Test the installation with ``pytest``.
   ::
 
-       conda install nose
-       nosetests cvxpy
+       conda install pytest
+       pytest cvxpy/tests
 
 .. _install_from_source:
 
@@ -76,7 +76,7 @@ CVXPY has the following dependencies:
  * `NumPy`_ >= 1.15
  * `SciPy`_ >= 1.1.0
 
-To test the CVXPY installation, you additionally need `Nose`_.
+To test the CVXPY installation, you additionally need `pytest`_.
 
 CVXPY automatically installs `OSQP`_, `ECOS`_, `SCS`_. `NumPy`_ and
 `SciPy`_ will need to be installed manually,
@@ -189,7 +189,7 @@ CVXPY's SCIP interface does not reliably recover dual variables for constraints.
 .. _SCS: http://github.com/cvxgrp/scs
 .. _NumPy: http://www.numpy.org/
 .. _SciPy: http://www.scipy.org/
-.. _Nose: http://nose.readthedocs.org
+.. _pytest: https://docs.pytest.org/en/latest/
 .. _CVXPY git repository: https://github.com/cvxgrp/cvxpy
 .. _Swig: http://www.swig.org/
 .. _pip: https://pip.pypa.io/

--- a/examples/advanced/numpy_test.py
+++ b/examples/advanced/numpy_test.py
@@ -41,12 +41,13 @@ class Test(numpy.ndarray):
         else:
             raise AttributeError("'Test' object has no attribute 'affa'")
 
-print(issubclass(Test, Meta))
-print(issubclass(Meta, numpy.ndarray))
-print(issubclass(Test, numpy.ndarray))
-print(issubclass(numpy.ndarray, Test))
-
-a = numpy.arange(2)
-t = Test(1)
-a + t
-import pdb; pdb.set_trace()
+if __name__ == "__main__":
+    print(issubclass(Test, Meta))
+    print(issubclass(Meta, numpy.ndarray))
+    print(issubclass(Test, numpy.ndarray))
+    print(issubclass(numpy.ndarray, Test))
+    
+    a = numpy.arange(2)
+    t = Test(1)
+    a + t
+    import pdb; pdb.set_trace()


### PR DESCRIPTION
This PR closes #1157 . It replaces nose with pytest, more specifically:

- CI/CD scripts and documentation have been changed.
- I changed the order of `flake8` and the tests. The rationale is that flake8 should go first since it's faster, causing the build to fail fast if there is an error with syntax.
- There are some differences in `cvxpy/tests/test_constant_atoms.py`, but the git diff is mostly syntax. The only real change is that I use the `pytest.mark.parametrize` decorator on the `test_constant_atoms` function.