### PR TITLE
Cplex variable names: Bugfix

### DIFF
--- a/cvxpy/reductions/inverse_data.py
+++ b/cvxpy/reductions/inverse_data.py
@@ -22,7 +22,7 @@ class InverseData(object):
 
     def __init__(self, problem):
         varis = problem.variables()
-        self.id_map, self.var_offsets, self.x_length, self.var_shapes = \
+        self.id_map, self.var_offsets, self.var_names, self.x_length, self.var_shapes = \
             InverseData.get_var_offsets(varis)
 
         self.param_shapes = {}
@@ -46,11 +46,13 @@ class InverseData(object):
     def get_var_offsets(variables):
         var_shapes = {}
         var_offsets = {}
+        var_names = {}
         id_map = {}
         vert_offset = 0
         for x in variables:
             var_shapes[x.id] = x.shape
             var_offsets[x.id] = vert_offset
+            var_names[x.id] = x.name()
             id_map[x.id] = (vert_offset, x.size)
             vert_offset += x.size
-        return (id_map, var_offsets, vert_offset, var_shapes)
+        return (id_map, var_offsets, var_names, vert_offset, var_shapes)

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -89,10 +89,6 @@ class CPLEX(QpSolver):
         n_ineq = data['n_ineq']
         param_prob = data['param_prob']
 
-        # Variable names
-        id_to_var = param_prob.id_to_var
-        variable_names = [v._name for idx, v in sorted(id_to_var.items())]
-
         # Constrain values between bounds
         constrain_cplex_infty(b)
         constrain_cplex_infty(g)
@@ -107,7 +103,7 @@ class CPLEX(QpSolver):
         var_idx = list(model.variables.add(obj=q,
                                            lb=-cpx.infinity*np.ones(n_var),
                                            ub=cpx.infinity*np.ones(n_var),
-                                           names=variable_names))
+                                           names=param_prob.q_names))
 
         # Constrain binary/integer variables if present
         for i in data[s.BOOL_IDX]:


### PR DESCRIPTION
Relates to my previous PR #1169. There was a problem with multidimensional variables. The `param_prob.id_to_var` names corresponded to number of variables but the `q` variable is if course for each item in that vector/matrix/tensor. Test suite did not catch it as it likely does not have Cplex test cases. 