### PR TITLE
Fix bug in C-style reshape

### DIFF
--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -86,7 +86,7 @@ class reshape(AffAtom):
         return [self._shape, self.order]
 
     def graph_implementation(self, arg_objs, shape, data=None):
-        """Convolve two vectors.
+        """Reshape
 
         Parameters
         ----------
@@ -104,11 +104,10 @@ class reshape(AffAtom):
         """
         arg = arg_objs[0]
         if data[1] == 'F':
-            return (lu.reshape(arg_objs[0], shape), [])
+            return (lu.reshape(arg, shape), [])
         else:  # 'C':
-            print(shape)
+            arg = lu.transpose(arg)
             if len(shape) <= 1:
-                arg = lu.transpose(arg_objs[0])
                 return (lu.reshape(arg, shape), [])
             else:
                 result = lu.reshape(arg, (shape[1], shape[0]))

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -542,6 +542,21 @@ class TestAtoms(BaseTest):
         prob.solve()
         self.assertItemsAlmostEqual(a_np, x.value)
 
+        # Test more complex C-style reshape: matrix to another matrix
+        b = np.array([
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8],
+            [9, 10, 11],
+        ])
+        b_reshaped = b.reshape((2, 6), order='C')
+        X = cp.Variable(b.shape)
+        X_reshaped = cp.reshape(X, (2, 6), order='C')
+        prob = cp.Problem(cp.Minimize(0), [X_reshaped == b_reshaped])
+        prob.solve()
+        self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
+        self.assertItemsAlmostEqual(b, X.value)
+
     def test_vec(self):
         """Test the vec atom.
         """


### PR DESCRIPTION
This change fixes a bug in the canonicalization of C-style reshape.

Previously a transpose was omitted when reshaping matrices.

This change also removes a stray `print` statement.

See the change for an example of a `reshape` that previously did not work.