### PR TITLE
Return correct domain

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -269,7 +269,7 @@ class Leaf(expression.Expression):
             domain.append(self >> 0)
         elif self.attributes['NSD']:
             domain.append(self << 0)
-        return []
+        return domain
 
     def project(self, val):
         """Project value onto the attribute set of the leaf.


### PR DESCRIPTION
I was trying to get the domain of an expression and was surprised that it always returned an empty array. After some investigation I found out that the domain property function in `leaf.py` always returns an empty array instead of the calculated domain (see changed line). To me this looks like a clear mistake/bug. I'm just a bit worried that no one noticed this since the part of the codebase is already over 3 years old.

Also, it seems like this isn't the only mistake in regard to returning the correct domain. For example, this is now correct after the change:
``` python
import cvxpy as cp

X = cp.Variable((3, 3), PSD=True)

constraints = []

objective = cp.Minimize(cp.norm(X, 2))
prob = cp.Problem(objective, constraints)

all_domains = objective.args[0].domain  # domain of the objective function
for arg in constraints:
  for l in range(len(arg.args)):
    for dom in arg.args[l].domain:
      all_domains.append(dom)  # domain on each side of constraints
print(all_domains) # returns '[PSD(Expression(AFFINE, UNKNOWN, (3, 3)))]'
```
but the slightly modified but equivalent problem has still an empty domain:
``` python
import cvxpy as cp

X = cp.Variable((3, 3))

constraints = [X >> 0]

objective = cp.Minimize(cp.norm(X, 2))
prob = cp.Problem(objective, constraints)

all_domains = objective.args[0].domain  # domain of the objective function
for arg in constraints:
  for l in range(len(arg.args)):
    for dom in arg.args[l].domain:
      all_domains.append(dom)  # domain on each side of constraints
print(all_domains) # returns '[]'
```