### PR TITLE
Gurobi warm start

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -134,11 +134,11 @@ class GUROBI(QpSolver):
                               lb={i: -grb.GRB.INFINITY for i in range(n)},
                               vtype=vtypes)
 
-        # Warm start variables if option provided
-        if 'start' in solver_opts:
-            start = solver_opts.pop('start')
+        if warm_start and solver_cache is not None \
+                and self.name() in solver_cache:
+            old_x_grb = solver_cache[self.name()].getVars()
             for idx in range(len(x_grb)):
-                x_grb[idx].start = start[idx]
+                x_grb[idx].start = old_x_grb[idx].X
         model.update()
 
         x = np.array(model.getVars(), copy=False)
@@ -225,5 +225,8 @@ class GUROBI(QpSolver):
             results_dict["status"] = s.SOLVER_ERROR
 
         results_dict["model"] = model
+
+        if solver_cache is not None:
+            solver_cache[self.name()] = model
 
         return results_dict

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -136,9 +136,13 @@ class GUROBI(QpSolver):
 
         if warm_start and solver_cache is not None \
                 and self.name() in solver_cache:
-            old_x_grb = solver_cache[self.name()].getVars()
-            for idx in range(len(x_grb)):
-                x_grb[idx].start = old_x_grb[idx].X
+            old_model = solver_cache[self.name()]
+            old_status = self.STATUS_MAP.get(old_model.Status,
+                                             s.SOLVER_ERROR)
+            if (old_status in s.SOLUTION_PRESENT) or (old_model.solCount > 0):
+                old_x_grb = old_model.getVars()
+                for idx in range(len(x_grb)):
+                    x_grb[idx].start = old_x_grb[idx].X
         model.update()
 
         x = np.array(model.getVars(), copy=False)

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -129,11 +129,18 @@ class GUROBI(QpSolver):
         for i in range(n):
             if i not in vtypes:
                 vtypes[i] = grb.GRB.CONTINUOUS
-        model.addVars(int(n),
-                      ub={i: grb.GRB.INFINITY for i in range(n)},
-                      lb={i: -grb.GRB.INFINITY for i in range(n)},
-                      vtype=vtypes)
+        x_grb = model.addVars(int(n),
+                              ub={i: grb.GRB.INFINITY for i in range(n)},
+                              lb={i: -grb.GRB.INFINITY for i in range(n)},
+                              vtype=vtypes)
+
+        # Warm start variables if option provided
+        if 'start' in solver_opts:
+            start = solver_opts.pop('start')
+            for idx in range(len(x_grb)):
+                x_grb[idx].start = start[idx]
         model.update()
+
         x = np.array(model.getVars(), copy=False)
 
         if A.shape[0] > 0:


