### PR TITLE
Bugfix for affine2direct: SolverErrors weren't being raised

### DIFF
--- a/cvxpy/reductions/cone2cone/affine2direct.py
+++ b/cvxpy/reductions/cone2cone/affine2direct.py
@@ -214,7 +214,7 @@ class Dualize(object):
             status = s.INFEASIBLE_INACCURATE
             opt_val = np.inf
         else:
-            status = s.UNKNOWN
+            status = s.SOLVER_ERROR
             opt_val = np.NaN
         sol = Solution(status, opt_val, primal_vars, dual_vars, prob_attr)
         return sol

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -17,6 +17,10 @@ Changes in version 1.1.8
    you want to use this type of constraint in your model, you will need to instantiate
    ``PowCone3D`` and/or ``PowConeND`` objects manually. Dual variables are not yet implemented
    for ``PowConeND`` objects. At present, only SCS and MOSEK support power cone constraints.
+ - We fixed a bug in our MOSEK interface that was introduced in version 1.1.6. The "unknown"
+   status code was not being handled correctly, resulting in ValueErrors rather than SolverErrors.
+   Users can now expect a SolverError when MOSEK returns an "unknown" status code (as was
+   standard before).
 
 .. _changes116:
 


### PR DESCRIPTION
This resolves #1226, and will be included in the release of CVXPY 1.1.8. The web documentation source files have been updated to make note of this fix.