### PR TITLE
Gurobi: fix for when time limit is hit with no solution (QP case)

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -75,6 +75,8 @@ class GUROBI(QpSolver):
 
         # Map GUROBI statuses back to CVXPY statuses
         status = self.STATUS_MAP.get(model.Status, s.SOLVER_ERROR)
+        if status == s.USER_LIMIT and not model.SolCount:
+            status = s.INFEASIBLE_INACCURATE
 
         if (status in s.SOLUTION_PRESENT) or (model.solCount > 0):
             opt_val = model.objVal + inverse_data[s.OFFSET]

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -499,3 +499,43 @@ class TestQp(BaseTest):
         prob = Problem(obj)
         prob.solve()
         self.assertAlmostEqual(obj.value, 1.0)
+
+    def test_gurobi_time_limit_no_solution(self):
+        """Make sure that if Gurobi terminates due to a time limit before finding a solution:
+            1) no error is raised,
+            2) solver stats are returned.
+            The test is skipped if something changes on Gurobi's side so that:
+            - a solution is found despite a time limit of zero,
+            - a different termination criteria is hit first.
+        """
+        from cvxpy import GUROBI
+        if GUROBI in INSTALLED_SOLVERS:
+            import gurobipy
+            objective = Minimize(self.x[0])
+            constraints = [self.x[0] >= 1]
+            prob = Problem(objective, constraints)
+            try:
+                prob.solve(solver=GUROBI, TimeLimit=0.0)
+            except Exception as e:
+                self.fail("An exception %s is raised instead of returning a result." % e)
+
+            extra_stats = None
+            solver_stats = getattr(prob, "solver_stats", None)
+            if solver_stats:
+                extra_stats = getattr(solver_stats, "extra_stats", None)
+            self.assertTrue(extra_stats, "Solver stats have not been returned.")
+
+            nb_solutions = getattr(extra_stats, "SolCount", None)
+            if nb_solutions:
+                self.skipTest("Gurobi has found a solution, the test is not relevant anymore.")
+
+            solver_status = getattr(extra_stats, "Status", None)
+            if solver_status != gurobipy.StatusConstClass.TIME_LIMIT:
+                self.skipTest("Gurobi terminated for a different reason than reaching time limit, "
+                              "the test is not relevant anymore.")
+
+        else:
+            with self.assertRaises(Exception) as cm:
+                prob = Problem(Minimize(norm(self.x, 1)), [self.x == 0])
+                prob.solve(solver=GUROBI, TimeLimit=0)
+            self.assertEqual(str(cm.exception), "The solver %s is not installed." % GUROBI)


### PR DESCRIPTION
Similar to my recent fix in #1270 for [gurobi_conif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py), we have encountered the same issue in [gurobi_qupif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py) this time. It is also documented in issue #1176. This PR should fix it.

The changes are **identical** to the one in #1270 **up to the following differences**:

1. the scope of the changes is [gurobi_qupif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py) instead of [gurobi_conif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py),
2. there was no need to explicitly pass `attr` with details from the solver, as it is already passed,
3. for the test, I had to slightly change the model to trigger the [gurobi_qupif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py) case instead of [gurobi_conif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py),
4. as to the location of the test, I have appended it to the [test_qp_solvers.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/tests/test_qp_solvers.py) suite.

Thanks for your thoughts!