### PR TITLE
Implement handling of `bool` valued constraints

### DIFF
--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -84,11 +84,11 @@ class TestProblem(BaseTest):
         vars_ = p.variables()
         ref = [self.a, self.x, self.b, self.A]
         self.assertCountEqual(vars_, ref)
-    
+
     def test_var_dict(self):
         p = Problem(cp.Minimize(self.a), [self.a <= self.x, self.b <= self.A + 2])
         assert p.var_dict == {"a": self.a, "x": self.x, "b": self.b, "A": self.A}
-        
+
     def test_parameters(self):
         """Test the parameters method.
         """
@@ -99,7 +99,7 @@ class TestProblem(BaseTest):
         params = p.parameters()
         ref = [p1, p2, p3]
         self.assertCountEqual(params, ref)
-    
+
     def test_param_dict(self):
         p1 = Parameter(name="p1")
         p2 = Parameter(3, nonpos=True, name="p2")
@@ -1763,7 +1763,27 @@ class TestProblem(BaseTest):
     def test_bool_constr(self):
         """Test constraints that evaluate to booleans.
         """
-        pass
+        x = cp.Variable(pos=True)
+        prob = cp.Problem(cp.Minimize(x), [True])
+        prob.solve()
+        self.assertAlmostEqual(x.value, 0)
+
+        x = cp.Variable(pos=True)
+        prob = cp.Problem(cp.Minimize(x), [True]*10)
+        prob.solve()
+        self.assertAlmostEqual(x.value, 0)
+
+        prob = cp.Problem(cp.Minimize(x), [False])
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
+
+        prob = cp.Problem(cp.Minimize(x), [False]*10)
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
+
+        prob = cp.Problem(cp.Minimize(x), [True]*10 + [False] + [True]*10)
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
 
     def test_pos(self):
         """Test the pos and neg attributes.

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1773,6 +1773,14 @@ class TestProblem(BaseTest):
         prob.solve()
         self.assertAlmostEqual(x.value, 0)
 
+        prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10)
+        prob.solve()
+        self.assertAlmostEqual(x.value, 42)
+
+        prob = cp.Problem(cp.Minimize(x), [True] + [42 <= x] + [True] * 10)
+        prob.solve()
+        self.assertAlmostEqual(x.value, 42)
+
         prob = cp.Problem(cp.Minimize(x), [False])
         prob.solve()
         self.assertEqual(prob.status, s.INFEASIBLE)
@@ -1782,6 +1790,15 @@ class TestProblem(BaseTest):
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [True]*10 + [False] + [True]*10)
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
+
+        prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10 + [False])
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
+
+        # only Trues, but infeasible solution since x must be non-negative.
+        prob = cp.Problem(cp.Minimize(x), [True] + [x <= -42] + [True]*10)
         prob.solve()
         self.assertEqual(prob.status, s.INFEASIBLE)
 


### PR DESCRIPTION
As described in issue #1280 and discussed with @SteveDiamond, this commit allows CVXPY to properly handle expressions that are just `bool` values (`True` or `False`). This happens at the level of the `Problem()` constructor, replacing these values with equivalent valid expressions (which are respectively either always True or False).

The commit replaces a stub unit test with an actual passing unit tests.  
Flake8 passes without event.

Pre-change benchmarks:

```
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.7.4, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\adishavit\Work\BuildOS\code\cvxpy
collected 11 items                                                                                                                                                                                                                     

test_benchmarks.py cone_matrix_stuffing_with_many_constraints: avg=1.198e+00 s , std=0.000e+00 s (1 iterations)
.diffcp_sdp: avg=7.318e+00 s , std=0.000e+00 s (1 iterations)
.least_squares: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.sConic canonicalization
(ECOS) solver time:  0.060931
cvxpy time:  1.079426732772827
Quadratic canonicalization
(OSQP) solver time:  0.0267756
cvxpy time:  1.2542173847717286
.qp: avg=1.558e-02 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=5.779e-02 s , std=1.220e-02 s (10 iterations)
.small_lp: avg=1.562e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.small_parameterized_cone_matrix_stuffing: avg=6.151e+00 s , std=0.000e+00 s (1 iterations)
.small_parameterized_lp: avg=8.491e+00 s , std=0.000e+00 s (1 iterations)
small_parameterized_lp_second_time: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.s

========================================================================================================== warnings summary ===========================================================================================================
cvxpy/tests/test_benchmarks.py: 6759 warnings
  C:\Users\adishavit\Work\BuildOS\code\cvxpy\cvxpy\interface\numpy_interface\ndarray_interface.py:47: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself
. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    if result.dtype in [numpy.complex, numpy.float64]:

cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_diffcp_sdp_example
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_least_squares
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_parameterized_qp
  C:\Users\adishavit\Work\BuildOS\code\cvxpy\cvxpy\interface\numpy_interface\sparse_matrix_interface.py:42: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by
itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    if value.dtype in [np.double, np.complex]:

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================================ 9 passed, 2 skipped, 6762 warnings in 27.39s =============================================================================================
```
Post change benchmarks:

```
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.7.4, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\adishavit\Work\BuildOS\code\cvxpy
collected 11 items                                                                                                                                                                                                                     

test_benchmarks.py cone_matrix_stuffing_with_many_constraints: avg=1.218e+00 s , std=0.000e+00 s (1 iterations)
.diffcp_sdp: avg=7.041e+00 s , std=0.000e+00 s (1 iterations)
.least_squares: avg=1.562e-02 s , std=0.000e+00 s (1 iterations)
.sConic canonicalization
(ECOS) solver time:  0.0611683
cvxpy time:  1.0554641615478515
Quadratic canonicalization
(OSQP) solver time:  0.0275637
cvxpy time:  1.237763038357544
.qp: avg=1.564e-02 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=5.624e-02 s , std=1.250e-02 s (10 iterations)
.small_lp: avg=1.562e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=1.566e-02 s , std=0.000e+00 s (1 iterations)
.small_parameterized_cone_matrix_stuffing: avg=6.068e+00 s , std=0.000e+00 s (1 iterations)
.small_parameterized_lp: avg=8.341e+00 s , std=0.000e+00 s (1 iterations)
small_parameterized_lp_second_time: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.s

========================================================================================================== warnings summary ===========================================================================================================
cvxpy/tests/test_benchmarks.py: 6759 warnings
  C:\Users\adishavit\Work\BuildOS\code\cvxpy\cvxpy\interface\numpy_interface\ndarray_interface.py:47: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself
. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    if result.dtype in [numpy.complex, numpy.float64]:

cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_diffcp_sdp_example
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_least_squares
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_parameterized_qp
  C:\Users\adishavit\Work\BuildOS\code\cvxpy\cvxpy\interface\numpy_interface\sparse_matrix_interface.py:42: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by
itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    if value.dtype in [np.double, np.complex]:

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================================ 9 passed, 2 skipped, 6762 warnings in 27.30s =============================================================================================
.
```