### PR TITLE
Add hint to docs about changes to ECOS_BB

### DIFF
--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -212,9 +212,9 @@ python package provides CVXPY with access to GLPK_MI; CVXOPT can be installed by
 
 CVXPY comes with ECOS_BB -- an open source mixed-integer nonlinear solver -- by default. However
 ECOS_BB will not be called automatically; you must explicitly call ``prob.solve(solver='ECOS_BB')``
-if you want to use it. This policy stems from the fact that there are recurring correctness issues
-with ECOS_BB. If you rely on this solver for some application then you need to be aware of the
-increased risks that come with using it.
+if you want to use it (:ref:`changed in CVXPY 1.1.6 <changes116>`). This policy stems from the fact
+that there are recurring correctness issues with ECOS_BB. If you rely on this solver for some
+application then you need to be aware of the increased risks that come with using it.
 
 If you need to solve a large mixed-integer problem quickly, or if you have a nonlinear mixed-integer
 model, then you will need to use a commercial solver such as CPLEX_, GUROBI_, XPRESS_, or MOSEK_.

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -9,6 +9,8 @@ The latest release of CVXPY is version 1.1.
 Recent patches
 --------------
 
+.. _changes116:
+
 Changes in version 1.1.6
  - The ECOS_BB solver (removed in 1.1.0) has been added back as an option. However ECOS_BB will not
    be called automatically; you must explicitly call ``prob.solve(solver='ECOS_BB')`` if you want to


### PR DESCRIPTION
This might also help somebody who is using 1.1.0 <= CVXPY < 1.1.6 and is
wondering why ECOS_BB is not installed.