### PR TITLE
Performance improvement for reducing problem data tensor [issue 1160]

### DIFF
--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -135,7 +135,6 @@ def reduce_problem_data_tensor(A, var_length, quad_form=False):
     positions, counts = np.unique(cols, return_counts=True)
     indptr[positions+1] = counts
     indptr = np.cumsum(indptr)
-    # assert np.all(indptr == indptr_bak)
 
     return reduced_A, indices, indptr, shape
 


### PR DESCRIPTION
In issue #1160, @akshayka and @rileyjmurray were disucssing ways to speed up `reduce_problem_data_tensor()`.

Using [line_profiler](https://github.com/pyutils/line_profiler) I have profiled the optimization problem stated in the issue, narrowing down the lines consuming most of the CPU time:
```
Total time: 124.153 s

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   111         2         17.0      8.5      0.0      old_row_to_new_row = {
   112         2    5266879.0 2633439.5      4.2          unique_old_row[i]: i for i in range(unique_old_row.size)
   113                                               }                                        
   ...
   119  10043002   21723051.0      2.2     17.5      for i in range(reduced_row.size):
   120  10043000   26991628.0      2.7     21.7          reduced_row[i] = old_row_to_new_row[old_row[i]]                              
   ...
   148  10043000   23828321.0      2.4     19.2          while col == prev_col and i < nnz - 1:
   149  10021000   21721225.0      2.2     17.5              i += 1
   150  10021000   23244796.0      2.3     18.7              col = cols[i]
```

Using the additional arguments `return_inverse` and `return_counts` of `np.unique()`, the time spent in the function was reduced from `124s` to `1.15s`. 

I haven't worked with CSR matrices extensively, so please let me know if I am overlooking something.

### Contributing guideline checks:

- [x]  no regression change
- [x] slight improvement in benchmark timings (34.76s pre-change vs. 31.02s after the change)
- [x] flake8 passing
I noticed many regression test sensitivities when trying out different approaches, so the function seems to be well tested. If you can think of any additional test case which I should add, please let me know.
