### PR TITLE
Allow for custom solvers

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -655,7 +655,8 @@ class Problem(u.Canonical):
         Raises
         ------
         cvxpy.error.SolverError
-            Raised if the name of the custom solver conflicts with the name of some officially supported solver
+            Raised if the name of the custom solver conflicts with the name of some officially
+            supported solver
         """
         if custom_solver.name() in SOLVERS:
             message = "Custom solvers must have a different name than the officially supported ones"

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -639,7 +639,7 @@ class Problem(u.Canonical):
 
     def _add_custom_solver_candidates(self, custom_solver: Solver):
         """
-        Returns custom_solver as the only candidate solver.
+        Returns a list of candidate solvers where custom_solver is the only potential option.
 
         Returns
         -------

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -651,7 +651,8 @@ class Problem(u.Canonical):
             Raised if the name of the custom solver conflicts with the name of some officially supported solver
         """
         if custom_solver.name() in SOLVERS:
-            raise(error.SolverError("Custom solvers must have a different name than the officially supported ones"))
+            message = "Custom solvers must have a different name than the officially supported ones"
+            raise(error.SolverError(message))
 
         candidates = {'qp_solvers': [], 'conic_solvers': []}
         if not self.is_mixed_integer() or custom_solver.MIP_CAPABLE:

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -648,7 +648,7 @@ class Problem(u.Canonical):
         Raises
         ------
         cvxpy.error.SolverError
-            Raised if the problem is not DCP and `gp` is False.
+            Raised if the name of the custom solver conflicts with the name of some officially supported solver
         """
         if custom_solver.name() in SOLVERS:
             raise(error.SolverError("Custom solvers must have a different name than the officially supported ones"))

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -22,6 +22,10 @@ from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.dqcp2dcp import dqcp2dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
+from cvxpy.reductions.solvers.defines import SOLVER_MAP_QP, SOLVER_MAP_CONIC
+from cvxpy.reductions.solvers.solver import Solver
 from cvxpy.reductions.solvers.solving_chain import construct_solving_chain
 from cvxpy.interface.matrix_utilities import scalar_value
 from cvxpy.reductions.solvers import bisection
@@ -570,6 +574,8 @@ class Problem(u.Canonical):
         """
         candidates = {'qp_solvers': [],
                       'conic_solvers': []}
+        if isinstance(solver, Solver):
+            return self._add_custom_solver_candidates(candidates, solver)
 
         if solver is not None:
             if solver not in slv_def.INSTALLED_SOLVERS:
@@ -628,6 +634,15 @@ class Problem(u.Canonical):
                     (candidates['qp_solvers'] +
                      candidates['conic_solvers']))
 
+        return candidates
+
+    def _add_custom_solver_candidates(self, candidates, solver: Solver):
+        if isinstance(solver, QpSolver):
+            SOLVER_MAP_QP[solver.name()] = solver
+            candidates['qp_solvers'] = solver.name()
+        elif isinstance(solver, ConicSolver):
+            SOLVER_MAP_CONIC[solver.name()] = solver
+            candidates['conic_solvers'] = solver.name()
         return candidates
 
     def _construct_chain(self, solver=None, gp=False, enforce_dpp=False):

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -714,10 +714,13 @@ class Problem(u.Canonical):
         None
         """
         if len(solvers['conic_solvers']) > 1:
-            solvers['conic_solvers'] = sorted(solvers['conic_solvers'], key=lambda s: slv_def.CONIC_SOLVERS.index(s))
+            solvers['conic_solvers'] = sorted(
+                solvers['conic_solvers'], key=lambda s: slv_def.CONIC_SOLVERS.index(s)
+            )
         if len(solvers['qp_solvers']) > 1:
-            solvers['qp_solvers'] = sorted(solvers['qp_solvers'], key=lambda s: slv_def.QP_SOLVERS.index(s))
-
+            solvers['qp_solvers'] = sorted(
+                solvers['qp_solvers'], key=lambda s: slv_def.QP_SOLVERS.index(s)
+            )
 
     def _invalidate_cache(self):
         self._cache_key = None

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -172,8 +172,7 @@ def construct_solving_chain(problem, candidates, gp=False, enforce_dpp=False):
     #   (2) ConeMatrixStuffing --> [a ConicSolver]
     if _solve_as_qp(problem, candidates):
         # Canonicalize as a QP
