### PR TITLE
do not use builtins as a dict

### DIFF
--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -31,6 +31,7 @@ from numpy import linalg as LA
 import numpy
 import numpy as np
 import scipy.sparse as sp
+import builtins
 import sys
 import pickle
 # Solvers.
@@ -1693,7 +1694,7 @@ class TestProblem(BaseTest):
         prob = Problem(cp.Minimize(cp.power(x, 1.7) + cp.power(x, -2.3) - cp.power(x, .45)))
         prob.solve()
         x = x.value
-        self.assertTrue(__builtins__['abs'](1.7*x**.7 - 2.3*x**-3.3 - .45*x**-.55) <= 1e-3)
+        self.assertTrue(builtins.abs(1.7*x**.7 - 2.3*x**-3.3 - .45*x**-.55) <= 1e-3)
 
     def test_multiply_by_scalar(self):
         """Test a problem with multiply by a scalar.


### PR DESCRIPTION
Fixing pypy failure uncovered in https://github.com/conda-forge/cvxpy-feedstock/pull/46