### PR TITLE
1191 fix cvxopt status

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -52,7 +52,7 @@ class CVXOPT(ECOS):
     # Map of CVXOPT status to CVXPY status.
     STATUS_MAP = {"optimal": s.OPTIMAL,
                   "feasible": s.OPTIMAL_INACCURATE,
-                  "infeasible": s.INFEASIBLE,
+                  "infeasible problem": s.INFEASIBLE,
                   "primal infeasible": s.INFEASIBLE,
                   "LP relaxation is primal infeasible": s.INFEASIBLE,
                   "LP relaxation is dual infeasible": s.UNBOUNDED,

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -516,8 +516,24 @@ def mi_lp_2():
     return sth
 
 
-# TODO: Add a test-case for an infeasible integer-linear program
-#  (infeasible only due integrality constraints).
+def mi_lp_3():
+    # infeasible (but relaxable) test case
+    x = cp.Variable(4, boolean=True)
+    from cvxpy.expressions.constants import Constant
+    objective = cp.Maximize(Constant(1))
+    constraints = [x[0] + x[1] + x[2] + x[3] <= 2,
+                   x[0] + x[1] + x[2] + x[3] >= 2,
+                   x[0] + x[1] <= 1,
+                   x[0] + x[2] <= 1,
+                   x[0] + x[3] <= 1,
+                   x[2] + x[3] <= 1,
+                   x[1] + x[3] <= 1,
+                   x[1] + x[2] <= 1]
+    obj_pair = (objective, -np.inf)
+    con_pairs = [(c, None) for c in constraints]
+    var_pairs = [(x, None)]
+    sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
+    return sth
 
 
 def mi_socp_1():
@@ -635,6 +651,13 @@ class StandardTestLPs(object):
     @staticmethod
     def test_mi_lp_2(solver, places=4, **kwargs):
         sth = mi_lp_2()
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.verify_primal_values(places)
+
+    @staticmethod
+    def test_mi_lp_3(solver, places=4, **kwargs):
+        sth = mi_lp_3()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -420,6 +420,9 @@ class TestMosek(unittest.TestCase):
     def test_mosek_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='MOSEK')
 
+    def test_mosek_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='MOSEK')
+
     def test_mosek_mi_socp_1(self):
         StandardTestSOCPs.test_mi_socp_1(solver='MOSEK')
 
@@ -615,6 +618,9 @@ class TestCBC(BaseTest):
     def test_cbc_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='CBC')
 
+    def test_cbc_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='CBC')
+
 
 @unittest.skipUnless('GLPK' in INSTALLED_SOLVERS, 'GLPK is not installed.')
 class TestGLPK(unittest.TestCase):
@@ -645,6 +651,9 @@ class TestGLPK(unittest.TestCase):
 
     def test_glpk_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='GLPK_MI')
+
+    def test_glpk_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='GLPK_MI')
 
 
 @unittest.skipUnless('CPLEX' in INSTALLED_SOLVERS, 'CPLEX is not installed.')
@@ -810,6 +819,9 @@ class TestCPLEX(BaseTest):
     def test_cplex_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='CPLEX')
 
+    def test_cplex_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='CPLEX')
+
     def test_cplex_mi_socp_1(self):
         StandardTestSOCPs.test_mi_socp_1(solver='CPLEX', places=3)
 
@@ -943,6 +955,9 @@ class TestGUROBI(BaseTest):
 
     def test_gurobi_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='GUROBI')
+
+    def test_gurobi_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='GUROBI')
 
     def test_gurobi_mi_socp_1(self):
         StandardTestSOCPs.test_mi_socp_1(solver='GUROBI', places=2)
@@ -1087,6 +1102,9 @@ class TestXPRESS(BaseTest):
     def test_xpress_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='XPRESS')
 
+    def test_xpress_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='XPRESS')
+
     def test_xpress_mi_socp_1(self):
         StandardTestSOCPs.test_mi_socp_1(solver='XPRESS')
 
@@ -1172,6 +1190,9 @@ class TestSCIP(unittest.TestCase):
 
     def test_scip_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver="SCIP")
+
+    def test_scip_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver="SCIP")
 
     def get_simple_problem(self):
         """Example problem that can be used within additional tests."""
@@ -1341,6 +1362,9 @@ class TestECOS_BB(unittest.TestCase):
 
     def test_ecos_bb_mi_lp_2(self):
         StandardTestLPs.test_mi_lp_2(solver='ECOS_BB')
+
+    def test_ecos_bb_mi_lp_3(self):
+        StandardTestLPs.test_mi_lp_3(solver='ECOS_BB')
 
     def test_ecos_bb_mi_socp_1(self):
         StandardTestSOCPs.test_mi_socp_1(solver='ECOS_BB')


### PR DESCRIPTION
This fixes #1191, which occurs because there is no status code 'infeasible' in CVXOPT/GLPK.  
The test case added is an MIP that is infeasible but integer relaxable and triggers the status 'infeasible problem' in GLPK. 

I particularly want to stress, that I did only add this test for solver='GLPK_MI', since I don't have other solvers installed and the test might be an edge case where some solvers are failing. Still, it would be interesting to see what other solvers have to say about this test, which is interesting in itself.