-        solver = sorted(candidates['qp_solvers'],
-                        key=lambda s: slv_def.QP_SOLVERS.index(s))[0]
+        solver = candidates['qp_solvers'][0]
         solver_instance = slv_def.SOLVER_MAP_QP[solver]
         reductions += [QpMatrixStuffing(),
                        solver_instance]
@@ -211,8 +210,7 @@ def construct_solving_chain(problem, candidates, gp=False, enforce_dpp=False):
     # increases the number of constraints in our problem.
     has_constr = len(cones) > 0 or len(problem.constraints) > 0
 
-    for solver in sorted(candidates['conic_solvers'],
-                         key=lambda s: slv_def.CONIC_SOLVERS.index(s)):
+    for solver in candidates['conic_solvers']:
         solver_instance = slv_def.SOLVER_MAP_CONIC[solver]
         if (all(c in solver_instance.SUPPORTED_CONSTRAINTS for c in cones)
                 and (has_constr or not solver_instance.REQUIRES_CONSTR)):

--- a/cvxpy/tests/test_custom_solver.py
+++ b/cvxpy/tests/test_custom_solver.py
@@ -105,5 +105,3 @@ class TestCustomSolvers(unittest.TestCase):
         z = cp.Variable(integer=True)
         quadratic = cp.sum_squares(x + z)
         problem = cp.Problem(cp.Minimize(quadratic), [cp.SOC(y, x)])
-        problem.solve(solver=solver)
-

--- a/cvxpy/tests/test_custom_solver.py
+++ b/cvxpy/tests/test_custom_solver.py
@@ -105,3 +105,4 @@ class TestCustomSolvers(unittest.TestCase):
         z = cp.Variable(integer=True)
         quadratic = cp.sum_squares(x + z)
         problem = cp.Problem(cp.Minimize(quadratic), [cp.SOC(y, x)])
+        problem.solve(solver=solver)