### PR DESCRIPTION
Added gurobi warm start using the `Start` attribute (see [docs](https://www.gurobi.com/documentation/9.1/refman/start.html)).  

It's related to https://github.com/cvxgrp/cvxpy/issues/849 This PR makes Gurobi store the model in cache and it uses it to retrieve the previous solution.

This is an example for a random MIQP. We reuse the previous solution on the exact same problem, but it can be applied to more complicated cases.

```python
import cvxpy as cp
import numpy as np

# Generate a random problem
np.random.seed(0)
m, n = 80, 30
A = np.random.rand(m, n)
b = np.random.randn(m)

print("Solve\n---")
x = cp.Variable(n, integer=True)
objective = cp.Minimize(cp.sum_squares(A @ x - b))
prob = cp.Problem(objective)
prob.solve(solver=cp.GUROBI, verbose=True)

print("\n\nSolve again\n---")
prob.solve(solver=cp.GUROBI, verbose=True)
```

Here is the output. Admittedly, it does not improve the speed much in this case, but it can help in general.

Note the "Loaded user MIP start with objective 50.6704". 

```
Solve first time
---
Parameter OutputFlag unchanged
   Value: 1  Min: 0  Max: 1  Default: 1
Changed value of parameter QCPDual to 1
   Prev: 0  Min: 0  Max: 1  Default: 0
Gurobi Optimizer version 9.1.1 build v9.1.1rc0 (mac64)
Thread count: 8 physical cores, 16 logical processors, using up to 16 threads
Optimize a model with 80 rows, 110 columns and 2480 nonzeros
Model fingerprint: 0x042affb3
Model has 80 quadratic objective terms
Variable types: 80 continuous, 30 integer (0 binary)
Coefficient statistics:
  Matrix range     [7e-05, 1e+00]
  Objective range  [0e+00, 0e+00]
  QObjective range [2e+00, 2e+00]
  Bounds range     [0e+00, 0e+00]
  RHS range        [2e-02, 2e+00]
Found heuristic solution: objective 66.6643507
Presolve time: 0.00s
Presolved: 80 rows, 110 columns, 2480 nonzeros
Presolved model has 80 quadratic objective terms
Variable types: 80 continuous, 30 integer (0 binary)

Root relaxation: objective 3.605752e+01, 111 iterations, 0.00 seconds

    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

     0     0   36.05752    0   30   66.66435   36.05752  45.9%     -    0s
H    0     0                      58.8737490   36.05752  38.8%     -    0s
H    0     0                      58.5380127   36.05752  38.4%     -    0s
H    0     0                      52.7767106   36.05752  31.7%     -    0s
     0     0   38.71155    0   30   52.77671   38.71155  26.7%     -    0s
     0     2   38.71155    0   30   52.77671   38.71155  26.7%     -    0s
H  135   134                      52.7044953   41.38283  21.5%   2.0    0s
H  138   134                      52.4071490   41.38283  21.0%   2.0    0s
H  383   255                      51.6354453   42.83010  17.1%   2.2    0s
*  786   375              32      50.9871801   44.12219  13.5%   2.1    0s
* 2828   646              30      50.9815114   47.30131  7.22%   2.1    0s
* 4504   350              31      50.6703955   48.96757  3.36%   2.1    0s

Explored 5175 nodes (11067 simplex iterations) in 0.46 seconds
Thread count was 16 (of 16 available processors)

Solution count 10: 50.6704 50.9815 50.9872 ... 66.6644

Optimal solution found (tolerance 1.00e-04)
Best objective 5.067039548775e+01, best bound 5.067039548775e+01, gap 0.0000%


Solve again
---
Parameter OutputFlag unchanged
   Value: 1  Min: 0  Max: 1  Default: 1
Changed value of parameter QCPDual to 1
   Prev: 0  Min: 0  Max: 1  Default: 0
Gurobi Optimizer version 9.1.1 build v9.1.1rc0 (mac64)
Thread count: 8 physical cores, 16 logical processors, using up to 16 threads
Optimize a model with 80 rows, 110 columns and 2480 nonzeros
Model fingerprint: 0xd9405a60
Model has 80 quadratic objective terms
Variable types: 80 continuous, 30 integer (0 binary)
Coefficient statistics:
  Matrix range     [7e-05, 1e+00]
  Objective range  [0e+00, 0e+00]
  QObjective range [2e+00, 2e+00]
  Bounds range     [0e+00, 0e+00]
  RHS range        [2e-02, 2e+00]

Loaded user MIP start with objective 50.6704

Presolve time: 0.00s
Presolved: 80 rows, 110 columns, 2480 nonzeros
Presolved model has 80 quadratic objective terms
Variable types: 80 continuous, 30 integer (0 binary)

Root relaxation: objective 3.605752e+01, 111 iterations, 0.00 seconds

    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

     0     0   36.05752    0   30   50.67040   36.05752  28.8%     -    0s
     0     0   38.71155    0   30   50.67040   38.71155  23.6%     -    0s
     0     2   38.71155    0   30   50.67040   38.71155  23.6%     -    0s

Explored 4863 nodes (10209 simplex iterations) in 0.44 seconds
Thread count was 16 (of 16 available processors)

Solution count 1: 50.6704

Optimal solution found (tolerance 1.00e-04)
Best objective 5.067039548775e+01, best bound 5.067039548775e+01, gap 0.0000%
```
