### PR TITLE
Cplex variable names

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -87,6 +87,11 @@ class CPLEX(QpSolver):
         n_var = data['n_var']
         n_eq = data['n_eq']
         n_ineq = data['n_ineq']
+        param_prob = data['param_prob']
+
+        # Variable names
+        id_to_var = param_prob.id_to_var
+        variable_names = [v._name for idx, v in sorted(id_to_var.items())]
 
         # Constrain values between bounds
         constrain_cplex_infty(b)
@@ -101,7 +106,8 @@ class CPLEX(QpSolver):
         # Add variables and linear objective
         var_idx = list(model.variables.add(obj=q,
                                            lb=-cpx.infinity*np.ones(n_var),
-                                           ub=cpx.infinity*np.ones(n_var)))
+                                           ub=cpx.infinity*np.ones(n_var),
+                                           names=variable_names))
 
         # Constrain binary/integer variables if present
         for i in data[s.BOOL_IDX]:


### PR DESCRIPTION
It exports Variable's `.name` property as variable name to Cplex. It is useful when debugging an infeasibility as Cplex will actually print the variable name. It gets even more useful when combined with the conflict refiner (PR #1168). 

This has two main limitations at the moment:

1. Cvxpy actually creates lots of variables under the hood, sometimes just copying ones created by the user. This often does not preserve the user-specified names. I'll try to address parts of this issue with future PRs.
2. It only works for variables and not for constraints. They are more complex to tackle. That is a story for another time I guess.