--- a/cvxpy/tests/test_custom_solver.py
+++ b/cvxpy/tests/test_custom_solver.py
@@ -1,0 +1,109 @@
+import unittest
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import SCS
+
+
+class CustomQPSolverCalled(Exception):
+    pass
+
+
+class CustomConicSolverCalled(Exception):
+    pass
+
+
+class CustomQPSolver(OSQP):
+    def name(self):
+        return "CUSTOM_QP_SOLVER"
+
+    def solve_via_data(self, *args, **kwargs):
+        raise(CustomQPSolverCalled())
+
+
+class CustomConicSolver(SCS):
+    def name(self):
+        return "CUSTOM_CONIC_SOLVER"
+
+    def solve_via_data(self, *args, **kwargs):
+        raise(CustomConicSolverCalled())
+
+
+class ConflictingCustomSolver(OSQP):
+    def name(self):
+        return "OSQP"
+
+
+class TestCustomSolvers(unittest.TestCase):
+    def setUp(self):
+        self.custom_qp_solver = CustomQPSolver()
+        self.custom_conic_solver = CustomConicSolver()
+
+    def test_custom_continuous_qp_solver_can_solve_continuous_qp(self):
+        with self.assertRaises(CustomQPSolverCalled):
+            self.solve_example_qp(solver=self.custom_qp_solver)
+
+    def test_custom_mip_qp_solver_can_solve_mip_qp(self):
+        self.custom_qp_solver.MIP_CAPABLE = True
+        with self.assertRaises(CustomQPSolverCalled):
+            self.solve_example_mixed_integer_qp(solver=self.custom_qp_solver)
+
+    def test_custom_continuous_qp_solver_cannot_solve_mip_qp(self):
+        self.custom_conic_solver.MIP_CAPABLE = False
+        with self.assertRaises(cp.error.SolverError):
+            self.solve_example_mixed_integer_qp(solver=self.custom_qp_solver)
+
+    def test_custom_qp_solver_cannot_solve_socp(self):
+        with self.assertRaises(cp.error.SolverError):
+            self.solve_example_socp(solver=self.custom_qp_solver)
+
+    def test_custom_continuous_conic_solver_can_solve_continuous_socp(self):
+        with self.assertRaises(CustomConicSolverCalled):
+            self.solve_example_socp(solver=self.custom_conic_solver)
+
+    def test_custom_mip_conic_solver_can_solve_mip_socp(self):
+        self.custom_conic_solver.MIP_CAPABLE = True
+        with self.assertRaises(CustomConicSolverCalled):
+            self.solve_example_mixed_integer_socp(solver=self.custom_conic_solver)
+
+    def test_custom_continuous_conic_solver_cannot_solve_mip_socp(self):
+        self.custom_conic_solver.MIP_CAPABLE = False
+        with self.assertRaises(cp.error.SolverError):
+            self.solve_example_mixed_integer_qp(solver=self.custom_conic_solver)
+
+    def test_custom_conflicting_solver_fails(self):
+        with self.assertRaises(cp.error.SolverError):
+            self.solve_example_qp(solver=ConflictingCustomSolver())
+
+    @staticmethod
+    def solve_example_qp(solver):
+        x = cp.Variable()
+        quadratic = cp.sum_squares(x)
+        problem = cp.Problem(cp.Minimize(quadratic))
+        problem.solve(solver=solver)
+
+    @staticmethod
+    def solve_example_mixed_integer_qp(solver):
+        x = cp.Variable()
+        z = cp.Variable(integer=True)
+        quadratic = cp.sum_squares(x + z)
+        problem = cp.Problem(cp.Minimize(quadratic))
+        problem.solve(solver=solver)
+
+    @staticmethod
+    def solve_example_socp(solver):
+        x = cp.Variable(2)
+        y = cp.Variable()
+        quadratic = cp.sum_squares(x)
+        problem = cp.Problem(cp.Minimize(quadratic), [cp.SOC(y, x)])
+        problem.solve(solver=solver)
+
+    @staticmethod
+    def solve_example_mixed_integer_socp(solver):
+        x = cp.Variable(2)
+        y = cp.Variable()
+        z = cp.Variable(integer=True)
+        quadratic = cp.sum_squares(x + z)
+        problem = cp.Problem(cp.Minimize(quadratic), [cp.SOC(y, x)])
+        problem.solve(solver=solver)
+

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -1360,7 +1360,7 @@ Custom Solvers
 ------------------------------------
 Although ``cvxpy`` supports many different solvers out of the box, it is also possible to define and use custom solvers. This can be helpful in prototyping or developing custom solvers tailored to a specific application.
 
-To do so, you have to implement a solver class that is a children of ``cvxpy.reductions.solvers.qp_solvers.qp_solver.QpSolver`` or ``cvxpy.reductions.solvers.conic_solvers.conic_solver.ConicSolver``. Then you pass an instance of this solver class to ``solver.solve(.)`` as following:
+To do so, you have to implement a solver class that is a child of ``cvxpy.reductions.solvers.qp_solvers.qp_solver.QpSolver`` or ``cvxpy.reductions.solvers.conic_solvers.conic_solver.ConicSolver``. Then you pass an instance of this solver class to ``solver.solve(.)`` as following:
 
 .. code:: python3
 

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -1320,9 +1320,6 @@ and say the derivative of ``f`` with respect to ``x*`` is ``dx``. To compute
 the derivative of ``f`` with respect to ``p``, before calling
 ``problem.backward()``, just set ``x.gradient = dx``.
 
-
-
-
 The ``backward`` method can be powerful when combined with software for
 automatic differentiation. We recommend the software package
 `CVXPY Layers <https://www.github.com/cvxgrp/cvxpylayers>`_, which provides

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -1358,7 +1358,7 @@ on derivatives.
 
 Custom Solvers
 ------------------------------------
-Although ``cvxpy`` supports many different solvers out of the box, it is possible to use custom solvers that are not currently officially supported. This could be helpful in prototyping or developing custom solvers tailored to a specific application.
+Although ``cvxpy`` supports many different solvers out of the box, it is also possible to define and use custom solvers. This can be helpful in prototyping or developing custom solvers tailored to a specific application.
 
 To do so, you have to implement a solver class that is a children of ``cvxpy.reductions.solvers.qp_solvers.qp_solver.QpSolver`` or ``cvxpy.reductions.solvers.conic_solvers.conic_solver.ConicSolver``. Then you pass an instance of this solver class to ``solver.solve(.)`` as following:
 

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -1320,6 +1320,9 @@ and say the derivative of ``f`` with respect to ``x*`` is ``dx``. To compute
 the derivative of ``f`` with respect to ``p``, before calling
 ``problem.backward()``, just set ``x.gradient = dx``.
 
