### PR TITLE
Matmul warning

### DIFF
--- a/cvxpy/error.py
+++ b/cvxpy/error.py
@@ -66,9 +66,3 @@ class ParameterError(Exception):
     """Error thrown for accessing the value of an unspecified parameter.
     """
     pass
-
-
-class MatmulWarning(Warning):
-    """Warning raised for accessing matmul by the * operator.
-    """
-    pass

--- a/cvxpy/error.py
+++ b/cvxpy/error.py
@@ -66,3 +66,9 @@ class ParameterError(Exception):
     """Error thrown for accessing the value of an unspecified parameter.
     """
     pass
+
+
+class MatmulWarning(Warning):
+    """Warning raised for accessing matmul by the * operator.
+    """
+    pass

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -48,12 +48,15 @@ def _cast_other(binary_op):
     return cast_op
 
 
+__STAR_MATMUL_COUNT__ = 1
+
 __STAR_MATMUL_WARNING__ = """
 This use of ``*`` has resulted in matrix multiplication.
 Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
     Use ``*`` for matrix-scalar and vector-scalar multiplication.
     Use ``@`` for matrix-matrix and matrix-vector multiplication.
     Use ``multiply`` for elementwise multiplication.
+This code path has been hit %s times so far.
 """
 
 
@@ -547,8 +550,12 @@ class Expression(u.Canonical):
             # Because we want to discourage using ``*`` to call matmul, we
             # raise a warning to the user.
             with warnings.catch_warnings():
-                warnings.simplefilter("always", error.MatmulWarning, append=True)
-                warnings.warn(__STAR_MATMUL_WARNING__, error.MatmulWarning)
+                global __STAR_MATMUL_COUNT__
+                warnings.simplefilter("always", UserWarning, append=True)
+                msg = __STAR_MATMUL_WARNING__ % __STAR_MATMUL_COUNT__
+                warnings.warn(msg, UserWarning)
+                warnings.warn(msg, DeprecationWarning)
+                __STAR_MATMUL_COUNT__ += 1
             return cvxtypes.matmul_expr()(self, other)
 
     @_cast_other

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -546,9 +546,9 @@ class Expression(u.Canonical):
                     warnings.warn("Forming a nonconvex expression.")
             # Because we want to discourage using ``*`` to call matmul, we
             # raise a warning to the user.
-            warnings.resetwarnings()
-            warnings.warn(__STAR_MATMUL_WARNING__, UserWarning)
-            warnings.resetwarnings()
+            with warnings.catch_warnings():
+                warnings.simplefilter("always", error.MatmulWarning, append=True)
+                warnings.warn(__STAR_MATMUL_WARNING__, error.MatmulWarning)
             return cvxtypes.matmul_expr()(self, other)
 
     @_cast_other

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -26,7 +26,6 @@ from cvxpy.tests.base_test import BaseTest
 import numpy as np
 import scipy.sparse as sp
 import warnings
-import sys
 
 
 class TestExpressions(BaseTest):

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -22,13 +22,11 @@ from cvxpy.expressions.constants import Parameter
 from cvxpy import Problem, Minimize
 import cvxpy.interface.matrix_utilities as intf
 import cvxpy.settings as s
-import cvxpy.error as cperr
 from cvxpy.tests.base_test import BaseTest
 import numpy as np
 import scipy.sparse as sp
 import warnings
 import sys
-PY35 = sys.version_info >= (3, 5)
 
 
 class TestExpressions(BaseTest):
@@ -596,24 +594,25 @@ class TestExpressions(BaseTest):
         c = Constant([[2], [2]])
         with warnings.catch_warnings(record=True) as w:
             c * self.x
-            self.assertEqual(len(w), 1)
-            self.assertEqual(w[0].category, cperr.MatmulWarning)
+            self.assertEqual(2, len(w))
+            self.assertEqual(w[0].category, UserWarning)
+            self.assertEqual(w[1].category, DeprecationWarning)
             # repeat, to make sure warnings continue to be displayed
             c * self.x
-            self.assertEqual(len(w), 2)
-            self.assertEqual(w[1].category, cperr.MatmulWarning)
-            # make sure a warning is displayed if a user
-            # says to suppress some other (unrelated) warning.
+            self.assertEqual(4, len(w))
+            self.assertEqual(w[2].category, UserWarning)
+            self.assertEqual(w[3].category, DeprecationWarning)
+            # suppress one of the two warnings
+            warnings.simplefilter('ignore', DeprecationWarning)
+            c * self.x
+            self.assertEqual(5, len(w))
+            # suppress both warnings
             warnings.simplefilter('ignore', UserWarning)
             c * self.x
-            self.assertEqual(len(w), 3)
-            # explicitly ignore MatmulWarning
-            warnings.simplefilter('ignore', cperr.MatmulWarning)
-            c * self.x
-            self.assertEqual(len(w), 3)  # the count hasn't changed
+            self.assertEqual(len(w), 5)
             # verify that an error can be raised.
-            warnings.simplefilter("error", cperr.MatmulWarning)
-            with self.assertRaises(cperr.MatmulWarning):
+            warnings.simplefilter("error", UserWarning)
+            with self.assertRaises(UserWarning):
                 c * self.x
 
     def test_matmul_expression(self):

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -9,6 +9,13 @@ The latest release of CVXPY is version 1.1.
 Recent patches
 --------------
 
+Changes in version 1.1.10
+ - When NumPy 1.20 was released many users encountered errors in installing or importing
+   CVXPY. Users would see errors like ``RuntimeError: module compiled
+   against API version 0xe but this version of numpy is 0xd``. We changed our build files
+   to avoid this problem, and it should be fixed as of CVXPY 1.1.10. For more information
+   you can refer to this `GitHub issue <https://github.com/cvxgrp/cvxpy/issues/1229>`_.
+
 .. _changes118:
 
 Changes in version 1.1.8


### PR DESCRIPTION
This addresses #1238 and is intended to supersede #1239. It removes side-effects of our existing warnings for accessing matmul through ``*`` and introduces a new ``MatmulWarning`` class for that purpose.

This PR also updates the web doc source to mention the importance of cvxpy 1.1.10 for the numpy installation issue.