### PR TITLE
Gurobi: fix for when time limit is hit with no solution

### DIFF
--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -18,7 +18,7 @@ import numpy as np
 import cvxpy.settings as s
 
 
-def failure_solution(status):
+def failure_solution(status, attr=None):
     """Factory function for infeasible or unbounded solutions.
 
     Parameters
@@ -37,7 +37,9 @@ def failure_solution(status):
         opt_val = -np.inf
     else:
         opt_val = None
-    return Solution(status, opt_val, {}, {}, {})
+    if attr is None:
+        attr = {}
+    return Solution(status, opt_val, {}, {}, attr)
 
 
 class Solution(object):

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -126,8 +126,6 @@ class GUROBI(SCS):
         else:
             return failure_solution(status, attr)
 
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
-
     def solve_via_data(self, data, warm_start, verbose, solver_opts, solver_cache=None):
         """Returns the result of the call to the solver.
 

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -52,7 +52,7 @@ class GUROBI(SCS):
                   8: s.SOLVER_ERROR,
                   # TODO could be anything.
                   # means time expired.
-                  9: s.OPTIMAL_INACCURATE,
+                  9: s.USER_LIMIT,
                   10: s.SOLVER_ERROR,
                   11: s.SOLVER_ERROR,
                   12: s.SOLVER_ERROR,
@@ -246,6 +246,8 @@ class GUROBI(SCS):
                                                  s.SOLVER_ERROR)
         if solution["status"] == s.SOLVER_ERROR and model.SolCount:
             solution["status"] = s.OPTIMAL_INACCURATE
+        if solution["status"] == s.USER_LIMIT and not model.SolCount:
+            solution["status"] = s.INFEASIBLE_INACCURATE
         solution["model"] = model
 
         return solution

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -124,7 +124,7 @@ class GUROBI(SCS):
                 dual_vars = eq_dual
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status)
+            return failure_solution(status, attr)
 
         return Solution(status, opt_val, primal_vars, dual_vars, attr)
 


### PR DESCRIPTION
A fix for #1177, following our discussion.

Here is a brief summary.

### Context:

Sometimes Gurobi hits the time limit before finding a solution or proving that the problem is infeasible or unbounded. Currently cvxpy raises an unexpected exception in this case, as it tries to unpack a solution.

### What we want

1. that cvxpy stops raising an unexpected exception,
2. to be able to identify this case so that the user could retry with a higher time limit.

### The simplest way to achieve the above given current code

1. map this case to `INFEASIBLE_INACCURATE` status (and not to `USER_LIMIT`, as it is in `SOLUTION_PRESENT` list, and then tries to unpack a solution at each given opportunity resulting in another unexpected exception),
2. pass `attr` with details from the solver to `failure_solution`.

### Result

1. cvxpy returns successfully with status `INFEASIBLE_INACCURATE`,
2. the solver status is accessible via `solver_stats` -> `extra_stats`, so that one can check if Gurobi raised the `TIME_LIMIT` status and act upon it.

### Tests

I have added a test to capture the expected behavior described above:

1. build a model which triggers our case,
2. test if no exception is raised,
3. test if Gurobi status is accessible via `solver_stats` -> `extra_stats`,
4. if Gurobi changes its algorithms so that a solution is found or the termination reason is different, skip the test as it's not relevant anymore.

The test might be a bit clumsy, but I figured it's better than nothing... 

Looking forward to your thoughts!