+
+
+
 The ``backward`` method can be powerful when combined with software for
 automatic differentiation. We recommend the software package
 `CVXPY Layers <https://www.github.com/cvxgrp/cvxpylayers>`_, which provides
@@ -1352,4 +1355,35 @@ on derivatives.
 .. _OSQP: https://osqp.org/
 .. _SCIP: https://scip.zib.de/
 .. _XPRESS: https://www.fico.com/en/products/fico-xpress-optimization
+
+Custom Solvers
+------------------------------------
+Although ``cvxpy`` supports many different solvers out of the box, it is possible to use custom solvers that are not currently officially supported. This could be helpful in prototyping or developing custom solvers tailored to a specific application.
+
+To do so, you have to implement a solver class that is a children of ``cvxpy.reductions.solvers.qp_solvers.qp_solver.QpSolver`` or ``cvxpy.reductions.solvers.conic_solvers.conic_solver.ConicSolver``. Then you pass an instance of this solver class to ``solver.solve(.)`` as following:
+
+.. code:: python3
+
+    import cvxpy as cp
+    from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
+
+
+    class CUSTOM_OSQP(OSQP):
+        MIP_CAPABLE=False
+
+        def name(self):
+            return "CUSTOM_OSQP"
+
+        def solve_via_data(self, *args, **kwargs):
+            print("Solving with a custom QP solver!")
+            super().solve_via_data(*args, **kwargs)
+
+
+    x = cp.Variable()
+    quadratic = cp.square(x)
+    problem = cp.Problem(cp.Minimize(quadratic))
+    problem.solve(solver=CUSTOM_OSQP())
+
+Note that the string returned by the ``name`` property should be different to all of the officially supported solvers (a list of which can be found in ``cvxpy.settings.SOLVERS``). Also, if your solver is mixed integer capable, you should set the class variable ``MIP_CAPABLE`` to ``True``.
+
 

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -1381,6 +1381,8 @@ To do so, you have to implement a solver class that is a child of ``cvxpy.reduct
     problem = cp.Problem(cp.Minimize(quadratic))
     problem.solve(solver=CUSTOM_OSQP())
 
+You might also want to override the methods ``invert`` and ``import_solver`` of the ``Solver`` class.
+
 Note that the string returned by the ``name`` property should be different to all of the officially supported solvers (a list of which can be found in ``cvxpy.settings.SOLVERS``). Also, if your solver is mixed integer capable, you should set the class variable ``MIP_CAPABLE`` to ``True``.
 
 


### PR DESCRIPTION
## Purpose
Allows the use of custom solvers in `cvxpy`. This can be helpful when prototyping new solvers, writing official solvers for `cvxpy`, or developing custom solvers tailored to a specific application. 

To use a custom solver, one has to implement a solver class that is a child of `QpSolver` or `ConicSolver`. Then an instance of this new solver class is passed to `problem.solve(solver=.)`. Note that conflicts with existing solvers are avoided because custom solvers are specified by passing objects that are instances of the `Solver` class, while standard solvers are specified via strings (e.g. "OSQP"). Furthermore, when a user specifies a custom solver, then no standard solvers are suggested as "candidates" via `cvxpy`. That was done on purpose for simplicity.

## Minimal usage example
```python
import cvxpy as cp
from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP


class CUSTOM_OSQP(OSQP):
    MIP_CAPABLE = False

    def name(self):
        return "CUSTOM_OSQP"

    def solve_via_data(self, *args, **kwargs):
        print("Solving with a custom QP solver!")
        super().solve_via_data(*args, **kwargs)


x = cp.Variable()
quadratic = cp.square(x)
problem = cp.Problem(cp.Minimize(quadratic))
problem.solve(solver=CUSTOM_OSQP())
```

See also the documentation and the tests added for more examples/details.


## ToDo List:
- [x] Tests
- [x] Documentation