### PR TITLE
Extend is_nonneg() of diag_mat to check if arg is psd [issue 1213]

### DIFF
--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -140,6 +140,11 @@ class diag_mat(AffAtom):
         rows, _ = self.args[0].shape
         return (rows,)
 
+    def is_nonneg(self):
+        """Is the expression nonnegative?
+        """
+        return self.args[0].is_nonneg() or self.args[0].is_psd()
+
     def graph_implementation(self, arg_objs, shape, data=None):
         """Extracts the diagonal of a matrix.
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -576,6 +576,12 @@ class TestAtoms(BaseTest):
         self.assertEqual(expr.curvature, s.AFFINE)
         self.assertEqual(expr.shape, (2, 2))
 
+        psd_matrix = np.array([[1, -1], [-1, 1]])
+        expr = cp.diag(psd_matrix)
+        self.assertEqual(expr.sign, s.NONNEG)
+        self.assertEqual(expr.curvature, s.CONSTANT)
+        self.assertEqual(expr.shape, (2,))
+
         with self.assertRaises(Exception) as cm:
             cp.diag(self.C)
         self.assertEqual(str(cm.exception),


### PR DESCRIPTION
This PR adds @SteveDiamond 's proposed improvement for the `is_nonneg()` check in the `diag_mat` class, as per discussion in #1213. Also, the tests are extended to cover this case.


### Contributing guideline checks:

- [x] no regression change
- [x] no relevant change in benchmark timings (25.33s pre-change vs. 25.05s after the change)
- [x] flake8 passing
