### PR TITLE
Allow single MI solver != ECOS_BB [issue 1232]

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -608,7 +608,7 @@ class Problem(u.Canonical):
 
         if self.is_mixed_integer():
             # ECOS_BB must be called explicitly.
-            if len(slv_def.INSTALLED_MI_SOLVERS) == 1 and solver != s.ECOS_BB:
+            if slv_def.INSTALLED_MI_SOLVERS == [s.ECOS_BB] and solver != s.ECOS_BB:
                 msg = """
 
                     You need a mixed-integer solver for this model. Refer to the documentation


### PR DESCRIPTION
The corresponding issue for this PR can be found here: #1232 

While the change is only one line, I followed the contributing guidelines:

- [x]  no regression change
- [x]  no benchmark timing change (`37.38s` pre-change vs. `37.28s` after the change)
- [x]  flake8 passing

A UT which checks exactly this scenario is likely not relevant for most users and indeed would be quite tricky to include.