### PR TITLE
Add some type annotations

### DIFF
--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -27,7 +27,7 @@ class AddExpression(AffAtom):
     """The sum of any number of expressions.
     """
 
-    def __init__(self, arg_groups):
+    def __init__(self, arg_groups) -> None:
         # For efficiency group args as sums.
         self._arg_groups = arg_groups
         super(AddExpression, self).__init__(*arg_groups)
@@ -57,23 +57,23 @@ class AddExpression(AffAtom):
     def numeric(self, values):
         return reduce(op.add, values)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         symm_args = all(arg.is_symmetric() for arg in self.args)
         return self.shape[0] == self.shape[1] and symm_args
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression Hermitian?
         """
         herm_args = all(arg.is_hermitian() for arg in self.args)

--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -22,6 +22,8 @@ from cvxpy.atoms.atom import Atom
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.expressions.constants import Constant
 from cvxpy.utilities import performance_utils as perf
+from typing import Any, List
+
 import scipy.sparse as sp
 
 
@@ -35,52 +37,52 @@ class AffAtom(Atom):
         """
         return u.sign.sum_signs([arg for arg in self.args])
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the expression imaginary?
         """
         # Default is most generic argument.
         return all(arg.is_imag() for arg in self.args)
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the expression complex valued?
         """
         # Default is most generic argument.
         return any(arg.is_complex() for arg in self.args)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         # Defaults to increasing.
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         # Defaults to increasing.
         return False
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         return all(arg.is_quadratic() for arg in self.args)
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         return all(arg.is_qpwa() for arg in self.args)
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         return all(arg.is_pwl() for arg in self.args)
 
     # TODO is this right?
     @perf.compute_once
-    def is_psd(self):
+    def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         for idx, arg in enumerate(self.args):
@@ -90,7 +92,7 @@ class AffAtom(Atom):
         return True
 
     @perf.compute_once
-    def is_nsd(self):
+    def is_nsd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         for idx, arg in enumerate(self.args):
@@ -99,7 +101,7 @@ class AffAtom(Atom):
                 return False
         return True
 
-    def _grad(self, values):
+    def _grad(self, values) -> List[Any]:
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
         Matrix expressions are vectorized, so the gradient is a matrix.

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -42,7 +42,7 @@ class BinaryOperator(AffAtom):
 
     OP_NAME = 'BINARY_OP'
 
-    def __init__(self, lh_exp, rh_exp):
+    def __init__(self, lh_exp, rh_exp) -> None:
         super(BinaryOperator, self).__init__(lh_exp, rh_exp)
 
     def name(self):
@@ -64,20 +64,20 @@ class BinaryOperator(AffAtom):
         """
         return u.sign.mul_sign(self.args[0], self.args[1])
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the expression imaginary?
         """
         return (self.args[0].is_imag() and self.args[1].is_real()) or \
             (self.args[0].is_real() and self.args[1].is_imag())
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the expression complex valued?
         """
         return (self.args[0].is_complex() or self.args[1].is_complex()) and \
             not (self.args[0].is_imag() and self.args[1].is_imag())
 
 
-def matmul(lh_exp, rh_exp):
+def matmul(lh_exp, rh_exp) -> "MulExpression":
     """Matrix multiplication."""
     return MulExpression(lh_exp, rh_exp)
 
@@ -115,7 +115,7 @@ class MulExpression(BinaryOperator):
         """
         return u.shape.mul_shapes(self.args[0].shape, self.args[1].shape)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Multiplication is convex (affine) in its arguments only if one of
            the arguments is constant.
         """
@@ -138,27 +138,27 @@ class MulExpression(BinaryOperator):
         else:
             return self.args[0].is_constant() or self.args[1].is_constant()
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """If the multiplication atom is convex, then it is affine.
         """
         return self.is_atom_convex()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[1-idx].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[1-idx].is_nonpos()
@@ -230,27 +230,27 @@ class multiply(MulExpression):
     """ Multiplies two expressions elementwise.
     """
 
-    def __init__(self, lh_expr, rh_expr):
+    def __init__(self, lh_expr, rh_expr) -> None:
         lh_expr, rh_expr = self.broadcast(lh_expr, rh_expr)
         super(multiply, self).__init__(lh_expr, rh_expr)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         return (
             self.args[0].is_constant() or self.args[1].is_constant()) or (
             self.args[0].is_nonneg() and self.args[1].is_nonpos()) or (
             self.args[0].is_nonpos() and self.args[1].is_nonneg())
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         return (
             self.args[0].is_constant() or self.args[1].is_constant()) or all(
             arg.is_nonneg() for arg in self.args) or all(
@@ -271,13 +271,13 @@ class multiply(MulExpression):
         """
         return u.shape.sum_shapes([arg.shape for arg in self.args])
 
-    def is_psd(self):
+    def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         return (self.args[0].is_psd() and self.args[1].is_psd()) or \
                (self.args[0].is_nsd() and self.args[1].is_nsd())
 
-    def is_nsd(self):
+    def is_nsd(self) -> bool:
         """Is the expression a negative semidefinite matrix?
         """
         return (self.args[0].is_psd() and self.args[1].is_nsd()) or \
@@ -321,7 +321,7 @@ class DivExpression(BinaryOperator):
     OP_NAME = "/"
     OP_FUNC = np.divide
 
-    def __init__(self, lh_expr, rh_expr):
+    def __init__(self, lh_expr, rh_expr) -> None:
         lh_expr, rh_expr = self.broadcast(lh_expr, rh_expr)
         super(DivExpression, self).__init__(lh_expr, rh_expr)
 
@@ -333,10 +333,10 @@ class DivExpression(BinaryOperator):
                 values[i] = values[i].todense().A
         return np.divide(values[0], values[1])
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         return self.args[0].is_quadratic() and self.args[1].is_constant()
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         return self.args[0].is_qpwa() and self.args[1].is_constant()
 
     def shape_from_args(self):
@@ -344,32 +344,32 @@ class DivExpression(BinaryOperator):
         """
         return self.args[0].shape
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Division is convex (affine) in its arguments only if
            the denominator is constant.
         """
         return self.args[1].is_constant()
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         return self.is_atom_convex()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         return self.args[1].is_nonneg() or self.args[1].is_nonpos()
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         return self.is_atom_quasiconvex()
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         if idx == 0:
@@ -377,7 +377,7 @@ class DivExpression(BinaryOperator):
         else:
             return self.args[0].is_nonpos()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         if idx == 0:

--- a/cvxpy/atoms/affine/conj.py
+++ b/cvxpy/atoms/affine/conj.py
@@ -21,7 +21,7 @@ import numpy as np
 class conj(AffAtom):
     """Complex conjugate.
     """
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(conj, self).__init__(expr)
 
     def numeric(self, values):
@@ -34,22 +34,22 @@ class conj(AffAtom):
         """
         return self.args[0].shape
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return self.args[0].is_symmetric()
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression Hermitian?
         """
         return self.args[0].is_hermitian()

--- a/cvxpy/atoms/affine/conv.py
+++ b/cvxpy/atoms/affine/conv.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.affine.affine_atom import AffAtom
+from typing import Tuple
+
 import cvxpy.utilities as u
 import cvxpy.interface as intf
 import cvxpy.lin_ops.lin_utils as lu
@@ -42,7 +44,7 @@ class conv(AffAtom):
     # TODO work with right hand constant.
     # TODO(akshayka): make DGP-compatible
 
-    def __init__(self, lh_expr, rh_expr):
+    def __init__(self, lh_expr, rh_expr) -> None:
         super(conv, self).__init__(lh_expr, rh_expr)
 
     @AffAtom.numpy_numeric
@@ -53,7 +55,7 @@ class conv(AffAtom):
         values = list(map(intf.from_2D_to_1D, values))
         return np.convolve(values[0], values[1])
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that both arguments are vectors, and the first is constant.
         """
         if not self.args[0].is_vector() or not self.args[1].is_vector():
@@ -61,7 +63,7 @@ class conv(AffAtom):
         if not self.args[0].is_constant():
             raise ValueError("The first argument to conv must be constant.")
 
-    def shape_from_args(self):
+    def shape_from_args(self) -> Tuple[int, int]:
         """The sum of the argument dimensions - 1.
         """
         lh_length = self.args[0].shape[0]
@@ -73,12 +75,12 @@ class conv(AffAtom):
         """
         return u.sign.mul_sign(self.args[0], self.args[1])
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[0].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[0].is_nonpos()

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -69,7 +69,7 @@ class cumsum(AffAtom, AxisAtom):
     axis : int
         The axis to sum across if 2D.
     """
-    def __init__(self, expr, axis=0):
+    def __init__(self, expr, axis: int=0) -> None:
         super(cumsum, self).__init__(expr, axis)
 
     @AffAtom.numpy_numeric

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -16,11 +16,13 @@ limitations under the License.
 
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.vec import vec
+from typing import Union
+
 import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 
 
-def diag(expr):
+def diag(expr) -> Union["diag_mat", "diag_vec"]:
     """Extracts the diagonal from a matrix or makes a vector a diagonal matrix.
 
     Parameters
@@ -46,15 +48,15 @@ class diag_vec(AffAtom):
     """Converts a vector into a diagonal matrix.
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(diag_vec, self).__init__(expr)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
@@ -70,22 +72,22 @@ class diag_vec(AffAtom):
         rows = self.args[0].shape[0]
         return (rows, rows)
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return True
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression symmetric?
         """
         return True
 
-    def is_psd(self):
+    def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         return self.is_nonneg()
 
-    def is_nsd(self):
+    def is_nsd(self) -> bool:
         """Is the expression a negative semidefinite matrix?
         """
         return self.is_nonpos()
@@ -114,15 +116,15 @@ class diag_mat(AffAtom):
     """Extracts the diagonal from a square matrix.
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(diag_mat, self).__init__(expr)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
@@ -140,7 +142,7 @@ class diag_mat(AffAtom):
         rows, _ = self.args[0].shape
         return (rows,)
 
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression nonnegative?
         """
         return self.args[0].is_nonneg() or self.args[0].is_psd()

--- a/cvxpy/atoms/affine/hstack.py
+++ b/cvxpy/atoms/affine/hstack.py
@@ -19,7 +19,7 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 import numpy as np
 
 
-def hstack(arg_list):
+def hstack(arg_list) -> "Hstack":
     """Horizontal concatenation of an arbitrary number of Expressions.
 
     Parameters
@@ -36,10 +36,10 @@ def hstack(arg_list):
 
 class Hstack(AffAtom):
     """ Horizontal concatenation """
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         return True
 
     # Returns the hstack of the values.
@@ -55,7 +55,7 @@ class Hstack(AffAtom):
             return (self.args[0].shape[0], cols) + self.args[0].shape[2:]
 
     # All arguments must have the same width.
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         model = self.args[0].shape
         error = ValueError(("All the input dimensions except"
                             " for axis 1 must match exactly."))

--- a/cvxpy/atoms/affine/imag.py
+++ b/cvxpy/atoms/affine/imag.py
@@ -21,7 +21,7 @@ import numpy as np
 class imag(AffAtom):
     """Extracts the imaginary part of an expression.
     """
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(imag, self).__init__(expr)
 
     def numeric(self, values):
@@ -34,17 +34,17 @@ class imag(AffAtom):
         """
         return self.args[0].shape
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the expression imaginary?
         """
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the expression complex valued?
         """
         return False
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return self.args[0].is_hermitian()

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -38,7 +38,7 @@ class index(AffAtom):
         The index/slicing key (i.e. expr[key[0],key[1]]).
     """
 
-    def __init__(self, expr, key, orig_key=None):
+    def __init__(self, expr, key, orig_key=None) -> None:
         # Format and validate key.
         if orig_key is None:
             self._orig_key = key
@@ -48,12 +48,12 @@ class index(AffAtom):
             self.key = key
         super(index, self).__init__(expr)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
@@ -111,7 +111,7 @@ class special_index(AffAtom):
         ndarrays or lists.
     """
 
-    def __init__(self, expr, key):
+    def __init__(self, expr, key) -> None:
         self.key = key
         # Order the entries of expr and select them using key.
         expr = index.cast_to_const(expr)
@@ -121,12 +121,12 @@ class special_index(AffAtom):
         self._shape = self._select_mat.shape
         super(special_index, self).__init__(expr)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True

--- a/cvxpy/atoms/affine/kron.py
+++ b/cvxpy/atoms/affine/kron.py
@@ -26,7 +26,7 @@ class kron(AffAtom):
     # TODO work with right hand constant.
     # TODO(akshayka): make DGP-compatible
 
-    def __init__(self, lh_expr, rh_expr):
+    def __init__(self, lh_expr, rh_expr) -> None:
         super(kron, self).__init__(lh_expr, rh_expr)
 
     @AffAtom.numpy_numeric
@@ -35,7 +35,7 @@ class kron(AffAtom):
         """
         return np.kron(values[0], values[1])
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that both arguments are vectors, and the first is constant.
         """
         if not self.args[0].is_constant():
@@ -55,12 +55,12 @@ class kron(AffAtom):
         """
         return u.sign.mul_sign(self.args[0], self.args[1])
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[0].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[0].is_nonpos()

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -56,7 +56,7 @@ class Promote(AffAtom):
         The shape to promote to.
     """
 
-    def __init__(self, expr, shape):
+    def __init__(self, expr, shape) -> None:
         self.promoted_shape = shape
         super(Promote, self).__init__(expr)
 
@@ -66,16 +66,16 @@ class Promote(AffAtom):
         """
         return np.ones(self.promoted_shape) * values[0]
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return self.ndim == 2 and self.shape[0] == self.shape[1]
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?"""
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?"""
         return True
 

--- a/cvxpy/atoms/affine/real.py
+++ b/cvxpy/atoms/affine/real.py
@@ -21,7 +21,7 @@ import numpy as np
 class real(AffAtom):
     """Extracts the real part of an expression.
     """
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(real, self).__init__(expr)
 
     def numeric(self, values):
@@ -35,17 +35,17 @@ class real(AffAtom):
         """
         return self.args[0].shape
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the expression imaginary?
         """
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the expression complex valued?
         """
         return False
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return self.args[0].is_hermitian()

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -17,6 +17,8 @@ limitations under the License.
 from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.affine_atom import AffAtom
+from typing import Tuple
+
 import cvxpy.lin_ops.lin_utils as lu
 import numbers
 import numpy as np
@@ -38,7 +40,7 @@ class reshape(AffAtom):
     order : F(ortran) or C
     """
 
-    def __init__(self, expr, shape, order='F'):
+    def __init__(self, expr, shape: Tuple[int], order: str='F') -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         if len(shape) > 2:
@@ -49,12 +51,12 @@ class reshape(AffAtom):
         self.order = order
         super(reshape, self).__init__(expr)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
@@ -65,7 +67,7 @@ class reshape(AffAtom):
         """
         return np.reshape(values[0], self.shape, self.order)
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that the new shape has the same number of entries as the old.
         """
         old_len = self.args[0].size

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -35,15 +35,15 @@ class Sum(AxisAtom, AffAtom):
         Whether to drop dimensions after summing.
     """
 
-    def __init__(self, expr, axis=None, keepdims=False):
+    def __init__(self, expr, axis=None, keepdims: bool=False) -> None:
         super(Sum, self).__init__(expr, axis=axis, keepdims=keepdims)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -28,7 +28,7 @@ class trace(AffAtom):
         The expression to sum the diagonal of.
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(trace, self).__init__(expr)
 
     @AffAtom.numpy_numeric
@@ -37,7 +37,7 @@ class trace(AffAtom):
         """
         return np.trace(values[0])
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that the argument is a square matrix.
         """
         shape = self.args[0].shape
@@ -49,12 +49,12 @@ class trace(AffAtom):
         """
         return tuple()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False

--- a/cvxpy/atoms/affine/transpose.py
+++ b/cvxpy/atoms/affine/transpose.py
@@ -23,12 +23,12 @@ class transpose(AffAtom):
     """Transpose an expression.
     """
 
-    def __init__(self, expr, axes=None):
+    def __init__(self, expr, axes=None) -> None:
         self.axes = axes
         super(AffAtom, self).__init__(expr)
 
     # The string representation of the atom.
-    def name(self):
+    def name(self) -> str:
         return "%s.T" % self.args[0]
 
     # Returns the transpose of the given value.
@@ -36,22 +36,22 @@ class transpose(AffAtom):
     def numeric(self, values):
         return np.transpose(values[0], axes=self.axes)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return self.args[0].is_symmetric()
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression Hermitian?
         """
         return self.args[0].is_hermitian()

--- a/cvxpy/atoms/affine/unary_operators.py
+++ b/cvxpy/atoms/affine/unary_operators.py
@@ -24,7 +24,7 @@ class UnaryOperator(AffAtom):
     Base class for expressions involving unary operators.
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(UnaryOperator, self).__init__(expr)
 
     def name(self):
@@ -51,22 +51,22 @@ class NegExpression(UnaryOperator):
         """
         return (self.args[0].is_nonpos(), self.args[0].is_nonneg())
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return True
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         return self.args[0].is_symmetric()
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression Hermitian?
         """
         return self.args[0].is_hermitian()

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -19,6 +19,7 @@ from cvxpy.atoms.affine.reshape import reshape
 import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 from scipy.sparse import csc_matrix
+from typing import Tuple
 
 
 class upper_tri(AffAtom):
@@ -38,7 +39,7 @@ class upper_tri(AffAtom):
     ```
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         super(upper_tri, self).__init__(expr)
 
     @AffAtom.numpy_numeric
@@ -54,7 +55,7 @@ class upper_tri(AffAtom):
                     count += 1
         return value
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that the argument is a square matrix.
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
@@ -62,18 +63,18 @@ class upper_tri(AffAtom):
                 "Argument to upper_tri must be a square matrix."
             )
 
-    def shape_from_args(self):
+    def shape_from_args(self) -> Tuple[int, int]:
         """A vector.
         """
         rows, cols = self.args[0].shape
         return (rows*(cols-1)//2, 1)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True

--- a/cvxpy/atoms/affine/vstack.py
+++ b/cvxpy/atoms/affine/vstack.py
@@ -19,7 +19,7 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 import numpy as np
 
 
-def vstack(arg_list):
+def vstack(arg_list) -> "Vstack":
     """Wrapper on vstack to ensure list argument.
     """
     return Vstack(*arg_list)
@@ -27,12 +27,12 @@ def vstack(arg_list):
 
 class Vstack(AffAtom):
     """ Vertical concatenation """
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
@@ -54,7 +54,7 @@ class Vstack(AffAtom):
             return (rows,) + self.args[0].shape[1:]
 
     # All arguments must have the same width.
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         model = self.args[0].shape
         for arg in self.args[1:]:
             if len(arg.shape) != len(model) or \

--- a/cvxpy/atoms/affine/wraps.py
+++ b/cvxpy/atoms/affine/wraps.py
@@ -20,13 +20,13 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 class Wrap(AffAtom):
     """A no-op wrapper to assert properties.
     """
-    def __init__(self, arg):
+    def __init__(self, arg) -> None:
         return super(Wrap, self).__init__(arg)
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         return True
 
     def numeric(self, values):
@@ -63,8 +63,8 @@ class psd_wrap(Wrap):
     """Asserts argument is PSD.
     """
 
-    def is_psd(self):
+    def is_psd(self) -> bool:
         return True
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         return True

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -23,6 +23,8 @@ from cvxpy.expressions.expression import Expression
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.utilities.deterministic import unique_list
 from cvxpy.utilities import performance_utils as perf
+from typing import List
+
 import abc
 import numpy as np
 
@@ -33,7 +35,7 @@ class Atom(Expression):
     _allow_complex = False
     # args are the expressions passed into the Atom constructor.
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         self.id = lu.get_id()
         # Throws error if args is empty.
         if len(args) == 0:
@@ -47,7 +49,7 @@ class Atom(Expression):
         if len(self._shape) > 2:
             raise ValueError("Atoms must be at most 2D.")
 
-    def name(self):
+    def name(self) -> str:
         """Returns the string representation of the function call.
         """
         if self.get_data() is None:
@@ -57,7 +59,7 @@ class Atom(Expression):
         return "%s(%s)" % (self.__class__.__name__,
                            ", ".join([arg.name() for arg in self.args] + data))
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Raises an error if the arguments are invalid.
         """
         if not self._allow_complex and any(arg.is_complex() for arg in self.args):
@@ -82,87 +84,87 @@ class Atom(Expression):
         raise NotImplementedError()
 
     @perf.compute_once
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression nonnegative?
         """
         return self.sign_from_args()[0]
 
     @perf.compute_once
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         """Is the expression nonpositive?
         """
         return self.sign_from_args()[1]
 
     @perf.compute_once
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the expression imaginary?
         """
         # Default is false.
         return False
 
     @perf.compute_once
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the expression complex valued?
         """
         # Default is false.
         return False
 
     @abc.abstractmethod
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         raise NotImplementedError()
 
-    def is_atom_affine(self):
+    def is_atom_affine(self) -> bool:
         """Is the atom affine?
         """
         return self.is_atom_concave() and self.is_atom_convex()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return self.is_atom_convex()
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconcave?
         """
         return self.is_atom_concave()
 
-    def is_atom_log_log_affine(self):
+    def is_atom_log_log_affine(self) -> bool:
         """Is the atom log-log affine?
         """
         return self.is_atom_log_log_concave() and self.is_atom_log_log_convex()
 
     @abc.abstractmethod
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         raise NotImplementedError()
 
     @perf.compute_once
-    def is_convex(self):
+    def is_convex(self) -> bool:
         """Is the expression convex?
         """
         # Applies DCP composition rule.
@@ -179,7 +181,7 @@ class Atom(Expression):
             return False
 
     @perf.compute_once
-    def is_concave(self):
+    def is_concave(self) -> bool:
         """Is the expression concave?
         """
         # Applies DCP composition rule.
@@ -195,7 +197,7 @@ class Atom(Expression):
         else:
             return False
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         """The expression is a disciplined parameterized expression.
         """
         if context.lower() == 'dcp':
@@ -206,7 +208,7 @@ class Atom(Expression):
             raise ValueError('Unsupported context ', context)
 
     @perf.compute_once
-    def is_log_log_convex(self):
+    def is_log_log_convex(self) -> bool:
         """Is the expression log-log convex?
         """
         # Verifies DGP composition rule.
@@ -223,7 +225,7 @@ class Atom(Expression):
             return False
 
     @perf.compute_once
-    def is_log_log_concave(self):
+    def is_log_log_concave(self) -> bool:
         """Is the expression log-log concave?
         """
         # Verifies DGP composition rule.
@@ -240,11 +242,11 @@ class Atom(Expression):
             return False
 
     @perf.compute_once
-    def _non_const_idx(self):
+    def _non_const_idx(self) -> List[int]:
         return [i for i, arg in enumerate(self.args) if not arg.is_constant()]
 
     @perf.compute_once
-    def _is_real(self):
+    def _is_real(self) -> bool:
         # returns true if this atom is a real function:
         #   the atom must have exactly one argument that is not a constant
         #   that argument must be a scalar
@@ -254,7 +256,7 @@ class Atom(Expression):
                 self.args[non_const[0]].is_scalar())
 
     @perf.compute_once
-    def is_quasiconvex(self):
+    def is_quasiconvex(self) -> bool:
         """Is the expression quaisconvex?
         """
         from cvxpy.atoms.max import max as max_atom
@@ -278,7 +280,7 @@ class Atom(Expression):
         return False
 
     @perf.compute_once
-    def is_quasiconcave(self):
+    def is_quasiconcave(self) -> bool:
         """Is the expression quasiconcave?
         """
         from cvxpy.atoms.min import min as min_atom

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -27,7 +27,7 @@ class AxisAtom(Atom):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, expr, axis=None, keepdims=False):
+    def __init__(self, expr, axis=None, keepdims: bool=False) -> None:
         self.axis = axis
         self.keepdims = keepdims
         super(AxisAtom, self).__init__(expr)
@@ -51,7 +51,7 @@ class AxisAtom(Atom):
         """
         return [self.axis, self.keepdims]
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that the new shape has the same number of entries as the old.
         """
         if self.axis is not None and self.axis > self.args[0].ndim:

--- a/cvxpy/atoms/cummax.py
+++ b/cvxpy/atoms/cummax.py
@@ -23,7 +23,7 @@ class cummax(AxisAtom):
     """Cumulative maximum.
     """
 
-    def __init__(self, x, axis=0):
+    def __init__(self, x, axis: int=0) -> None:
         super(cummax, self).__init__(x, axis=axis)
 
     @Atom.numpy_numeric
@@ -81,22 +81,22 @@ class cummax(AxisAtom):
         """
         return [self.axis]
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/dist_ratio.py
+++ b/cvxpy/atoms/dist_ratio.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from cvxpy.atoms.atom import Atom
+from typing import Tuple
+
 import numpy as np
 
 
@@ -22,7 +24,7 @@ class dist_ratio(Atom):
 
     `a` and `b` must be constants.
     """
-    def __init__(self, x, a, b):
+    def __init__(self, x, a, b) -> None:
         super(dist_ratio, self).__init__(x, a, b)
         if not self.args[1].is_constant():
             raise ValueError("`a` must be a constant.")
@@ -42,41 +44,41 @@ class dist_ratio(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always nonnegative.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconvex?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def _grad(self, values):
+    def _grad(self, values) -> None:
         return None

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from .elementwise import Elementwise
+from typing import Tuple
+
 import numpy as np
 
 
@@ -22,7 +24,7 @@ class abs(Elementwise):
     """ Elementwise absolute value """
     _allow_complex = True
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(abs, self).__init__(x)
 
     # Returns the elementwise absolute value of x.
@@ -30,33 +32,33 @@ class abs(Elementwise):
     def numeric(self, values):
         return np.absolute(values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[idx].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[idx].is_nonpos()
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return self.args[0].is_pwl() and \

--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Tuple
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -21,14 +23,14 @@ import scipy.sparse as sp
 class ceil(Elementwise):
     """Elementwise ceiling."""
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         return super(ceil, self).__init__(x)
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
         return np.ceil(values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         if self.args[0].is_nonneg() and self.args[0].is_nonpos():
@@ -40,42 +42,42 @@ class ceil(Elementwise):
         else:
             return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconcave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
@@ -97,14 +99,14 @@ class ceil(Elementwise):
 class floor(Elementwise):
     """Elementwise floor."""
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         return super(floor, self).__init__(x)
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
         return np.floor(values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         if self.args[0].is_nonneg() and self.args[0].is_nonpos():
@@ -116,42 +118,42 @@ class floor(Elementwise):
         else:
             return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconcave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -31,7 +31,7 @@ class Elementwise(Atom):
         """
         return u.shape.sum_shapes([arg.shape for arg in self.args])
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """
         Verify that all the shapes are the same
         or can be promoted.
@@ -39,7 +39,7 @@ class Elementwise(Atom):
         u.shape.sum_shapes([arg.shape for arg in self.args])
         super(Elementwise, self).validate_arguments()
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         symm_args = all(arg.is_symmetric() for arg in self.args)

--- a/cvxpy/atoms/elementwise/entr.py
+++ b/cvxpy/atoms/elementwise/entr.py
@@ -17,6 +17,7 @@ limitations under the License.
 from cvxpy.atoms.elementwise.elementwise import Elementwise
 import numpy as np
 from scipy.special import xlogy
+from typing import Tuple
 
 # TODO(akshayka): DGP support.
 
@@ -25,7 +26,7 @@ class entr(Elementwise):
     """Elementwise :math:`-x\\log x`.
     """
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(entr, self).__init__(x)
 
     def numeric(self, values):
@@ -39,28 +40,28 @@ class entr(Elementwise):
             results[np.isnan(results)] = -np.inf
         return results
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always unknown.
         return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/elementwise/exp.py
+++ b/cvxpy/atoms/elementwise/exp.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Tuple
+
 import numpy as np
 
 
@@ -22,7 +24,7 @@ class exp(Elementwise):
     """Elementwise :math:`e^{x}`.
     """
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(exp, self).__init__(x)
 
     # Returns the matrix e^x[i, j].
@@ -30,38 +32,38 @@ class exp(Elementwise):
     def numeric(self, values):
         return np.exp(values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Tuple
+
 import scipy.special
 import numpy as np
 
@@ -42,43 +44,43 @@ class huber(Elementwise):
         A scalar constant.
     """
 
-    def __init__(self, x, M=1):
+    def __init__(self, x, M: int=1) -> None:
         self.M = self.cast_to_const(M)
         super(huber, self).__init__(x)
 
     @Elementwise.numpy_numeric
-    def numeric(self, values):
+    def numeric(self, values) -> float:
         """Returns the huber function applied elementwise to x.
         """
         return 2*scipy.special.huber(self.M.value, values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[idx].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[idx].is_nonpos()
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Quadratic if x is affine.
         """
         return self.args[0].is_affine()
@@ -88,7 +90,7 @@ class huber(Elementwise):
         """
         return [self.M]
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that M >= 0 and is constant.
         """
         if not (self.M.is_nonneg() and

--- a/cvxpy/atoms/elementwise/kl_div.py
+++ b/cvxpy/atoms/elementwise/kl_div.py
@@ -18,6 +18,7 @@ from __future__ import division
 from cvxpy.atoms.elementwise.elementwise import Elementwise
 import numpy as np
 from scipy.special import xlogy
+from typing import Any, List, Tuple
 
 
 class kl_div(Elementwise):
@@ -25,7 +26,7 @@ class kl_div(Elementwise):
 
     """
 
-    def __init__(self, x, y):
+    def __init__(self, x, y) -> None:
         super(kl_div, self).__init__(x, y)
 
     @Elementwise.numpy_numeric
@@ -35,33 +36,33 @@ class kl_div(Elementwise):
         # TODO return inf outside the domain
         return xlogy(x, x/y) - x + y
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def _grad(self, values):
+    def _grad(self, values) -> List[Any]:
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
         Matrix expressions are vectorized, so the gradient is a matrix.

--- a/cvxpy/atoms/elementwise/log.py
+++ b/cvxpy/atoms/elementwise/log.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Tuple
+
 import numpy as np
 
 
@@ -22,7 +24,7 @@ class log(Elementwise):
     """Elementwise :math:`\\log x`.
     """
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(log, self).__init__(x)
 
     @Elementwise.numpy_numeric
@@ -31,38 +33,38 @@ class log(Elementwise):
         """
         return np.log(values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always unknown.
         return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/elementwise/log1p.py
+++ b/cvxpy/atoms/elementwise/log1p.py
@@ -23,7 +23,7 @@ class log1p(log):
     """Elementwise :math:`\\log (1 + x)`.
     """
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(log1p, self).__init__(x)
 
     @log.numpy_numeric

--- a/cvxpy/atoms/elementwise/logistic.py
+++ b/cvxpy/atoms/elementwise/logistic.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Tuple
+
 import numpy as np
 
 
@@ -25,7 +27,7 @@ class logistic(Elementwise):
     than to a scalar which is useful for logistic regression.
     """
 
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(logistic, self).__init__(x)
 
     @Elementwise.numpy_numeric
@@ -34,28 +36,28 @@ class logistic(Elementwise):
         """
         return np.logaddexp(0, values[0])
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/elementwise/maximum.py
+++ b/cvxpy/atoms/elementwise/maximum.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 import sys
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Any, List, Tuple
+
 import numpy as np
 if sys.version_info >= (3, 0):
     from functools import reduce
@@ -25,7 +27,7 @@ class maximum(Elementwise):
     """Elementwise maximum of a sequence of expressions.
     """
 
-    def __init__(self, arg1, arg2, *args):
+    def __init__(self, arg1, arg2, *args) -> None:
         """Requires at least 2 arguments.
         """
         super(maximum, self).__init__(arg1, arg2, *args)
@@ -36,7 +38,7 @@ class maximum(Elementwise):
         """
         return reduce(np.maximum, values)
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Reduces the list of argument signs according to the following rules:
@@ -50,42 +52,42 @@ class maximum(Elementwise):
         is_neg = all(arg.is_nonpos() for arg in self.args)
         return (is_pos, is_neg)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return all(arg.is_pwl() for arg in self.args)
 
-    def _grad(self, values):
+    def _grad(self, values) -> List[Any]:
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
         Matrix expressions are vectorized, so the gradient is a matrix.

--- a/cvxpy/atoms/elementwise/minimum.py
+++ b/cvxpy/atoms/elementwise/minimum.py
@@ -15,6 +15,8 @@ limitations under the License.
 
 import sys
 from cvxpy.atoms.elementwise.elementwise import Elementwise
+from typing import Any, List, Tuple
+
 import numpy as np
 if sys.version_info >= (3, 0):
     from functools import reduce
@@ -24,7 +26,7 @@ class minimum(Elementwise):
     """Elementwise minimum of a sequence of expressions.
     """
 
-    def __init__(self, arg1, arg2, *args):
+    def __init__(self, arg1, arg2, *args) -> None:
         """Requires at least 2 arguments.
         """
         super(minimum, self).__init__(arg1, arg2, *args)
@@ -35,49 +37,49 @@ class minimum(Elementwise):
         """
         return reduce(np.minimum, values)
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         is_pos = all(arg.is_nonneg() for arg in self.args)
         is_neg = any(arg.is_nonpos() for arg in self.args)
         return (is_pos, is_neg)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return all(arg.is_pwl() for arg in self.args)
 
-    def _grad(self, values):
+    def _grad(self, values) -> List[Any]:
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
         Matrix expressions are vectorized, so the gradient is a matrix.

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -22,7 +22,7 @@ import numpy as np
 import scipy.sparse as sp
 
 
-def _is_const(p):
+def _is_const(p) -> bool:
     return isinstance(p, cvxtypes.constant())
 
 
@@ -121,7 +121,7 @@ class power(Elementwise):
         of ``p``; only relevant when solving as a DCP program.
     """
 
-    def __init__(self, x, p, max_denom=1024):
+    def __init__(self, x, p, max_denom: int=1024) -> None:
         self._p_orig = p
         # NB: It is important that the exponent is an attribute, not
         # an argument. This prevents parametrized exponents from being replaced
@@ -182,7 +182,7 @@ class power(Elementwise):
             # Always positive.
             return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         # Parametrized powers are not allowed for DCP (curvature analysis
@@ -191,7 +191,7 @@ class power(Elementwise):
         # p == 0 is affine here.
         return _is_const(self.p) and (self.p.value <= 0 or self.p.value >= 1)
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         # Parametrized powers are not allowed for DCP.
@@ -217,7 +217,7 @@ class power(Elementwise):
         # So, as a workaround, we overload the parameters method.
         return self.args[0].parameters() + self.p.parameters()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         if u.scopes.dpp_scope_active():
@@ -239,17 +239,17 @@ class power(Elementwise):
         else:
             return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return self.is_atom_log_log_convex()
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         """Is the expression constant?
         """
         return (_is_const(self.p) and self.p.value == 0) or super(power, self).is_constant()
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         if not _is_const(self.p):
@@ -266,7 +266,7 @@ class power(Elementwise):
         else:
             return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         if not _is_const(self.p):
@@ -283,7 +283,7 @@ class power(Elementwise):
         else:
             return False
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         if not _is_const(self.p):
             return False
 
@@ -297,7 +297,7 @@ class power(Elementwise):
         else:
             return self.args[0].is_constant()
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         if not _is_const(self.p):
             # disallow parameters
             return False
@@ -368,7 +368,7 @@ class power(Elementwise):
     def get_data(self):
         return [self._p_orig, self.max_denom]
 
-    def copy(self, args=None, id_objects={}):
+    def copy(self, args=None, id_objects={}) -> "power":
         """Returns a shallow copy of the power atom.
 
         Parameters
@@ -385,7 +385,7 @@ class power(Elementwise):
             args = self.args
         return power(args[0], self._p_orig, self.max_denom)
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s, %s)" % (self.__class__.__name__,
                                self.args[0].name(),
                                self.p.value)

--- a/cvxpy/atoms/eye_minus_inv.py
+++ b/cvxpy/atoms/eye_minus_inv.py
@@ -15,10 +15,12 @@ limitations under the License.
 """
 
 from cvxpy.atoms.atom import Atom
+from typing import Tuple
+
 import numpy as np
 
 
-def resolvent(X, s):
+def resolvent(X, s: float):
     r"""The resolvent of a positive matrix, :math:`(sI - X)^{-1}`.
 
     For an elementwise positive matrix :math:`X` and a positive scalar
@@ -62,7 +64,7 @@ class eye_minus_inv(Atom):
     X : cvxpy.Expression
         A positive square matrix.
     """
-    def __init__(self, X):
+    def __init__(self, X) -> None:
         super(eye_minus_inv, self).__init__(X)
         if len(X.shape) != 2 or X.shape[0] != X.shape[1]:
             raise ValueError("The argument to `eye_minus_inv` must be a "
@@ -72,7 +74,7 @@ class eye_minus_inv(Atom):
     def numeric(self, values):
         return np.linalg.inv(np.eye(self.args[0].shape[0]) - values[0])
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 
     def shape_from_args(self):
@@ -80,41 +82,41 @@ class eye_minus_inv(Atom):
         """
         return self.args[0].shape
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
     # TODO(akshayka): Figure out monotonicity.
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def _grad(self, values):
+    def _grad(self, values) -> None:
         return None

--- a/cvxpy/atoms/gen_lambda_max.py
+++ b/cvxpy/atoms/gen_lambda_max.py
@@ -16,13 +16,14 @@ limitations under the License.
 
 from cvxpy.atoms.atom import Atom
 from scipy import linalg as LA
+from typing import Tuple
 
 
 class gen_lambda_max(Atom):
     """ Maximum generalized eigenvalue; :math:`\\lambda_{\\max}(A, B)`.
     """
 
-    def __init__(self, A, B):
+    def __init__(self, A, B) -> None:
         super(gen_lambda_max, self).__init__(A, B)
 
     def numeric(self, values):
@@ -54,7 +55,7 @@ class gen_lambda_max(Atom):
         """
         raise NotImplementedError()
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Verify that the argument A, B are square and of the same dimension.
         """
         if (not self.args[0].ndim == 2 or
@@ -71,37 +72,37 @@ class gen_lambda_max(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconcave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy.sparse as sp
 from cvxpy.utilities.power_tools import (fracify, decompose, approx_error, lower_bound,
                                          over_bound, prettydict)
+from typing import List, Optional, Tuple
 
 
 class geo_mean(Atom):
@@ -165,7 +166,7 @@ class geo_mean(Atom):
         :math:`\\|p/\\mathbf{1}^T p - w \\|_\\infty`
     """
 
-    def __init__(self, x, p=None, max_denom=1024):
+    def __init__(self, x, p: Optional[List[int]]=None, max_denom: int=1024) -> None:
         """ Implementation details of geo_mean.
 
         Attributes
@@ -228,7 +229,7 @@ class geo_mean(Atom):
         self.cone_num = self.cone_lb + self.cone_num_over
 
     # Returns the (weighted) geometric mean of the elements of x.
-    def numeric(self, values):
+    def numeric(self, values) -> float:
         values = np.array(values[0]).flatten()
         val = 1.0
         for x, p in zip(values, self.w):
@@ -263,12 +264,12 @@ class geo_mean(Atom):
             D = w_arr/x.ravel(order='F')*self.numeric(values)
             return [sp.csc_matrix(D).T]
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s, (%s))" % (self.__class__.__name__,
                                  self.args[0].name(),
                                  ', '.join(str(v) for v in self.w))
 
-    def pretty_tree(self):
+    def pretty_tree(self) -> None:
         print(prettydict(self.tree))
 
     def shape_from_args(self):
@@ -276,38 +277,38 @@ class geo_mean(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/gmatmul.py
+++ b/cvxpy/atoms/gmatmul.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions import cvxtypes
+from typing import Tuple
+
 import cvxpy.utilities as u
 import numpy as np
 
@@ -43,7 +45,7 @@ class gmatmul(Atom):
     X : cvxpy.Expression
         A positive matrix.
     """
-    def __init__(self, A, X):
+    def __init__(self, A, X) -> None:
         # NB: It is important that the exponent is an attribute, not
         # an argument. This prevents parametrized exponents from being replaced
         # with their logs in Dgp2Dcp.
@@ -56,12 +58,12 @@ class gmatmul(Atom):
         logX = np.log(values[0])
         return np.exp(self.A.value @ logX)
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s, %s)" % (self.__class__.__name__,
                                self.A,
                                self.args[0])
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Raises an error if the arguments are invalid.
         """
         super(gmatmul, self).validate_arguments()
@@ -88,17 +90,17 @@ class gmatmul(Atom):
         """
         return [self.A]
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
@@ -107,7 +109,7 @@ class gmatmul(Atom):
         # The exponent matrix, which is not an argument, may be parametrized.
         return self.args[0].parameters() + self.A.parameters()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         if u.scopes.dpp_scope_active():
@@ -129,20 +131,20 @@ class gmatmul(Atom):
         else:
             return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return self.is_atom_log_log_convex()
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.A.is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.A.is_nonpos()
 
-    def _grad(self, values):
+    def _grad(self, values) -> None:
         return None

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms.atom import Atom
 from scipy import linalg as LA
+from typing import Tuple
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -24,7 +26,7 @@ class lambda_max(Atom):
     """ Maximum eigenvalue; :math:`\\lambda_{\\max}(A)`.
     """
 
-    def __init__(self, A):
+    def __init__(self, A) -> None:
         super(lambda_max, self).__init__(A)
 
     def numeric(self, values):
@@ -58,7 +60,7 @@ class lambda_max(Atom):
         D = v.dot(d).dot(v.T)
         return [sp.csc_matrix(D.ravel(order='F')).T]
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Verify that the argument A is square.
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
@@ -70,27 +72,27 @@ class lambda_max(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -25,11 +25,11 @@ class lambda_sum_largest(lambda_max):
     """
     _allow_complex = True
 
-    def __init__(self, X, k):
+    def __init__(self, X, k) -> None:
         self.k = k
         super(lambda_sum_largest, self).__init__(X)
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Verify that the argument A is square.
         """
         X = self.args[0]

--- a/cvxpy/atoms/length.py
+++ b/cvxpy/atoms/length.py
@@ -14,20 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from cvxpy.atoms.atom import Atom
+from typing import Tuple
+
 import numpy as np
 
 
 class length(Atom):
     """Length of a vector (index of last nonzero, ones-based).
     """
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(length, self).__init__(x)
         if not self.args[0].is_vector():
             raise ValueError(
                 "`length` can only be applied to vectors.")
 
     @Atom.numpy_numeric
-    def numeric(self, values):
+    def numeric(self, values) -> int:
         """Returns the length of x.
         """
         return np.max(np.nonzero(values[0])) + 1
@@ -37,41 +39,41 @@ class length(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always nonnegative.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconvex?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def _grad(self, values):
+    def _grad(self, values) -> None:
         return None

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from cvxpy.constraints.constraint import Constraint
 from cvxpy.atoms.atom import Atom
 import numpy as np
 from numpy import linalg as LA
+from typing import List, Tuple
+
 import scipy.sparse as sp
 
 
@@ -25,7 +28,7 @@ class log_det(Atom):
 
     """
 
-    def __init__(self, A):
+    def __init__(self, A) -> None:
         super(log_det, self).__init__(A)
 
     def numeric(self, values):
@@ -41,7 +44,7 @@ class log_det(Atom):
             return -np.inf
 
     # Any argument shape is valid.
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         X = self.args[0]
         if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to log_det must be a square matrix.")
@@ -51,27 +54,27 @@ class log_det(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
@@ -97,7 +100,7 @@ class log_det(Atom):
         else:
             return [None]
 
-    def _domain(self):
+    def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.
         """
         return [self.args[0] >> 0]

--- a/cvxpy/atoms/log_sum_exp.py
+++ b/cvxpy/atoms/log_sum_exp.py
@@ -18,6 +18,7 @@ from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
 import numpy as np
 from scipy.special import logsumexp
+from typing import Tuple
 
 
 class log_sum_exp(AxisAtom):
@@ -25,7 +26,7 @@ class log_sum_exp(AxisAtom):
 
     """
 
-    def __init__(self, x, axis=None, keepdims=False):
+    def __init__(self, x, axis=None, keepdims: bool=False) -> None:
         super(log_sum_exp, self).__init__(x, axis=axis, keepdims=keepdims)
 
     @Atom.numpy_numeric
@@ -63,27 +64,27 @@ class log_sum_exp(AxisAtom):
         D = nom/denom
         return D
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/matrix_frac.py
+++ b/cvxpy/atoms/matrix_frac.py
@@ -16,17 +16,19 @@ limitations under the License.
 
 from functools import wraps
 from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
 from numpy import linalg as LA
 import numpy as np
 import scipy.sparse as sp
 from cvxpy.atoms.quad_form import QuadForm
+from typing import List, Tuple
 
 
 class MatrixFrac(Atom):
     """ tr X.T*P^-1*X """
     _allow_complex = True
 
-    def __init__(self, X, P):
+    def __init__(self, X, P) -> None:
         super(MatrixFrac, self).__init__(X, P)
 
     def numeric(self, values):
@@ -41,7 +43,7 @@ class MatrixFrac(Atom):
             product = X.T.dot(LA.inv(P)).dot(X)
         return product.trace() if len(product.shape) == 2 else product
 
-    def _domain(self):
+    def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.
         """
         return [self.args[1] >> 0]
@@ -80,7 +82,7 @@ class MatrixFrac(Atom):
             DP = sp.csc_matrix(DP.T.ravel(order='F')).T
             return [DX, DP]
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Checks that the dimensions of x and P match.
         """
         X = self.args[0]
@@ -99,37 +101,37 @@ class MatrixFrac(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Quadratic if x is affine and P is constant.
         """
         return self.args[0].is_affine() and self.args[1].is_constant()
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         """Quadratic of piecewise affine if x is PWL and P is constant.
         """
         return self.args[0].is_pwl() and self.args[1].is_constant()

--- a/cvxpy/atoms/max.py
+++ b/cvxpy/atoms/max.py
@@ -23,7 +23,7 @@ class max(AxisAtom):
     """:math:`\\max_{i,j}\\{X_{i,j}\\}`.
     """
 
-    def __init__(self, x, axis=None, keepdims=False):
+    def __init__(self, x, axis=None, keepdims: bool=False) -> None:
         super(max, self).__init__(x, axis=axis, keepdims=keepdims)
 
     @Atom.numpy_numeric
@@ -69,37 +69,37 @@ class max(AxisAtom):
         # Same as argument.
         return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return self.args[0].is_pwl()

--- a/cvxpy/atoms/min.py
+++ b/cvxpy/atoms/min.py
@@ -23,7 +23,7 @@ class min(AxisAtom):
     """:math:`\\min{i,j}\\{X_{i,j}\\}`.
     """
 
-    def __init__(self, x, axis=None, keepdims=False):
+    def __init__(self, x, axis=None, keepdims: bool=False) -> None:
         super(min, self).__init__(x, axis=axis, keepdims=keepdims)
 
     @Atom.numpy_numeric
@@ -69,37 +69,37 @@ class min(AxisAtom):
         # Same as argument.
         return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return True
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return self.args[0].is_pwl()

--- a/cvxpy/atoms/norm1.py
+++ b/cvxpy/atoms/norm1.py
@@ -18,6 +18,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from cvxpy.atoms.axis_atom import AxisAtom
+from typing import Tuple
 
 
 class norm1(AxisAtom):
@@ -32,33 +33,33 @@ class norm1(AxisAtom):
             values = np.array(values[0])
         return np.linalg.norm(values, 1, axis=self.axis, keepdims=self.keepdims)
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[0].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[0].is_nonpos()
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return self.args[0].is_pwl() and \
@@ -67,7 +68,7 @@ class norm1(AxisAtom):
     def get_data(self):
         return [self.axis]
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__,
                            self.args[0].name())
 

--- a/cvxpy/atoms/norm_inf.py
+++ b/cvxpy/atoms/norm_inf.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.axis_atom import AxisAtom
+from typing import Tuple
+
 import numpy as np
 
 
@@ -30,43 +32,43 @@ class norm_inf(AxisAtom):
             values = np.array(values[0])
         return np.linalg.norm(values, np.inf, axis=self.axis, keepdims=self.keepdims)
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[0].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.args[0].is_nonpos()
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return self.args[0].is_pwl()
@@ -74,7 +76,7 @@ class norm_inf(AxisAtom):
     def get_data(self):
         return [self.axis]
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__,
                            self.args[0].name())
 

--- a/cvxpy/atoms/norm_nuc.py
+++ b/cvxpy/atoms/norm_nuc.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.atom import Atom
+from typing import Tuple
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -24,7 +26,7 @@ class normNuc(Atom):
     """
     _allow_complex = True
 
-    def __init__(self, A):
+    def __init__(self, A) -> None:
         super(normNuc, self).__init__(A)
 
     def numeric(self, values):
@@ -53,27 +55,27 @@ class normNuc(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/one_minus_pos.py
+++ b/cvxpy/atoms/one_minus_pos.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.affine.binary_operators import multiply
+from typing import Tuple
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -45,7 +47,7 @@ class one_minus_pos(Atom):
     x : :class:`~cvxpy.expressions.expression.Expression`
         An Expression.
     """
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(one_minus_pos, self).__init__(x)
         self.args[0] = x
         self._ones = np.ones(self.args[0].shape)
@@ -57,7 +59,7 @@ class one_minus_pos(Atom):
         del values
         return sp.csc_matrix(-1.0 * self._ones)
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 
     def shape_from_args(self):
@@ -65,37 +67,37 @@ class one_minus_pos(Atom):
         """
         return self.args[0].shape
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return True

--- a/cvxpy/atoms/pf_eigenvalue.py
+++ b/cvxpy/atoms/pf_eigenvalue.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.atom import Atom
+from typing import Tuple
+
 import numpy as np
 
 
@@ -33,7 +35,7 @@ class pf_eigenvalue(Atom):
     X : cvxpy.Expression
         A positive square matrix.
     """
-    def __init__(self, X):
+    def __init__(self, X) -> None:
         super(pf_eigenvalue, self).__init__(X)
         if len(X.shape) != 2 or X.shape[0] != X.shape[1]:
             raise ValueError("Argument to `spectral radius` must be a "
@@ -43,7 +45,7 @@ class pf_eigenvalue(Atom):
     def numeric(self, values):
         return np.max(np.abs(np.linalg.eig(values[0])[0]))
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 
     def shape_from_args(self):
@@ -51,40 +53,40 @@ class pf_eigenvalue(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def _grad(self, values):
+    def _grad(self, values) -> None:
         return None

--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -20,6 +20,7 @@ from cvxpy.atoms.norm_inf import norm_inf
 import numpy as np
 import scipy.sparse as sp
 from cvxpy.utilities.power_tools import pow_high, pow_mid, pow_neg
+from typing import Tuple
 
 
 def pnorm(x, p=2, axis=None, keepdims=False, max_denom=1024):
@@ -115,7 +116,7 @@ class Pnorm(AxisAtom):
     """
     _allow_complex = True
 
-    def __init__(self, x, p=2, axis=None, keepdims=False, max_denom=1024):
+    def __init__(self, x, p: int=2, axis=None, keepdims: bool=False, max_denom: int=1024) -> None:
         if p < 0:
             # TODO(akshayka): Why do we accept p < 0?
             self.p, _ = pow_neg(p, max_denom)
@@ -151,7 +152,7 @@ class Pnorm(AxisAtom):
         return np.linalg.norm(values, float(self.p), axis=self.axis,
                               keepdims=self.keepdims)
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         super(Pnorm, self).validate_arguments()
         # TODO(akshayka): Why is axis not supported for other norms?
         if self.axis is not None and self.p != 2:
@@ -160,43 +161,43 @@ class Pnorm(AxisAtom):
         if self.p < 1 and self.args[0].is_complex():
             raise ValueError("pnorm(x, p) cannot have x complex for p < 1.")
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return self.p > 1
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return self.p < 1
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.p < 1 or (self.p > 1 and self.args[0].is_nonneg())
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return self.p > 1 and self.args[0].is_nonpos()
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return False
@@ -204,7 +205,7 @@ class Pnorm(AxisAtom):
     def get_data(self):
         return [self.p, self.axis]
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s, %s)" % (self.__class__.__name__,
                                self.args[0].name(),
                                self.p)

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.axis_atom import AxisAtom
+from typing import Tuple
+
 import cvxpy.interface as intf
 import numpy as np
 
@@ -37,42 +39,42 @@ class Prod(AxisAtom):
         Whether to drop dimensions after summing.
     """
 
-    def __init__(self, expr, axis=None, keepdims=False):
+    def __init__(self, expr, axis=None, keepdims: bool=False) -> None:
         super(Prod, self).__init__(expr, axis=axis, keepdims=keepdims)
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         if self.args[0].is_nonneg():
             return (True, False)
         return (False, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return self.args[0].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
@@ -115,7 +117,7 @@ class Prod(AxisAtom):
         return self._axis_grad(values)
 
 
-def prod(expr, axis=None, keepdims=False):
+def prod(expr, axis=None, keepdims: bool=False) -> Prod:
     """Multiply the entries of an expression.
 
     The semantics of this atom are the same as np.prod.

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -24,6 +24,7 @@ from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.expression import Expression
 from cvxpy.interface.matrix_utilities import is_sparse
 import scipy.sparse as sp
+from typing import Tuple
 
 
 class CvxPyDomainError(Exception):
@@ -33,7 +34,7 @@ class CvxPyDomainError(Exception):
 class QuadForm(Atom):
     _allow_complex = True
 
-    def __init__(self, x, P):
+    def __init__(self, x, P) -> None:
         super(QuadForm, self).__init__(x, P)
 
     def numeric(self, values):
@@ -44,7 +45,7 @@ class QuadForm(Atom):
             quad = np.dot(np.transpose(values[0]), prod)
         return np.real(quad)
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         super(QuadForm, self).validate_arguments()
         n = self.args[1].shape[0]
         if self.args[1].shape[1] != n or self.args[0].shape not in [(n, 1), (n,)]:
@@ -52,56 +53,56 @@ class QuadForm(Atom):
         if not self.args[1].is_hermitian():
             raise ValueError("P must be symmetric/Hermitian.")
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         return (self.is_atom_convex(), self.is_atom_concave())
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         P = self.args[1]
         return P.is_constant() and P.is_psd()
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         P = self.args[1]
         return P.is_constant() and P.is_nsd()
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return (self.args[0].is_nonneg() and self.args[1].is_nonneg()) or \
                (self.args[0].is_nonpos() and self.args[1].is_nonneg())
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return (self.args[0].is_nonneg() and self.args[1].is_nonpos()) or \
                (self.args[0].is_nonpos() and self.args[1].is_nonpos())
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Is the atom quadratic?
         """
         return True
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the atom piecewise linear?
         """
         return False
 
-    def name(self):
+    def name(self) -> str:
         return "%s(%s, %s)" % (self.__class__.__name__,
                                self.args[0],
                                self.args[1])
@@ -120,7 +121,7 @@ class SymbolicQuadForm(Atom):
     """
     Symbolic form of QuadForm when quadratic matrix is not known (yet).
     """
-    def __init__(self, x, P, expr):
+    def __init__(self, x, P, expr) -> None:
         self.original_expression = expr
         super(SymbolicQuadForm, self).__init__(x, P)
         self.P = self.args[1]
@@ -131,16 +132,16 @@ class SymbolicQuadForm(Atom):
     def _grad(self, values):
         raise NotImplementedError()
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         return self.original_expression.is_atom_concave()
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         return self.original_expression.is_atom_convex()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         return self.original_expression.is_decr(idx)
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         return self.original_expression.is_incr(idx)
 
     def shape_from_args(self):
@@ -149,7 +150,7 @@ class SymbolicQuadForm(Atom):
     def sign_from_args(self):
         return self.original_expression.sign_from_args()
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         return True
 
 

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.atom import Atom
+from typing import Tuple
+
 import numpy as np
 import scipy.sparse as sp
 import scipy as scipy
@@ -26,7 +28,7 @@ class quad_over_lin(Atom):
     """
     _allow_complex = True
 
-    def __init__(self, x, y):
+    def __init__(self, x, y) -> None:
         super(quad_over_lin, self).__init__(x, y)
 
     @Atom.numpy_numeric
@@ -76,43 +78,43 @@ class quad_over_lin(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
         return True
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return (idx == 0) and self.args[idx].is_nonneg()
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return ((idx == 0) and self.args[idx].is_nonpos()) or (idx == 1)
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Check dimensions of arguments.
         """
         if not self.args[1].is_scalar():
@@ -121,12 +123,12 @@ class quad_over_lin(Atom):
             raise ValueError("The second argument to quad_over_lin cannot be complex.")
         super(quad_over_lin, self).validate_arguments()
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Quadratic if x is affine and y is constant.
         """
         return self.args[0].is_affine() and self.args[1].is_constant()
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         """Quadratic of piecewise affine if x is PWL and y is constant.
         """
         return self.args[0].is_pwl() and self.args[1].is_constant()

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -17,6 +17,8 @@ limitations under the License.
 from cvxpy.atoms.atom import Atom
 import scipy.sparse as sp
 from numpy import linalg as LA
+from typing import Tuple
+
 import numpy as np
 
 
@@ -24,7 +26,7 @@ class sigma_max(Atom):
     """ Maximum singular value. """
     _allow_complex = True
 
-    def __init__(self, A):
+    def __init__(self, A) -> None:
         super(sigma_max, self).__init__(A)
 
     @Atom.numpy_numeric
@@ -56,28 +58,28 @@ class sigma_max(Atom):
         """
         return tuple()
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
         # Always positive.
         return (True, False)
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/sign.py
+++ b/cvxpy/atoms/sign.py
@@ -19,7 +19,7 @@ from cvxpy.atoms.atom import Atom
 class sign(Atom):
     """Sign of an expression (-1 for x <= 0, +1 for x > 0).
     """
-    def __init__(self, x):
+    def __init__(self, x) -> None:
         super(sign, self).__init__(x)
 
     @Atom.numpy_numeric
@@ -41,35 +41,35 @@ class sign(Atom):
         """
         return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return False
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconvex?
         """
         return True
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False
 
-    def _grad(self, values):
+    def _grad(self, values) -> None:
         return None

--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -24,11 +24,11 @@ class sum_largest(Atom):
     """Sum of the largest k values in the matrix X.
     """
 
-    def __init__(self, x, k):
+    def __init__(self, x, k) -> None:
         self.k = k
         super(sum_largest, self).__init__(x)
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         """Verify that k is a positive integer.
         """
         if int(self.k) != self.k or self.k <= 0:
@@ -71,22 +71,22 @@ class sum_largest(Atom):
         # Same as argument.
         return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
         return True
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
         return False

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -1,13 +1,15 @@
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.variable import Variable
+from typing import Tuple
+
 import scipy.sparse as sp
 import numpy as np
 
 
 class SuppFuncAtom(Atom):
 
-    def __init__(self, y, parent):
+    def __init__(self, y, parent) -> None:
         """
         Parameters
         ----------
@@ -24,7 +26,7 @@ class SuppFuncAtom(Atom):
         self._shape = tuple()
         self.validate_arguments()
 
-    def validate_arguments(self):
+    def validate_arguments(self) -> None:
         if self.args[0].is_complex():
             raise ValueError("Arguments to SuppFuncAtom cannot be complex.")
         if not self.args[0].is_affine():
@@ -43,63 +45,63 @@ class SuppFuncAtom(Atom):
     def shape_from_args(self):
         return self._shape
 
-    def sign_from_args(self):
+    def sign_from_args(self) -> Tuple[bool, bool]:
         return (False, False)
 
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         return False
 
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         return False
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         return False
 
-    def is_atom_convex(self):
+    def is_atom_convex(self) -> bool:
         return True
 
-    def is_atom_concave(self):
+    def is_atom_concave(self) -> bool:
         return False
 
-    def is_atom_log_log_convex(self):
+    def is_atom_log_log_convex(self) -> bool:
         return False
 
-    def is_atom_log_log_concave(self):
+    def is_atom_log_log_concave(self) -> bool:
         return False
 
-    def is_atom_quasiconvex(self):
+    def is_atom_quasiconvex(self) -> bool:
         return True
 
-    def is_atom_quasiconcave(self):
+    def is_atom_quasiconcave(self) -> bool:
         return False
 
-    def is_incr(self, idx):
+    def is_incr(self, idx) -> bool:
         return False
 
-    def is_decr(self, idx):
+    def is_decr(self, idx) -> bool:
         return False
 
-    def is_convex(self):
+    def is_convex(self) -> bool:
         # The argument "y" is restricted to being affine.
         return True
 
-    def is_concave(self):
+    def is_concave(self) -> bool:
         return False
 
-    def is_log_log_convex(self):
+    def is_log_log_convex(self) -> bool:
         return False
 
-    def is_log_log_concave(self):
+    def is_log_log_concave(self) -> bool:
         return False
 
-    def is_quasiconvex(self):
+    def is_quasiconvex(self) -> bool:
         # The argument "y" is restricted to being affine.
         return True
 
-    def is_quasiconcave(self):
+    def is_quasiconcave(self) -> bool:
         return False
 
     def _value_impl(self):

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -38,7 +38,7 @@ class Constraint(u.Canonical):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, args, constr_id=None):
+    def __init__(self, args, constr_id=None) -> None:
         # TODO cast constants.
         # self.args = [cvxtypes.expression().cast_to_const(arg) for arg in args]
         self.args = args
@@ -54,13 +54,13 @@ class Constraint(u.Canonical):
         """
         return self.name()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string with information about the constraint.
         """
         return "%s(%s)" % (self.__class__.__name__,
                            repr(self.args[0]))
 
-    def _construct_dual_variables(self, args):
+    def _construct_dual_variables(self, args) -> None:
         self.dual_variables = [cvxtypes.variable()(arg.shape) for arg in args]
 
     @property
@@ -73,23 +73,23 @@ class Constraint(u.Canonical):
         """int : The size of the constrained expression."""
         return self.args[0].size
 
-    def is_real(self):
+    def is_real(self) -> bool:
         """Is the Leaf real valued?
         """
         return not self.is_complex()
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
         return all(arg.is_imag() for arg in self.args)
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the Leaf complex valued?
         """
         return any(arg.is_complex() for arg in self.args)
 
     @abc.abstractmethod
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """Checks whether the constraint is DCP.
 
         Returns
@@ -100,7 +100,7 @@ class Constraint(u.Canonical):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp=False) -> bool:
         """Checks whether the constraint is DGP.
 
         Returns
@@ -110,7 +110,7 @@ class Constraint(u.Canonical):
         """
         raise NotImplementedError()
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         if context.lower() == 'dcp':
             return self.is_dcp(dpp=True)
         elif context.lower() == 'dgp':
@@ -238,7 +238,7 @@ class Constraint(u.Canonical):
         else:
             return dual_vals
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         """Save the value of the dual variable for the constraint's parent.
         Args:
             value: The value of the dual variable.

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -18,6 +18,8 @@ limitations under the License.
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
+from typing import List, Tuple
+
 import numpy as np
 
 
@@ -50,7 +52,7 @@ class ExpCone(Constraint):
         z in the exponential cone.
     """
 
-    def __init__(self, x, y, z, constr_id=None):
+    def __init__(self, x, y, z, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         self.x = Expression.cast_to_const(x)
         self.y = Expression.cast_to_const(y)
@@ -58,10 +60,10 @@ class ExpCone(Constraint):
         super(ExpCone, self).__init__([self.x, self.y, self.z],
                                       constr_id)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "ExpCone(%s, %s, %s)" % (self.x, self.y, self.z)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "ExpCone(%s, %s, %s)" % (self.x, self.y, self.z)
 
     @property
@@ -80,7 +82,7 @@ class ExpCone(Constraint):
         return problem.solve()
 
     @property
-    def size(self):
+    def size(self) -> int:
         """The number of entries in the combined cones.
         """
         return 3 * self.num_cones()
@@ -90,7 +92,7 @@ class ExpCone(Constraint):
         """
         return self.x.size
 
-    def cone_sizes(self):
+    def cone_sizes(self) -> List[int]:
         """The dimensions of the exponential cones.
 
         Returns
@@ -100,7 +102,7 @@ class ExpCone(Constraint):
         """
         return [3]*self.num_cones()
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp: bool=False) -> bool:
         """An exponential constraint is DCP if each argument is affine.
         """
         if dpp:
@@ -108,18 +110,18 @@ class ExpCone(Constraint):
                 return all(arg.is_affine() for arg in self.args)
         return all(arg.is_affine() for arg in self.args)
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
     @property
-    def shape(self):
+    def shape(self) -> Tuple[int, ...]:
         s = (3,) + self.x.shape
         return s
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         # TODO(akshaya,SteveDiamond): verify that reshaping below works correctly
         value = np.reshape(value, newshape=(-1, 3))
         dv0 = np.reshape(value[:, 0], newshape=self.x.shape)

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -38,23 +38,23 @@ class NonPos(Constraint):
     constr_id : int
         A unique id for the constraint.
     """
-    def __init__(self, expr, constr_id=None):
+    def __init__(self, expr, constr_id=None) -> None:
         super(NonPos, self).__init__([expr], constr_id)
 
-    def name(self):
+    def name(self) -> str:
         return "%s <= 0" % self.args[0]
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """A non-positive constraint is DCP if its argument is convex."""
         if dpp:
             with scopes.dpp_scope():
                 return self.args[0].is_convex()
         return self.args[0].is_convex()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.args[0].is_quasiconvex()
 
     @property
@@ -97,23 +97,23 @@ class NonNeg(Constraint):
     constr_id : int
         A unique id for the constraint.
     """
-    def __init__(self, expr, constr_id=None):
+    def __init__(self, expr, constr_id=None) -> None:
         super(NonNeg, self).__init__([expr], constr_id)
 
-    def name(self):
+    def name(self) -> str:
         return "0 <= %s" % self.args[0]
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """A non-negative constraint is DCP if its argument is concave."""
         if dpp:
             with scopes.dpp_scope():
                 return self.args[0].is_concave()
         return self.args[0].is_concave()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.args[0].is_quasiconcave()
 
     @property
@@ -149,21 +149,21 @@ class Inequality(Constraint):
     constr_id : int
         A unique id for the constraint.
     """
-    def __init__(self, lhs, rhs, constr_id=None):
+    def __init__(self, lhs, rhs, constr_id=None) -> None:
         self._expr = lhs - rhs
         # TODO remove this restriction.
         if self._expr.is_complex():
             raise ValueError("Inequality constraints cannot be complex.")
         super(Inequality, self).__init__([lhs, rhs], constr_id)
 
-    def _construct_dual_variables(self, args):
+    def _construct_dual_variables(self, args) -> None:
         super(Inequality, self)._construct_dual_variables([self._expr])
 
     @property
     def expr(self):
         return self._expr
 
-    def name(self):
+    def name(self) -> str:
         return "%s <= %s" % (self.args[0], self.args[1])
 
     @property
@@ -176,14 +176,14 @@ class Inequality(Constraint):
         """int : The size of the constrained expression."""
         return self.expr.size
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """A non-positive constraint is DCP if its argument is convex."""
         if dpp:
             with scopes.dpp_scope():
                 return self.expr.is_convex()
         return self.expr.is_convex()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp=False) -> bool:
         if dpp:
             with scopes.dpp_scope():
                 return (self.args[0].is_log_log_convex() and
@@ -191,7 +191,7 @@ class Inequality(Constraint):
         return (self.args[0].is_log_log_convex() and
                 self.args[1].is_log_log_concave())
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         if context.lower() == 'dcp':
             return self.is_dcp(dpp=True)
         elif context.lower() == 'dgp':
@@ -199,7 +199,7 @@ class Inequality(Constraint):
         else:
             raise ValueError('Unsupported context ', context)
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return (
             self.is_dcp() or
             (self.args[0].is_quasiconvex() and self.args[1].is_constant()) or

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -17,6 +17,8 @@ limitations under the License.
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
+from typing import List, Tuple
+
 import numpy as np
 
 
@@ -37,7 +39,7 @@ class PowCone3D(Constraint):
     with respect to these flattened representations.
     """
 
-    def __init__(self, x, y, z, alpha, constr_id=None):
+    def __init__(self, x, y, z, alpha, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         self.x = Expression.cast_to_const(x)
         self.y = Expression.cast_to_const(y)
@@ -60,7 +62,7 @@ class PowCone3D(Constraint):
         super(PowCone3D, self).__init__([self.x, self.y, self.z],
                                         constr_id)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Pow3D(%s, %s, %s; %s)" % (self.x, self.y, self.z, self.alpha)
 
     def residual(self):
@@ -80,23 +82,23 @@ class PowCone3D(Constraint):
     def get_data(self):
         return [self.alpha]
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         return False
 
     @property
-    def size(self):
+    def size(self) -> int:
         return 3 * self.num_cones()
 
     def num_cones(self):
         return self.x.size
 
-    def cone_sizes(self):
+    def cone_sizes(self) -> List[int]:
         return [3]*self.num_cones()
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp: bool=False) -> bool:
         if dpp:
             with scopes.dpp_scope():
                 args_ok = all(arg.is_affine() for arg in self.args)
@@ -104,18 +106,18 @@ class PowCone3D(Constraint):
                 return args_ok and exps_ok
         return all(arg.is_affine() for arg in self.args)
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
     @property
-    def shape(self):
+    def shape(self) -> Tuple[int, ...]:
         s = (3,) + self.x.shape
         return s
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         value = np.reshape(value, newshape=(3, -1))
         dv0 = np.reshape(value[0, :], newshape=self.x.shape)
         dv1 = np.reshape(value[1, :], newshape=self.y.shape)
@@ -151,7 +153,7 @@ class PowConeND(Constraint):
 
     _TOL_ = 1e-6
 
-    def __init__(self, W, z, alpha, axis=0, constr_id=None):
+    def __init__(self, W, z, alpha, axis: int=0, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         W = Expression.cast_to_const(W)
         if not (W.is_real() and W.is_affine()):
@@ -188,13 +190,13 @@ class PowConeND(Constraint):
             z = z.flatten()
         super(PowConeND, self).__init__([W, z], constr_id)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "PowND(%s, %s; %s)" % (self.W, self.z, self.alpha)
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         return False
 
     def get_data(self):
@@ -218,15 +220,15 @@ class PowConeND(Constraint):
         return self.z.size
 
     @property
-    def size(self):
+    def size(self) -> int:
         cone_size = 1 + self.args[0].shape[self.axis]
         return cone_size * self.num_cones()
 
-    def cone_sizes(self):
+    def cone_sizes(self) -> List[int]:
         cone_size = 1 + self.args[0].shape[self.axis]
         return [cone_size] * self.num_cones()
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """A power cone constraint is DCP if each argument is affine.
         """
         if dpp:
@@ -236,12 +238,12 @@ class PowConeND(Constraint):
                 return args_ok and exps_ok
         return True
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         # TODO: implement
         pass

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -46,7 +46,7 @@ class PSD(Constraint):
         A unique id for the constraint.
     """
 
-    def __init__(self, expr, constr_id=None):
+    def __init__(self, expr, constr_id=None) -> None:
         # Argument must be square matrix.
         if len(expr.shape) != 2 or expr.shape[0] != expr.shape[1]:
             raise ValueError(
@@ -54,10 +54,10 @@ class PSD(Constraint):
             )
         super(PSD, self).__init__([expr], constr_id)
 
-    def name(self):
+    def name(self) -> str:
         return "%s >> 0" % self.args[0]
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """A PSD constraint is DCP if the constrained expression is affine.
         """
         if dpp:
@@ -65,10 +65,10 @@ class PSD(Constraint):
                 return self.args[0].is_affine()
         return self.args[0].is_affine()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
     @property

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -17,6 +17,8 @@ limitations under the License.
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
+from typing import List
+
 import numpy as np
 
 
@@ -32,7 +34,7 @@ class SOC(Constraint):
         axis: Slice by column 0 or row 1.
     """
 
-    def __init__(self, t, X, axis=0, constr_id=None):
+    def __init__(self, t, X, axis: int=0, constr_id=None) -> None:
         t = cvxtypes.expression().cast_to_const(t)
         if len(t.shape) >= 2 or not t.is_real():
             raise ValueError("Invalid first argument.")
@@ -49,7 +51,7 @@ class SOC(Constraint):
             t = t.flatten()
         super(SOC, self).__init__([t, X], constr_id)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "SOC(%s, %s)" % (self.args[0], self.args[1])
 
     @property
@@ -89,13 +91,13 @@ class SOC(Constraint):
         return self.args[0].size
 
     @property
-    def size(self):
+    def size(self) -> int:
         """The number of entries in the combined cones.
         """
         cone_size = 1 + self.args[1].shape[self.axis]
         return cone_size * self.num_cones()
 
-    def cone_sizes(self):
+    def cone_sizes(self) -> List[int]:
         """The dimensions of the second-order cones.
 
         Returns
@@ -106,7 +108,7 @@ class SOC(Constraint):
         cone_size = 1 + self.args[1].shape[self.axis]
         return [cone_size] * self.num_cones()
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp: bool=False) -> bool:
         """An SOC constraint is DCP if each of its arguments is affine.
         """
         if dpp:
@@ -114,13 +116,13 @@ class SOC(Constraint):
                 return all(arg.is_affine() for arg in self.args)
         return all(arg.is_affine() for arg in self.args)
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         cone_size = 1 + self.args[1].shape[self.axis]
         value = np.reshape(value, newshape=(-1, cone_size))
         t = value[:, 0]

--- a/cvxpy/constraints/zero.py
+++ b/cvxpy/constraints/zero.py
@@ -27,7 +27,7 @@ class Zero(Constraint):
     simply write ``x == 0``. The former creates a ``Zero`` constraint with
     ``x`` as its argument.
     """
-    def __init__(self, expr, constr_id=None):
+    def __init__(self, expr, constr_id=None) -> None:
         super(Zero, self).__init__([expr], constr_id)
 
     def __str__(self):
@@ -35,7 +35,7 @@ class Zero(Constraint):
         """
         return self.name()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string with information about the constraint.
         """
         return "%s(%s)" % (self.__class__.__name__,
@@ -51,20 +51,20 @@ class Zero(Constraint):
         """int : The size of the constrained expression."""
         return self.args[0].size
 
-    def name(self):
+    def name(self) -> str:
         return "%s == 0" % self.args[0]
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """A zero constraint is DCP if its argument is affine."""
         if dpp:
             with scopes.dpp_scope():
                 return self.args[0].is_affine()
         return self.args[0].is_affine()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         return False
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
     @property
@@ -86,7 +86,7 @@ class Zero(Constraint):
         """
         return self.dual_variables[0].value
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         """Save the value of the dual variable for the constraint's parent.
 
         Args:
@@ -98,7 +98,7 @@ class Zero(Constraint):
 class Equality(Constraint):
     """A constraint of the form :math:`x = y`.
     """
-    def __init__(self, lhs, rhs, constr_id=None):
+    def __init__(self, lhs, rhs, constr_id=None) -> None:
         self._expr = lhs - rhs
         super(Equality, self).__init__([lhs, rhs], constr_id)
 
@@ -107,13 +107,13 @@ class Equality(Constraint):
         """
         return self.name()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string with information about the constraint.
         """
         return "%s(%s, %s)" % (self.__class__.__name__,
                                repr(self.args[0]), repr(self.args[1]))
 
-    def _construct_dual_variables(self, args):
+    def _construct_dual_variables(self, args) -> None:
         super(Equality, self)._construct_dual_variables([self._expr])
 
     @property
@@ -130,17 +130,17 @@ class Equality(Constraint):
         """int : The size of the constrained expression."""
         return self.expr.size
 
-    def name(self):
+    def name(self) -> str:
         return "%s == %s" % (self.args[0], self.args[1])
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """An equality constraint is DCP if its argument is affine."""
         if dpp:
             with scopes.dpp_scope():
                 return self.expr.is_affine()
         return self.expr.is_affine()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp=False) -> bool:
         if dpp:
             with scopes.dpp_scope():
                 return (self.args[0].is_log_log_affine() and
@@ -148,7 +148,7 @@ class Equality(Constraint):
         return (self.args[0].is_log_log_affine() and
                 self.args[1].is_log_log_affine())
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         return self.is_dcp()
 
     @property
@@ -169,7 +169,7 @@ class Equality(Constraint):
         """
         return self.dual_variables[0].value
 
-    def save_dual_value(self, value):
+    def save_dual_value(self, value) -> None:
         """Save the value of the dual variable for the constraint's parent.
 
         Args:

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -411,7 +411,7 @@ def get_type(linPy):
         raise NotImplementedError("Type %s is not supported." % ty)
 
 
-def set_matrix_data(linC, linPy):
+def set_matrix_data(linC, linPy) -> None:
     """Calls the appropriate cvxcore function to set the matrix data field of
        our C++ linOp.
     """
@@ -425,7 +425,7 @@ def set_matrix_data(linC, linPy):
         linC.set_data_ndim(len(linPy.data.shape))
 
 
-def set_slice_data(linC, linPy):
+def set_slice_data(linC, linPy) -> None:
     """
     Loads the slice data, start, stop, and step into our C++ linOp.
     The semantics of the slice operator is treated exactly the same as in
@@ -439,7 +439,7 @@ def set_slice_data(linC, linPy):
         linC.push_back_slice_vec(slice_vec)
 
 
-def set_linC_data(linC, linPy):
+def set_linC_data(linC, linPy) -> None:
     """Sets numerical data fields in linC."""
     assert linPy.data is not None
     if isinstance(linPy.data, tuple) and isinstance(linPy.data[0], slice):
@@ -452,7 +452,7 @@ def set_linC_data(linC, linPy):
         set_matrix_data(linC, linPy)
 
 
-def make_linC_from_linPy(linPy, linPy_to_linC):
+def make_linC_from_linPy(linPy, linPy_to_linC) -> None:
     """Construct a C++ LinOp corresponding to LinPy.
 
     Children of linPy are retrieved from linPy_to_linC.
@@ -478,7 +478,7 @@ def make_linC_from_linPy(linPy, linPy_to_linC):
             set_linC_data(linC, linPy)
 
 
-def build_lin_op_tree(root_linPy, linPy_to_linC):
+def build_lin_op_tree(root_linPy, linPy_to_linC) -> None:
     """Construct C++ LinOp tree from Python LinOp tree.
 
     Constructed C++ linOps are stored in the linPy_to_linC dict,

--- a/cvxpy/cvxcore/python/cvxcore.py
+++ b/cvxpy/cvxcore/python/cvxcore.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     import __builtin__
 
-def _swig_repr(self):
+def _swig_repr(self) -> str:
     try:
         strthis = "proxy of " + self.this.__repr__()
     except __builtin__.Exception:
@@ -151,13 +151,13 @@ class LinOp(object):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
-    def __init__(self, type, shape, args):
+    def __init__(self, type, shape, args) -> None:
         _cvxcore.LinOp_swiginit(self, _cvxcore.new_LinOp(type, shape, args))
 
     def get_type(self):
         return _cvxcore.LinOp_get_type(self)
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         return _cvxcore.LinOp_is_constant(self)
 
     def get_shape(self):
@@ -187,7 +187,7 @@ class LinOp(object):
     def set_data_ndim(self, ndim):
         return _cvxcore.LinOp_set_data_ndim(self, ndim)
 
-    def is_sparse(self):
+    def is_sparse(self) -> bool:
         return _cvxcore.LinOp_is_sparse(self)
 
     def get_sparse_data(self):
@@ -245,7 +245,7 @@ class ProblemData(object):
     def getJ(self, values):
         return _cvxcore.ProblemData_getJ(self, values)
 
-    def __init__(self):
+    def __init__(self) -> None:
         _cvxcore.ProblemData_swiginit(self, _cvxcore.new_ProblemData())
     __swig_destroy__ = _cvxcore.delete_ProblemData
 
@@ -329,7 +329,7 @@ class IntVector(object):
     def erase(self, *args):
         return _cvxcore.IntVector_erase(self, *args)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.IntVector_swiginit(self, _cvxcore.new_IntVector(*args))
 
     def push_back(self, x):
@@ -435,7 +435,7 @@ class DoubleVector(object):
     def erase(self, *args):
         return _cvxcore.DoubleVector_erase(self, *args)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.DoubleVector_swiginit(self, _cvxcore.new_DoubleVector(*args))
 
     def push_back(self, x):
@@ -541,7 +541,7 @@ class IntVector2D(object):
     def erase(self, *args):
         return _cvxcore.IntVector2D_erase(self, *args)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.IntVector2D_swiginit(self, _cvxcore.new_IntVector2D(*args))
 
     def push_back(self, x):
@@ -647,7 +647,7 @@ class DoubleVector2D(object):
     def erase(self, *args):
         return _cvxcore.DoubleVector2D_erase(self, *args)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.DoubleVector2D_swiginit(self, _cvxcore.new_DoubleVector2D(*args))
 
     def push_back(self, x):
@@ -737,7 +737,7 @@ class IntIntMap(object):
     def asdict(self):
         return _cvxcore.IntIntMap_asdict(self)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.IntIntMap_swiginit(self, _cvxcore.new_IntIntMap(*args))
 
     def empty(self):
@@ -861,7 +861,7 @@ class LinOpVector(object):
     def erase(self, *args):
         return _cvxcore.LinOpVector_erase(self, *args)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.LinOpVector_swiginit(self, _cvxcore.new_LinOpVector(*args))
 
     def push_back(self, x):
@@ -967,7 +967,7 @@ class ConstLinOpVector(object):
     def erase(self, *args):
         return _cvxcore.ConstLinOpVector_erase(self, *args)
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         _cvxcore.ConstLinOpVector_swiginit(self, _cvxcore.new_ConstLinOpVector(*args))
 
     def push_back(self, x):
@@ -1001,5 +1001,3 @@ _cvxcore.ConstLinOpVector_swigregister(ConstLinOpVector)
 
 def build_matrix(*args):
     return _cvxcore.build_matrix(*args)
-
-

--- a/cvxpy/cvxcore/tests/python/test_linops.py
+++ b/cvxpy/cvxcore/tests/python/test_linops.py
@@ -6,7 +6,7 @@ import scipy.sparse as sp
 
 
 class TestLinOps(BaseTest):
-    def assertDataEqual(self, original_data, canon_data):
+    def assertDataEqual(self, original_data, canon_data) -> None:
         for key in ['A', 'b', 'c', 'G', 'h']:
             M1, M2 = original_data[key], canon_data[key]
             if isinstance(M1, sp.csc.csc_matrix):
@@ -14,7 +14,7 @@ class TestLinOps(BaseTest):
             else:
                 self.assertTrue(np.allclose(M1, M2))
 
-    def assertConstraintsMatch(self, constraints):
+    def assertConstraintsMatch(self, constraints) -> None:
         settings.USE_CVXCANON = False
         p = Problem(Minimize(0), constraints)
         cvxpy_data = p.get_problem_data(ECOS)
@@ -25,27 +25,27 @@ class TestLinOps(BaseTest):
 
         self.assertDataEqual(cvxpy_data, cvx_canon_data)
 
-    def test_sum_dense(self):
+    def test_sum_dense(self) -> None:
         rows, cols = 3, 3
         x1 = Variable(rows, cols)
         x2 = Variable(rows, cols)
         A = np.random.randn(rows, cols)
         self.assertConstraintsMatch([x1 + x2 == A])
 
-    def test_sum_sparse(self):
+    def test_sum_sparse(self) -> None:
         rows, cols = 75, 100
         x1 = Variable(rows, cols)
         x2 = Variable(rows, cols)
         A_sp = sp.rand(rows, cols, density=0.01)
         self.assertConstraintsMatch([x1 + x2 == A_sp])
 
-    def test_promote(self):
+    def test_promote(self) -> None:
         rows = 10
         b = Variable()
         v1 = Variable(rows, 1)
         self.assertConstraintsMatch([v1 == b])
 
-    def test_mul_dense(self):
+    def test_mul_dense(self) -> None:
         rows, cols = 15, 17
 
         A = np.random.randn(rows, cols)
@@ -54,7 +54,7 @@ class TestLinOps(BaseTest):
         y = Variable(rows, 1)
         self.assertConstraintsMatch([A*x == b, A*x == y])
 
-    def test_mul_sparse(self):
+    def test_mul_sparse(self) -> None:
         rows, cols = 75, 100
 
         A_sp = Constant(sp.rand(rows, cols, density=0.01))
@@ -63,7 +63,7 @@ class TestLinOps(BaseTest):
         y = Variable(rows, 1)
         self.assertConstraintsMatch([A_sp*x == b, A_sp*x == y])
 
-    def test_rmul_dense(self):
+    def test_rmul_dense(self) -> None:
         rows, cols = 15, 17
         A = np.random.randn(rows, cols)
         b = Variable(1, cols)
@@ -71,7 +71,7 @@ class TestLinOps(BaseTest):
         y = Variable(1, cols)
         self.assertConstraintsMatch([x * A == b, x * A == y])
 
-    def test_rmul_sparse(self):
+    def test_rmul_sparse(self) -> None:
         rows, cols = 75, 100
         A_sp = Constant(sp.rand(rows, cols, density=0.01))
         b = Variable(1, cols)
@@ -79,39 +79,39 @@ class TestLinOps(BaseTest):
         y = Variable(1, cols)
         self.assertConstraintsMatch([x * A_sp == b, x * A_sp == y])
 
-    def test_mul_elemwise_dense(self):
+    def test_mul_elemwise_dense(self) -> None:
         rows, cols = 15, 17
         A = np.random.randn(rows, cols)
         x1 = Variable(rows, cols)
         M = Variable(rows, cols)
         self.assertConstraintsMatch([mul_elemwise(A, x1) == M])
 
-    def test_mul_elemwise_sparse(self):
+    def test_mul_elemwise_sparse(self) -> None:
         rows, cols = 75, 100
         A_sp = Constant(sp.rand(rows, cols, density=0.01))
         x1 = Variable(rows, cols)
         M = Variable(rows, cols)
         self.assertConstraintsMatch([mul_elemwise(A_sp, x1) == M])
 
-    def test_div(self):
+    def test_div(self) -> None:
         x = Variable()
         self.assertConstraintsMatch([x / 4 == 3])
 
-    def test_neg_dense(self):
+    def test_neg_dense(self) -> None:
         rows, cols = 3, 3
         x1 = Variable(rows, cols)
         x2 = Variable(rows, cols)
         A = np.random.randn(rows, cols)
         self.assertConstraintsMatch([x1 - x2 == A])
 
-    def test_neg_sparse(self):
+    def test_neg_sparse(self) -> None:
         rows, cols = 3, 3
         x1 = Variable(rows, cols)
         x2 = Variable(rows, cols)
         A_sp = sp.rand(rows, cols, density=0.01)
         self.assertConstraintsMatch([x1 - x2 == A_sp])
 
-    def test_index(self):
+    def test_index(self) -> None:
         rows, cols = 15, 17
         X = Variable(rows, cols)
 
@@ -137,29 +137,29 @@ class TestLinOps(BaseTest):
             constr = [X[xi:xj:xk, ry] == 0, X[rx, yi:yj:yk] == 0]
             self.assertConstraintsMatch(constr)
 
-    def test_transpose_dense(self):
+    def test_transpose_dense(self) -> None:
         rows, cols = 15, 17
         X = Variable(rows, cols)
         A = np.random.randn(rows, cols)
         self.assertConstraintsMatch([X.T == A.T])
 
-    def test_transpose_sparse(self):
+    def test_transpose_sparse(self) -> None:
         rows, cols = 75, 100
         X = Variable(rows, cols)
         A_sp = sp.rand(rows, cols, density=0.01)
         self.assertConstraintsMatch([X.T == A_sp.T])
 
-    def test_sum_entries(self):
+    def test_sum_entries(self) -> None:
         rows, cols = 15, 17
         X = Variable(rows, cols)
         self.assertConstraintsMatch([sum_entries(X) == 4.5])
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         n = 15
         X = Variable(n, n)
         self.assertConstraintsMatch([trace(X) == 3])
 
-    def test_reshape_dense(self):
+    def test_reshape_dense(self) -> None:
         rows, cols = 15, 17
         X = Variable(rows, cols)
 
@@ -176,7 +176,7 @@ class TestLinOps(BaseTest):
         constr = [reshape(X, m, n) == A]
         self.assertConstraintsMatch(constr)
 
-    def test_reshape_sparse(self):
+    def test_reshape_sparse(self) -> None:
         rows, cols = 75, 100
         X = Variable(rows, cols)
 
@@ -193,39 +193,39 @@ class TestLinOps(BaseTest):
         constr = [reshape(X, m, n) == A]
         self.assertConstraintsMatch(constr)
 
-    def test_diag_vec_dense(self):
+    def test_diag_vec_dense(self) -> None:
         n = 15
         x = Variable(n, 1)
         constr = [diag(x) == np.eye(n)]
         self.assertConstraintsMatch(constr)
 
-    def test_diag_vec_sparse(self):
+    def test_diag_vec_sparse(self) -> None:
         n = 15
         x = Variable(n, 1)
         constr = [diag(x) == sp.eye(n)]
         self.assertConstraintsMatch(constr)
 
-    def test_diag_mat_dense(self):
+    def test_diag_mat_dense(self) -> None:
         n = 15
         X = Variable(n, n)
         v = np.random.randn(n)
         constr = [diag(X) == v]
         self.assertConstraintsMatch(constr)
 
-    def test_diag_mat_sparse(self):
+    def test_diag_mat_sparse(self) -> None:
         n = 15
         X = Variable(n, n)
         v = sp.rand(n, 1, density=0.01)
         constr = [diag(X) == v]
         self.assertConstraintsMatch(constr)
 
-    def test_upper_tri(self):
+    def test_upper_tri(self) -> None:
         n = 15
         X = Variable(n, n)
         constr = [upper_tri(X) == 0]
         self.assertConstraintsMatch(constr)
 
-    def test_conv(self):
+    def test_conv(self) -> None:
         n, m = 15, 17
         c = np.random.randn(m, 1)
         x = Variable(n, 1)
@@ -234,7 +234,7 @@ class TestLinOps(BaseTest):
         constr = [conv(c, x) == y]
         self.assertConstraintsMatch(constr)
 
-    def test_hstack_dense(self):
+    def test_hstack_dense(self) -> None:
         rows, cols = 15, 17
         X1 = Variable(rows, cols)
         X2 = Variable(rows, cols)
@@ -246,7 +246,7 @@ class TestLinOps(BaseTest):
         constr = [hstack(X1, X2, X3, X4, X5) == A]
         self.assertConstraintsMatch(constr)
 
-    def test_hstack_sparse(self):
+    def test_hstack_sparse(self) -> None:
         rows, cols = 15, 17
         X1 = Variable(rows, cols)
         X2 = Variable(rows, cols)
@@ -258,7 +258,7 @@ class TestLinOps(BaseTest):
         constr = [hstack(X1, X2, X3, X4, X5) == A_sp]
         self.assertConstraintsMatch(constr)
 
-    def test_vstack_dense(self):
+    def test_vstack_dense(self) -> None:
         rows, cols = 15, 17
         X1 = Variable(rows, cols)
         X2 = Variable(rows, cols)
@@ -270,7 +270,7 @@ class TestLinOps(BaseTest):
         constr = [vstack(X1, X2, X3, X4, X5) == A]
         self.assertConstraintsMatch(constr)
 
-    def test_vstack_sparse(self):
+    def test_vstack_sparse(self) -> None:
         rows, cols = 75, 100
         X1 = Variable(rows, cols)
         X2 = Variable(rows, cols)
@@ -282,7 +282,7 @@ class TestLinOps(BaseTest):
         constr = [vstack(X1, X2, X3, X4, X5) == A_sp]
         self.assertConstraintsMatch(constr)
 
-    def test_kron_dense(self):
+    def test_kron_dense(self) -> None:
         m, n = 3, 5
         p, q = 7, 9
         X = Variable(m, n)
@@ -291,7 +291,7 @@ class TestLinOps(BaseTest):
         constr = [kron(C, X) == A]
         self.assertConstraintsMatch(constr)
 
-    def test_kron_sparse(self):
+    def test_kron_sparse(self) -> None:
         m, n = 13, 15
         p, q = 17, 19
         X = Variable(m, n)

--- a/cvxpy/error.py
+++ b/cvxpy/error.py
@@ -18,17 +18,17 @@ limitations under the License.
 WARN = False
 
 
-def disable_warnings():
+def disable_warnings() -> None:
     global WARN
     WARN = False
 
 
-def enable_warnings():
+def enable_warnings() -> None:
     global WARN
     WARN = True
 
 
-def warnings_enabled():
+def warnings_enabled() -> bool:
     return WARN
 
 

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -22,6 +22,7 @@ from cvxpy.utilities import performance_utils as perf
 from scipy.sparse.linalg import eigsh
 from scipy.sparse.linalg.eigen.arpack.arpack import ArpackError
 import numpy as np
+from typing import List
 
 
 class Constant(Leaf):
@@ -35,7 +36,7 @@ class Constant(Leaf):
     casting ``c`` to a Constant.
     """
 
-    def __init__(self, value):
+    def __init__(self, value) -> None:
         # Keep sparse matrices sparse.
         if intf.is_sparse(value):
             self._value = intf.DEFAULT_SPARSE_INTF.const_to_matrix(
@@ -52,17 +53,17 @@ class Constant(Leaf):
         self._bottom_eig = None
         super(Constant, self).__init__(intf.shape(self.value))
 
-    def name(self):
+    def name(self) -> str:
         """The value as a string.
         """
         return str(self.value)
 
-    def constants(self):
+    def constants(self) -> List["Constant"]:
         """Returns self as a constant.
         """
         return [self]
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         return True
 
     @property
@@ -71,7 +72,7 @@ class Constant(Leaf):
         """
         return self._value
 
-    def is_pos(self):
+    def is_pos(self) -> bool:
         """Returns whether the constant is elementwise positive.
         """
         if not hasattr(self, '._cached_is_pos'):
@@ -104,28 +105,28 @@ class Constant(Leaf):
         obj = lu.create_const(self.value, self.shape, self._sparse)
         return (obj, [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string with information about the expression.
         """
         return "Constant(%s, %s, %s)" % (self.curvature,
                                          self.sign,
                                          self.shape)
 
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression nonnegative?
         """
         if self._nonneg is None:
             self._compute_attr()
         return self._nonneg
 
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         """Is the expression nonpositive?
         """
         if self._nonpos is None:
             self._compute_attr()
         return self._nonpos
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
         if self._imag is None:
@@ -133,13 +134,13 @@ class Constant(Leaf):
         return self._imag
 
     @perf.compute_once
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the Leaf complex valued?
         """
         return np.iscomplexobj(self.value)
 
     @perf.compute_once
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         if self.is_scalar():
@@ -152,7 +153,7 @@ class Constant(Leaf):
             return False
 
     @perf.compute_once
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression a Hermitian matrix?
         """
         if self.is_scalar() and self.is_real():
@@ -164,7 +165,7 @@ class Constant(Leaf):
         else:
             return False
 
-    def _compute_attr(self):
+    def _compute_attr(self) -> None:
         """Compute the attributes of the constant related to complex/real, sign.
         """
         # Set DCP attributes.
@@ -177,7 +178,7 @@ class Constant(Leaf):
         self._nonpos = is_nonpos
         self._nonneg = is_nonneg
 
-    def _compute_symm_attr(self):
+    def _compute_symm_attr(self) -> None:
         """Determine whether the constant is symmetric/Hermitian.
         """
         # Set DCP attributes.
@@ -186,7 +187,7 @@ class Constant(Leaf):
         self._herm = is_herm
 
     @perf.compute_once
-    def is_psd(self):
+    def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         # Symbolic only cases.
@@ -209,7 +210,7 @@ class Constant(Leaf):
         return self._bottom_eig >= -EIGVAL_TOL
 
     @perf.compute_once
-    def is_nsd(self):
+    def is_nsd(self) -> bool:
         """Is the expression a negative semidefinite matrix?
         """
         # Symbolic only cases.
@@ -232,7 +233,7 @@ class Constant(Leaf):
         return self._top_eig <= EIGVAL_TOL
 
 
-def extremal_eig_near_ref(A, ref, low=True):
+def extremal_eig_near_ref(A, ref, low: bool = True):
 
     def SA_eigsh(sigma):
         return eigsh(A, k=1, sigma=sigma, return_eigenvectors=False)

--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -19,13 +19,13 @@ import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.utilities import scopes
 
 
-def is_param_affine(expr):
+def is_param_affine(expr) -> bool:
     """Returns true if expression is parameters-affine (and variable-free)"""
     with scopes.dpp_scope():
         return not expr.variables() and expr.is_affine()
 
 
-def is_param_free(expr):
+def is_param_free(expr) -> bool:
     """Returns true if expression is not parametrized."""
     return not expr.parameters()
 
@@ -65,7 +65,7 @@ class Parameter(Leaf):
     def name(self):
         return self._name
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         if scopes.dpp_scope_active():
             return False
         return True

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -109,7 +109,7 @@ class Expression(u.Canonical):
         """
         return self.name()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string with information about the expression.
         """
         return "Expression(%s, %s, %s)" % (self.curvature,
@@ -167,32 +167,32 @@ class Expression(u.Canonical):
         return curvature_str
 
     @perf.compute_once
-    def is_constant(self):
+    def is_constant(self) -> bool:
         """Is the expression constant?
         """
         return 0 in self.shape or all(
             arg.is_constant() for arg in self.args)
 
     @perf.compute_once
-    def is_affine(self):
+    def is_affine(self) -> bool:
         """Is the expression affine?
         """
         return self.is_constant() or (self.is_convex() and self.is_concave())
 
     @abc.abstractmethod
-    def is_convex(self):
+    def is_convex(self) -> bool:
         """Is the expression convex?
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def is_concave(self):
+    def is_concave(self) -> bool:
         """Is the expression concave?
         """
         raise NotImplementedError()
 
     @perf.compute_once
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """Checks whether the Expression is DCP.
 
         Parameters
@@ -211,7 +211,7 @@ class Expression(u.Canonical):
                 return self.is_convex() or self.is_concave()
         return self.is_convex() or self.is_concave()
 
-    def is_log_log_constant(self):
+    def is_log_log_constant(self) -> bool:
         """Is the expression log-log constant, ie, elementwise positive?
         """
         if not self.is_constant():
@@ -223,25 +223,25 @@ class Expression(u.Canonical):
             return self.value is not None and np.all(self.value > 0)
 
     @perf.compute_once
-    def is_log_log_affine(self):
+    def is_log_log_affine(self) -> bool:
         """Is the expression affine?
         """
         return (self.is_log_log_constant()
                 or (self.is_log_log_convex() and self.is_log_log_concave()))
 
     @abc.abstractmethod
-    def is_log_log_convex(self):
+    def is_log_log_convex(self) -> bool:
         """Is the expression log-log convex?
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def is_log_log_concave(self):
+    def is_log_log_concave(self) -> bool:
         """Is the expression log-log concave?
         """
         raise NotImplementedError()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp=False) -> bool:
         """Checks whether the Expression is log-log DCP.
 
         Returns
@@ -255,22 +255,22 @@ class Expression(u.Canonical):
         return self.is_log_log_convex() or self.is_log_log_concave()
 
     @abc.abstractmethod
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         """The expression is a disciplined parameterized expression.
         """
         raise NotImplementedError()
 
-    def is_quasiconvex(self):
+    def is_quasiconvex(self) -> bool:
         return self.is_convex()
 
-    def is_quasiconcave(self):
+    def is_quasiconcave(self) -> bool:
         return self.is_concave()
 
-    def is_quasilinear(self):
+    def is_quasilinear(self) -> bool:
         return self.is_quasiconvex() and self.is_quasiconcave()
 
     @perf.compute_once
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         """Checks whether the Expression is DQCP.
 
         Returns
@@ -280,42 +280,42 @@ class Expression(u.Canonical):
         """
         return self.is_quasiconvex() or self.is_quasiconcave()
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the expression a Hermitian matrix?
         """
         return (self.is_real() and self.is_symmetric())
 
-    def is_psd(self):
+    def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         # Default to False.
         return False
 
-    def is_nsd(self):
+    def is_nsd(self) -> bool:
         """Is the expression a negative semidefinite matrix?
         """
         # Default to False.
         return False
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Is the expression quadratic?
         """
         # Defaults to is constant.
         return self.is_constant()
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
         # Defaults to false unless scalar.
         return self.is_scalar()
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Is the expression piecewise linear?
         """
         # Defaults to constant.
         return self.is_constant()
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         """Is the expression quadratic of piecewise affine?
         """
         return self.is_quadratic() or self.is_pwl()
@@ -337,19 +337,19 @@ class Expression(u.Canonical):
         return sign_str
 
     @perf.compute_once
-    def is_zero(self):
+    def is_zero(self) -> bool:
         """Is the expression all zero?
         """
         return self.is_nonneg() and self.is_nonpos()
 
     @abc.abstractmethod
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression positive?
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         """Is the expression negative?
         """
         raise NotImplementedError()
@@ -360,19 +360,19 @@ class Expression(u.Canonical):
         """
         raise NotImplementedError()
 
-    def is_real(self):
+    def is_real(self) -> bool:
         """Is the Leaf real valued?
         """
         return not self.is_complex()
 
     @abc.abstractproperty
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
         raise NotImplementedError()
 
     @abc.abstractproperty
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the Leaf complex valued?
         """
         raise NotImplementedError()
@@ -384,7 +384,7 @@ class Expression(u.Canonical):
         return np.prod(self.shape, dtype=int)
 
     @property
-    def ndim(self):
+    def ndim(self) -> int:
         """int : The number of dimensions in the expression's shape.
         """
         return len(self.shape)
@@ -394,17 +394,17 @@ class Expression(u.Canonical):
         """
         return cvxtypes.vec()(self)
 
-    def is_scalar(self):
+    def is_scalar(self) -> bool:
         """Is the expression a scalar?
         """
         return all(d == 1 for d in self.shape)
 
-    def is_vector(self):
+    def is_vector(self) -> bool:
         """Is the expression a column or row vector?
         """
         return self.ndim <= 1 or (self.ndim == 2 and min(self.shape) == 1)
 
-    def is_matrix(self):
+    def is_matrix(self) -> bool:
         """Is the expression a matrix?
         """
         return self.ndim == 2 and self.shape[0] > 1 and self.shape[1] > 1
@@ -639,7 +639,7 @@ class Expression(u.Canonical):
         return PSD(self - other)
 
     # Needed for Python3:
-    def __hash__(self):
+    def __hash__(self) -> int:
         return id(self)
 
     # Comparison operators.

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -19,6 +19,8 @@ from cvxpy.expressions import expression
 from cvxpy.settings import (GENERAL_PROJECTION_TOL,
                             PSD_NSD_PROJECTION_TOL,
                             SPARSE_PROJECTION_TOL)
+from typing import Tuple
+
 import cvxpy.interface as intf
 import numbers
 import numpy as np
@@ -82,12 +84,12 @@ class Leaf(expression.Expression):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, shape, value=None, nonneg=False, nonpos=False,
-                 complex=False, imag=False,
-                 symmetric=False, diag=False, PSD=False,
-                 NSD=False, hermitian=False,
-                 boolean=False, integer=False,
-                 sparsity=None, pos=False, neg=False):
+    def __init__(self, shape: Tuple[int], value=None, nonneg: bool=False, nonpos: bool=False,
+                 complex: bool=False, imag: bool=False,
+                 symmetric: bool=False, diag: bool=False, PSD: bool=False,
+                 NSD: bool=False, hermitian: bool=False,
+                 boolean: bool=False, integer: bool=False,
+                 sparsity=None, pos: bool=False, neg: bool=False) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         elif len(shape) > 2:
@@ -137,7 +139,7 @@ class Leaf(expression.Expression):
 
         self.args = []
 
-    def _get_attr_str(self):
+    def _get_attr_str(self) -> str:
         """Get a string representing the attributes.
         """
         attr_str = ""
@@ -165,7 +167,7 @@ class Leaf(expression.Expression):
             return id_objects[id(self)]
         return self  # Leaves are not deep copied.
 
-    def get_data(self):
+    def get_data(self) -> None:
         """Leaves are not copied.
         """
         pass
@@ -191,65 +193,65 @@ class Leaf(expression.Expression):
         """
         return []
 
-    def is_convex(self):
+    def is_convex(self) -> bool:
         """Is the expression convex?
         """
         return True
 
-    def is_concave(self):
+    def is_concave(self) -> bool:
         """Is the expression concave?
         """
         return True
 
-    def is_log_log_convex(self):
+    def is_log_log_convex(self) -> bool:
         """Is the expression log-log convex?
         """
         return self.is_pos()
 
-    def is_log_log_concave(self):
+    def is_log_log_concave(self) -> bool:
         """Is the expression log-log concave?
         """
         return self.is_pos()
 
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression nonnegative?
         """
         return (self.attributes['nonneg'] or self.attributes['pos'] or
                 self.attributes['boolean'])
 
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         """Is the expression nonpositive?
         """
         return self.attributes['nonpos'] or self.attributes['neg']
 
-    def is_pos(self):
+    def is_pos(self) -> bool:
         """Is the expression positive?
         """
         return self.attributes['pos']
 
-    def is_neg(self):
+    def is_neg(self) -> bool:
         """Is the expression negative?
         """
         return self.attributes['neg']
 
-    def is_hermitian(self):
+    def is_hermitian(self) -> bool:
         """Is the Leaf hermitian?
         """
         return (self.is_real() and self.is_symmetric()) or \
             self.attributes['hermitian'] or self.is_psd() or self.is_nsd()
 
-    def is_symmetric(self):
+    def is_symmetric(self) -> bool:
         """Is the Leaf symmetric?
         """
         return self.is_scalar() or \
             any(self.attributes[key] for key in ['diag', 'symmetric', 'PSD', 'NSD'])
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
         return self.attributes['imag']
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the Leaf complex valued?
         """
         return self.attributes['complex'] or self.is_imag() or self.attributes['hermitian']
@@ -341,20 +343,20 @@ class Leaf(expression.Expression):
             return val
 
     # Getter and setter for parameter value.
-    def save_value(self, val):
+    def save_value(self, val) -> None:
         self._value = val
 
     @property
-    def value(self):
+    def value(self) -> None:
         """NumPy.ndarray or None: The numeric value of the parameter.
         """
         return self._value
 
     @value.setter
-    def value(self, val):
+    def value(self, val) -> None:
         self.save_value(self._validate_value(val))
 
-    def project_and_assign(self, val):
+    def project_and_assign(self, val) -> None:
         """Project and assign a value to the variable.
         """
         self.save_value(self.project(val))
@@ -429,27 +431,27 @@ class Leaf(expression.Expression):
                 )
         return val
 
-    def is_psd(self):
+    def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?
         """
         return self.attributes['PSD']
 
-    def is_nsd(self):
+    def is_nsd(self) -> bool:
         """Is the expression a negative semidefinite matrix?
         """
         return self.attributes['NSD']
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Leaf nodes are always quadratic.
         """
         return True
 
-    def is_pwl(self):
+    def is_pwl(self) -> bool:
         """Leaf nodes are always piecewise linear.
         """
         return True
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context: str='dcp') -> bool:
         """The expression is a disciplined parameterized expression.
 
            context: dcp or dgp

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -84,7 +84,7 @@ class Variable(Leaf):
         """str : The name of the variable."""
         return self._name
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         return False
 
     @property

--- a/cvxpy/interface/base_matrix_interface.py
+++ b/cvxpy/interface/base_matrix_interface.py
@@ -96,7 +96,7 @@ class BaseMatrixInterface(object):
         raise NotImplementedError()
 
     def block_add(self, matrix, block, vert_offset, horiz_offset, rows, cols,
-                  vert_step=1, horiz_step=1):
+                  vert_step: int=1, horiz_step: int=1) -> None:
         """Add the block to a slice of the matrix.
 
         Args:

--- a/cvxpy/interface/matrix_utilities.py
+++ b/cvxpy/interface/matrix_utilities.py
@@ -108,7 +108,7 @@ def cvxopt2dense(value):
     return np.array(value)
 
 
-def is_sparse(constant):
+def is_sparse(constant) -> bool:
     """Is the constant a sparse matrix?
     """
     return sp.issparse(constant)
@@ -137,13 +137,13 @@ def shape(constant):
 # Is the constant a column vector?
 
 
-def is_vector(constant):
+def is_vector(constant) -> bool:
     return shape(constant)[1] == 1
 
 # Is the constant a scalar?
 
 
-def is_scalar(constant):
+def is_scalar(constant) -> bool:
     return shape(constant) == (1, 1)
 
 
@@ -222,7 +222,7 @@ def sign(constant):
     return (min_val >= 0, max_val <= 0)
 
 
-def is_complex(constant, tol=1e-5):
+def is_complex(constant, tol=1e-5) -> bool:
     """Return (is real, is imaginary).
 
     Parameters
@@ -267,7 +267,7 @@ def index(constant, key):
         return interface.index(constant, key)
 
 
-def is_hermitian(constant):
+def is_hermitian(constant) -> bool:
     """Check if a matrix is Hermitian and/or symmetric.
     """
     complex_type = np.iscomplexobj(constant)
@@ -287,7 +287,7 @@ def is_hermitian(constant):
     return is_symm, is_herm
 
 
-def is_sparse_symmetric(m, complex=False):
+def is_sparse_symmetric(m, complex=False) -> bool:
     """Check if a sparse matrix is symmetric
 
     Parameters

--- a/cvxpy/interface/numpy_interface/ndarray_interface.py
+++ b/cvxpy/interface/numpy_interface/ndarray_interface.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 
 from .. import base_matrix_interface as base
+from typing import Tuple
+
 import numpy
 import scipy.sparse
 
@@ -54,7 +56,7 @@ class NDArrayInterface(base.BaseMatrixInterface):
         return numpy.eye(size)
 
     # Return the dimensions of the matrix.
-    def shape(self, matrix):
+    def shape(self, matrix) -> Tuple[int, ...]:
         return tuple(int(d) for d in matrix.shape)
 
     def size(self, matrix):

--- a/cvxpy/interface/numpy_interface/sparse_matrix_interface.py
+++ b/cvxpy/interface/numpy_interface/sparse_matrix_interface.py
@@ -74,7 +74,7 @@ class SparseMatrixInterface(NDArrayInterface):
         return self.const_to_matrix(matrix, convert_scalars=True)
 
     def block_add(self, matrix, block, vert_offset, horiz_offset, rows, cols,
-                  vert_step=1, horiz_step=1):
+                  vert_step: int=1, horiz_step: int=1) -> None:
         """Add the block to a slice of the matrix.
 
         Args:

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -21,7 +21,7 @@ DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 # A linear operator applied to a variable
 # or a constant or function of parameters.
 class LinOp(object):
-    def __init__(self, type, shape, args, data):
+    def __init__(self, type, shape, args, data) -> None:
         self.type = type
         self.shape = shape
         self.args = args

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -33,14 +33,14 @@ class Counter(object):
         The current count.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.count = 0
 
 
 ID_COUNTER = Counter()
 
 
-def get_id():
+def get_id() -> int:
     """Returns a new id and updates the id counter.
 
     Returns
@@ -123,7 +123,7 @@ def create_const(value, shape, sparse=False):
     return lo.LinOp(op_type, shape, [], value)
 
 
-def is_scalar(operator):
+def is_scalar(operator) -> bool:
     """Returns whether a LinOp is a scalar.
 
     Parameters
@@ -138,7 +138,7 @@ def is_scalar(operator):
     return len(operator.shape) == 0 or np.prod(operator.shape, dtype=int) == 1
 
 
-def is_const(operator):
+def is_const(operator) -> bool:
     """Returns whether a LinOp is constant.
 
     Parameters

--- a/cvxpy/lin_ops/tree_mat.py
+++ b/cvxpy/lin_ops/tree_mat.py
@@ -393,7 +393,7 @@ def prune_constants(constraints):
     return pruned_constraints
 
 
-def prune_expr(lin_op):
+def prune_expr(lin_op) -> bool:
     """Prunes constant branches from the expression.
 
     Parameters

--- a/cvxpy/performance_tests/test_param_cache.py
+++ b/cvxpy/performance_tests/test_param_cache.py
@@ -24,7 +24,7 @@ import cvxpy as cvx
 
 class TestParamCache(unittest.TestCase):
 
-    def test_param_timings(self):
+    def test_param_timings(self) -> None:
         """Test that it is faster to solve a parameterized
         problem after the first solve.
         """

--- a/cvxpy/performance_tests/test_robustness.py
+++ b/cvxpy/performance_tests/test_robustness.py
@@ -31,7 +31,7 @@ import unittest
 class TestProblem(unittest.TestCase):
     """ Unit tests for the expression/expression module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
         self.b = Variable(name='b')
         self.c = Variable(name='c')
@@ -45,7 +45,7 @@ class TestProblem(unittest.TestCase):
         self.C = Variable((3, 2), name='C')
 
     # Overridden method to handle lists and lower accuracy.
-    def assertAlmostEqual(self, a, b, interface=intf.DEFAULT_INTF):
+    def assertAlmostEqual(self, a, b, interface=intf.DEFAULT_INTF) -> None:
         try:
             a = list(a)
             b = list(b)
@@ -54,7 +54,7 @@ class TestProblem(unittest.TestCase):
         except Exception:
             super(TestProblem, self).assertAlmostEqual(a, b, places=1)
 
-    def test_large_sum(self):
+    def test_large_sum(self) -> None:
         """Test large number of variables summed.
         """
         self.skipTest("Too slow.")
@@ -68,7 +68,7 @@ class TestProblem(unittest.TestCase):
             print(result - answer)
             self.assertAlmostEqual(result, answer)
 
-    def test_large_square(self):
+    def test_large_square(self) -> None:
         """Test large number of variables squared.
         """
         self.skipTest("Too slow.")
@@ -81,7 +81,7 @@ class TestProblem(unittest.TestCase):
             result = p.solve()
             self.assertAlmostEqual(result, 0)
 
-    def test_sdp(self):
+    def test_sdp(self) -> None:
         """Test a problem with semidefinite cones.
         """
         self.skipTest("Too slow.")
@@ -92,7 +92,7 @@ class TestProblem(unittest.TestCase):
         p = Problem(cp.Minimize(obj))
         p.solve(solver="SCS")
 
-    def test_large_sdp(self):
+    def test_large_sdp(self) -> None:
         """Test for bug where large PSD caused integer overflow in cvxcore.
         """
         self.skipTest("Too slow.")

--- a/cvxpy/performance_tests/test_warmstart.py
+++ b/cvxpy/performance_tests/test_warmstart.py
@@ -26,7 +26,7 @@ import cvxpy as cp
 
 class TestWarmstart(unittest.TestCase):
 
-    def test_warmstart(self):
+    def test_warmstart(self) -> None:
         """Testing warmstart LASSO with SCS.
         """
         import numpy

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -36,7 +36,7 @@ class Objective(u.Canonical):
         If expr is not a scalar.
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         self.args = [Expression.cast_to_const(expr)]
         # Validate that the objective resolves to a scalar.
         if not self.args[0].is_scalar():
@@ -46,10 +46,10 @@ class Objective(u.Canonical):
             raise ValueError("The '%s' objective must be real valued."
                              % self.NAME)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, repr(self.args[0]))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ' '.join([self.NAME, self.args[0].name()])
 
     def __radd__(self, other):
@@ -98,12 +98,12 @@ class Objective(u.Canonical):
         else:
             return scalar_value(v)
 
-    def is_quadratic(self):
+    def is_quadratic(self) -> bool:
         """Returns if the objective is a quadratic function.
         """
         return self.args[0].is_quadratic()
 
-    def is_qpwa(self):
+    def is_qpwa(self) -> bool:
         """Returns if the objective is a quadratic of piecewise affine.
         """
         return self.args[0].is_qpwa()
@@ -125,7 +125,7 @@ class Minimize(Objective):
 
     NAME = "minimize"
 
-    def __neg__(self):
+    def __neg__(self) -> "Maximize":
         return Maximize(-self.args[0])
 
     def __add__(self, other):
@@ -142,7 +142,7 @@ class Minimize(Objective):
         """
         return self.args[0].canonical_form
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """The objective must be convex.
         """
         if dpp:
@@ -150,7 +150,7 @@ class Minimize(Objective):
                 return self.args[0].is_convex()
         return self.args[0].is_convex()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp=False) -> bool:
         """The objective must be log-log convex.
         """
         if dpp:
@@ -158,7 +158,7 @@ class Minimize(Objective):
                 return self.args[0].is_log_log_convex()
         return self.args[0].is_log_log_convex()
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         with scopes.dpp_scope():
             if context.lower() == 'dcp':
                 return self.is_dcp(dpp=True)
@@ -167,7 +167,7 @@ class Minimize(Objective):
             else:
                 raise ValueError("Unsupported context ", context)
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         """The objective must be quasiconvex.
         """
         return self.args[0].is_quasiconvex()
@@ -195,7 +195,7 @@ class Maximize(Objective):
 
     NAME = "maximize"
 
-    def __neg__(self):
+    def __neg__(self) -> Minimize:
         return Minimize(-self.args[0])
 
     def __add__(self, other):
@@ -213,7 +213,7 @@ class Maximize(Objective):
         obj, constraints = self.args[0].canonical_form
         return (lu.neg_expr(obj), constraints)
 
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp=False) -> bool:
         """The objective must be concave.
         """
         if dpp:
@@ -221,7 +221,7 @@ class Maximize(Objective):
                 return self.args[0].is_concave()
         return self.args[0].is_concave()
 
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp=False) -> bool:
         """The objective must be log-log concave.
         """
         if dpp:
@@ -229,7 +229,7 @@ class Maximize(Objective):
                 return self.args[0].is_log_log_concave()
         return self.args[0].is_log_log_concave()
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         with scopes.dpp_scope():
             if context.lower() == 'dcp':
                 return self.is_dcp(dpp=True)
@@ -238,7 +238,7 @@ class Maximize(Objective):
             else:
                 raise ValueError("Unsupported context ", context)
 
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         """The objective must be quasiconcave.
         """
         return self.args[0].is_quasiconcave()

--- a/cvxpy/problems/param_prob.py
+++ b/cvxpy/problems/param_prob.py
@@ -25,7 +25,7 @@ class ParamProb(object):
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
-    def is_mixed_integer(self):
+    def is_mixed_integer(self) -> bool:
         """Is the problem mixed-integer?"""
         raise NotImplementedError()
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -82,13 +82,13 @@ _FOOTER = (
 
 
 class Cache(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self.key = None
         self.solving_chain = None
         self.param_prog = None
         self.inverse_data = None
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.key = None
         self.solving_chain = None
         self.param_prog = None
@@ -118,7 +118,7 @@ class Problem(u.Canonical):
     # The solve methods available.
     REGISTERED_SOLVE_METHODS = {}
 
-    def __init__(self, objective, constraints=None):
+    def __init__(self, objective, constraints=None) -> None:
         if constraints is None:
             constraints = []
         # Check that objective is Minimize or Maximize.
@@ -203,7 +203,7 @@ class Problem(u.Canonical):
         return {variable.name(): variable for variable in self.variables()}
 
     @perf.compute_once
-    def is_dcp(self, dpp=False):
+    def is_dcp(self, dpp: bool=False) -> bool:
         """Does the problem satisfy DCP rules?
 
         Arguments
@@ -226,7 +226,7 @@ class Problem(u.Canonical):
           expr.is_dcp(dpp) for expr in self.constraints + [self.objective])
 
     @perf.compute_once
-    def is_dgp(self, dpp=False):
+    def is_dgp(self, dpp: bool=False) -> bool:
         """Does the problem satisfy DGP rules?
 
         Arguments
@@ -249,14 +249,14 @@ class Problem(u.Canonical):
           expr.is_dgp(dpp) for expr in self.constraints + [self.objective])
 
     @perf.compute_once
-    def is_dqcp(self):
+    def is_dqcp(self) -> bool:
         """Does the problem satisfy the DQCP rules?
         """
         return all(
           expr.is_dqcp() for expr in self.constraints + [self.objective])
 
     @perf.compute_once
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         """Does the problem satisfy DPP rules?
 
         DPP is a mild restriction of DGP. When a problem involving
@@ -287,7 +287,7 @@ class Problem(u.Canonical):
             raise ValueError("Unsupported context ", context)
 
     @perf.compute_once
-    def is_qp(self):
+    def is_qp(self) -> bool:
         """Is problem a quadratic program?
         """
         for c in self.constraints:
@@ -299,7 +299,7 @@ class Problem(u.Canonical):
         return (self.is_dcp() and self.objective.args[0].is_qpwa())
 
     @perf.compute_once
-    def is_mixed_integer(self):
+    def is_mixed_integer(self) -> bool:
         return any(v.attributes['boolean'] or v.attributes['integer']
                    for v in self.variables())
 
@@ -457,7 +457,7 @@ class Problem(u.Canonical):
         return solve_func(self, *args, **kwargs)
 
     @classmethod
-    def register_solve(cls, name, func):
+    def register_solve(cls, name, func) -> None:
         """Adds a solve method to the Problem class.
 
         Arguments
@@ -790,7 +790,7 @@ class Problem(u.Canonical):
                                        enforce_dpp=enforce_dpp)
 
     @staticmethod
-    def _sort_candidate_solvers(solvers):
+    def _sort_candidate_solvers(solvers) -> None:
         """Sorts candidate solvers lists according to slv_def.CONIC_SOLVERS/QP_SOLVERS
 
         Arguments
@@ -811,7 +811,7 @@ class Problem(u.Canonical):
                 solvers['qp_solvers'], key=lambda s: slv_def.QP_SOLVERS.index(s)
             )
 
-    def _invalidate_cache(self):
+    def _invalidate_cache(self) -> None:
         self._cache_key = None
         self._solving_chain = None
         self._param_prog = None
@@ -957,7 +957,7 @@ class Problem(u.Canonical):
                     '%.3e seconds' % self._solve_time)
         return self.value
 
-    def backward(self):
+    def backward(self) -> None:
         """Compute the gradient of a solution with respect to Parameters.
 
         This method differentiates through the solution map of the problem,
@@ -1092,7 +1092,7 @@ class Problem(u.Canonical):
                     grad += (1.0 / param.value) * dparams[new_param.id]
                 param.gradient = grad
 
-    def derivative(self):
+    def derivative(self) -> None:
         """Apply the derivative of the solution map to perturbations in the Parameters
 
         This method applies the derivative of the solution map to perturbations
@@ -1190,7 +1190,7 @@ class Problem(u.Canonical):
                 # dx_gp/d x_cone_program = exp(x_cone_program) = x_gp
                 variable.delta *= variable.value
 
-    def _clear_solution(self):
+    def _clear_solution(self) -> None:
         for v in self.variables():
             v.save_value(None)
         for c in self.constraints:
@@ -1200,7 +1200,7 @@ class Problem(u.Canonical):
         self._status = None
         self._solution = None
 
-    def unpack(self, solution):
+    def unpack(self, solution) -> None:
         """Updates the problem state given a Solution.
 
         Updates problem.status, problem.value and value of primal and dual
@@ -1236,7 +1236,7 @@ class Problem(u.Canonical):
         self._status = solution.status
         self._solution = solution
 
-    def unpack_results(self, solution, chain, inverse_data):
+    def unpack_results(self, solution, chain, inverse_data) -> None:
         """Updates the problem state given the solver results.
 
         Updates problem.status, problem.value and value of
@@ -1286,11 +1286,11 @@ class Problem(u.Canonical):
                 lines += [len(subject_to) * " " + str(constr)]
             return '\n'.join(lines)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Problem(%s, %s)" % (repr(self.objective),
                                     repr(self.constraints))
 
-    def __neg__(self):
+    def __neg__(self) -> "Problem":
         return Problem(-self.objective, self.constraints)
 
     def __add__(self, other):
@@ -1331,7 +1331,7 @@ class Problem(u.Canonical):
             raise NotImplementedError()
         return Problem(self.objective * (1.0 / other), self.constraints)
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         return False
 
     __truediv__ = __div__
@@ -1357,7 +1357,7 @@ class SolverStats(object):
         returned directly from the solver, without modification by CVXPY.
         This object may be a dict, or a custom Python object.
     """
-    def __init__(self, results_dict, solver_name):
+    def __init__(self, results_dict, solver_name) -> None:
         self.solver_name = solver_name
         self.solve_time = None
         self.setup_time = None
@@ -1401,7 +1401,7 @@ class SizeMetrics(object):
         for each data block.
     """
 
-    def __init__(self, problem):
+    def __init__(self, problem) -> None:
         # num_scalar_variables
         self.num_scalar_variables = 0
         for var in problem.variables():

--- a/cvxpy/problems/xpress_problem.py
+++ b/cvxpy/problems/xpress_problem.py
@@ -45,19 +45,19 @@ class XpressProblem (Problem):
     # The solve methods available.
     REGISTERED_SOLVE_METHODS = {}
 
-    def __init__(self, objective, constraints=None):
+    def __init__(self, objective, constraints=None) -> None:
 
         super(XpressProblem, self).__init__(objective, constraints)
         self._iis = None
 
-    def _reset_iis(self):
+    def _reset_iis(self) -> None:
         """Clears the iis information
         """
 
         self._iis = None
         self._transferRow = None
 
-    def _update_problem_state(self, results_dict, sym_data, solver):
+    def _update_problem_state(self, results_dict, sym_data, solver) -> None:
         """Updates the problem state given the solver results.
 
         Updates problem.status, problem.value and value of
@@ -78,11 +78,11 @@ class XpressProblem (Problem):
         self._iis = results_dict[s.XPRESS_IIS]
         self._transferRow = results_dict[s.XPRESS_TROW]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "XpressProblem(%s, %s)" % (repr(self.objective),
                                           repr(self.constraints))
 
-    def __neg__(self):
+    def __neg__(self) -> "XpressProblem":
         return XpressProblem(-self.objective, self.constraints)
 
     def __add__(self, other):

--- a/cvxpy/reductions/canonicalization.py
+++ b/cvxpy/reductions/canonicalization.py
@@ -48,7 +48,7 @@ class Canonicalization(Reduction):
         problem : Problem
             A problem owned by this reduction.
     """
-    def __init__(self, canon_methods, problem=None):
+    def __init__(self, canon_methods, problem=None) -> None:
         super(Canonicalization, self).__init__(problem=problem)
         self.canon_methods = canon_methods
 

--- a/cvxpy/reductions/chain.py
+++ b/cvxpy/reductions/chain.py
@@ -11,14 +11,14 @@ class Chain(Reduction):
         A list of reductions.
     """
 
-    def __init__(self, problem=None, reductions=[]):
+    def __init__(self, problem=None, reductions=[]) -> None:
         super(Chain, self).__init__(problem=problem)
         self.reductions = reductions
 
     def __str__(self):
         return str(self.reductions)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Chain(reductions=%s)" % repr(self.reductions)
 
     def get(self, reduction_type):
@@ -27,7 +27,7 @@ class Chain(Reduction):
                 return reduction
         raise KeyError
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """A problem is accepted if the sequence of reductions is valid.
 
         In particular, the i-th reduction must accept the output of the i-1th

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -27,7 +27,7 @@ from cvxpy.lin_ops import lin_utils as lu
 from cvxpy import settings as s
 
 
-def accepts(problem):
+def accepts(problem) -> bool:
     leaves = problem.variables() + problem.parameters() + problem.constants()
     return any(leaf.is_complex() for leaf in leaves)
 
@@ -35,7 +35,7 @@ def accepts(problem):
 class Complex2Real(Reduction):
     """Lifts complex numbers to a real representation."""
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> None:
         accepts(problem)
 
     def apply(self, problem):

--- a/cvxpy/reductions/cone2cone/exotic2common.py
+++ b/cvxpy/reductions/cone2cone/exotic2common.py
@@ -87,6 +87,6 @@ class Exotic2Common(Canonicalization):
         PowConeND: pow_nd_canon
     }
 
-    def __init__(self, problem=None):
+    def __init__(self, problem=None) -> None:
         super(Exotic2Common, self).__init__(
             problem=problem, canon_methods=Exotic2Common.CANON_METHODS)

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -86,7 +86,7 @@ def lower_value(variable, value):
 class CvxAttr2Constr(Reduction):
     """Expand convex variable attributes into constraints."""
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         return True
 
     def apply(self, problem):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/normNuc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/normNuc_canon.py
@@ -15,11 +15,13 @@ limitations under the License.
 """
 
 from cvxpy.atoms.affine.trace import trace
+from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.variable import Variable
 from cvxpy.atoms.affine.bmat import bmat
+from typing import List, Tuple
 
 
-def normNuc_canon(expr, args):
+def normNuc_canon(expr, args) -> Tuple[float, List[Constraint]]:
     A = args[0]
     m, n = A.shape
     # Create the equivalent problem:

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -62,7 +62,7 @@ class ConeDims(object):
     PSD_DIM = s.PSD_DIM
     P3D_DIM = 'p3'
 
-    def __init__(self, constr_map):
+    def __init__(self, constr_map) -> None:
         self.zero = int(sum(c.size for c in constr_map[Zero]))
         self.nonneg = int(sum(c.size for c in constr_map[NonNeg]))
         self.exp = int(sum(c.num_cones() for c in constr_map[ExpCone]))
@@ -73,11 +73,11 @@ class ConeDims(object):
             p3d = np.concatenate([c.alpha.value for c in constr_map[PowCone3D]]).tolist()
         self.p3d = p3d
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "(zero: {0}, nonneg: {1}, exp: {2}, soc: {3}, psd: {4}, p3d: {5})".format(
             self.zero, self.nonneg, self.exp, self.soc, self.psd, self.p3d)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation.
         """
         return ("%i equalities, %i inequalities, %i exponential cones, \n"
@@ -154,7 +154,7 @@ class ParamConeProg(ParamProb):
         # whether this param cone prog has been formatted for a solver
         self.formatted = formatted
 
-    def is_mixed_integer(self):
+    def is_mixed_integer(self) -> bool:
         """Is the problem mixed-integer?"""
         return self.x.attributes['boolean'] or \
             self.x.attributes['integer']

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/__init__.py
@@ -82,7 +82,7 @@ CANON_METHODS[minimum] = PWL_METHODS[minimum]
 
 # Canonicalization of DGPs is a stateful procedure, hence the need for a class.
 class DgpCanonMethods(dict):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(DgpCanonMethods, self).__init__(*args, **kwargs)
         self._variables = {}
         self._parameters = {}

--- a/cvxpy/reductions/dgp2dcp/dgp2dcp.py
+++ b/cvxpy/reductions/dgp2dcp/dgp2dcp.py
@@ -53,7 +53,7 @@ class Dgp2Dcp(Canonicalization):
     >>> print(dgp_problem.value)
     >>> print(dgp_problem.variables())
     """
-    def __init__(self, problem=None):
+    def __init__(self, problem=None) -> None:
         # Canonicalization of DGP is stateful; canon_methods created
         # in `apply`.
         super(Dgp2Dcp, self).__init__(canon_methods=None, problem=problem)

--- a/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
+++ b/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
@@ -32,6 +32,7 @@ from cvxpy.reductions.solution import Solution
 import cvxpy.settings as s
 
 from collections import namedtuple
+from typing import Any, List, Tuple
 
 import numpy as np
 
@@ -65,7 +66,7 @@ class Dqcp2Dcp(Canonicalization):
     Problems emitted by this reduction can be solved with the `cp.bisect`
     function.
    """
-    def __init__(self, problem=None):
+    def __init__(self, problem=None) -> None:
         super(Dqcp2Dcp, self).__init__(
             canon_methods=CANON_METHODS, problem=problem)
         self._bisection_data = None
@@ -112,7 +113,7 @@ class Dqcp2Dcp(Canonicalization):
         constrs += c
         return canon_expr, constrs
 
-    def _canon_args(self, expr):
+    def _canon_args(self, expr) -> Tuple[List[Any], List[Any]]:
         """Canonicalize arguments of an expression.
 
         Like Canonicalization.canonicalize_tree, but preserves signs.

--- a/cvxpy/reductions/eliminate_pwl/eliminate_pwl.py
+++ b/cvxpy/reductions/eliminate_pwl/eliminate_pwl.py
@@ -23,11 +23,11 @@ from cvxpy.reductions.eliminate_pwl.atom_canonicalizers import (
 class EliminatePwl(Canonicalization):
     """Eliminates piecewise linear atoms."""
 
-    def __init__(self, problem=None):
+    def __init__(self, problem=None) -> None:
         super(EliminatePwl, self).__init__(
           problem=problem, canon_methods=elim_pwl_methods)
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         atom_types = [type(atom) for atom in problem.atoms()]
         pwl_types = [abs, maximum, sum_largest, max, norm1, norm_inf]
         return any(atom in pwl_types for atom in atom_types)

--- a/cvxpy/reductions/eval_params.py
+++ b/cvxpy/reductions/eval_params.py
@@ -24,7 +24,7 @@ def replace_params_with_consts(expr):
 class EvalParams(Reduction):
     """Replaces symbolic parameters with their constant values."""
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         return True
 
     def apply(self, problem):

--- a/cvxpy/reductions/flip_objective.py
+++ b/cvxpy/reductions/flip_objective.py
@@ -23,7 +23,7 @@ class FlipObjective(Reduction):
     """Flip a minimization objective to a maximization and vice versa.
      """
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         return True
 
     def apply(self, problem):

--- a/cvxpy/reductions/inverse_data.py
+++ b/cvxpy/reductions/inverse_data.py
@@ -20,7 +20,7 @@ import cvxpy.lin_ops.lin_op as lo
 class InverseData(object):
     """Stores data useful for solution retrieval."""
 
-    def __init__(self, problem):
+    def __init__(self, problem) -> None:
         varis = problem.variables()
         self.id_map, self.var_offsets, self.x_length, self.var_shapes = \
             InverseData.get_var_offsets(varis)

--- a/cvxpy/reductions/matrix_stuffing.py
+++ b/cvxpy/reductions/matrix_stuffing.py
@@ -18,11 +18,12 @@ limitations under the License.
 import abc
 
 from cvxpy.reductions.reduction import Reduction
+from typing import Any, List, Tuple, Type
 
 import numpy as np
 
 
-def extract_mip_idx(variables):
+def extract_mip_idx(variables) -> Tuple[List[int], List[int]]:
     """Coalesces bool, int indices for variables.
 
        The indexing scheme assumes that the variables will be coalesced into
@@ -53,7 +54,7 @@ class MatrixStuffing(Reduction):
 
     __metaclass__ = abc.ABCMeta
 
-    def apply(self, problem):
+    def apply(self, problem) -> None:
         """Returns a stuffed problem.
 
         The returned problem is a minimization problem in which every

--- a/cvxpy/reductions/qp2quad_form/qp2symbolic_qp.py
+++ b/cvxpy/reductions/qp2quad_form/qp2symbolic_qp.py
@@ -41,7 +41,7 @@ class Qp2SymbolicQp(Canonicalization):
     Reduces a quadratic problem to a problem that consists of affine
     expressions and symbolic quadratic forms.
     """
-    def __init__(self, problem=None):
+    def __init__(self, problem=None) -> None:
         super(Qp2SymbolicQp, self).__init__(
           problem=problem, canon_methods=qp_canon_methods)
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -52,18 +52,18 @@ class ConeDims(object):
         A list of the positive semidefinite cone dimensions, where the
         dimension of the PSD cone of k by k matrices is k.
     """
-    def __init__(self, constr_map):
+    def __init__(self, constr_map) -> None:
         self.zero = int(sum(c.size for c in constr_map[Zero]))
         self.nonpos = int(sum(c.size for c in constr_map[NonPos]))
         self.exp = int(sum(c.num_cones() for c in constr_map[ExpCone]))
         self.soc = [int(dim) for c in constr_map[SOC] for dim in c.cone_sizes()]
         self.psd = [int(c.shape[0]) for c in constr_map[PSD]]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "(zero: {0}, nonpos: {1}, exp: {2}, soc: {3}, psd: {4})".format(
             self.zero, self.nonpos, self.exp, self.soc, self.psd)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation.
         """
         return ("%i equalities, %i inequalities, %i exponential cones, \n"
@@ -105,7 +105,7 @@ class ParamQuadProg(ParamProb):
                  constraints,
                  parameters,
                  param_id_to_col,
-                 formatted=False):
+                 formatted: bool=False) -> None:
         self.P = P
         self.q = q
         self.x = x
@@ -151,7 +151,7 @@ class ParamQuadProg(ParamProb):
         # whether this param cone prog has been formatted for a solver
         self.formatted = formatted
 
-    def is_mixed_integer(self):
+    def is_mixed_integer(self) -> bool:
         """Is the problem mixed-integer?"""
         return self.x.attributes['boolean'] or \
             self.x.attributes['integer']

--- a/cvxpy/reductions/reduction.py
+++ b/cvxpy/reductions/reduction.py
@@ -48,7 +48,7 @@ class Reduction(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, problem=None):
+    def __init__(self, problem=None) -> None:
         """Construct a reduction for reducing `problem`.
 
         If `problem` is not None, then a subsequent invocation of `reduce()`

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -18,7 +18,7 @@ import numpy as np
 import cvxpy.settings as s
 
 
-def failure_solution(status, attr=None):
+def failure_solution(status, attr=None) -> "Solution":
     """Factory function for infeasible or unbounded solutions.
 
     Parameters
@@ -58,25 +58,25 @@ class Solution(object):
     attr : dict
         Miscelleneous information propagated up from a solver.
     """
-    def __init__(self, status, opt_val, primal_vars, dual_vars, attr):
+    def __init__(self, status, opt_val, primal_vars, dual_vars, attr) -> None:
         self.status = status
         self.opt_val = opt_val
         self.primal_vars = primal_vars
         self.dual_vars = dual_vars
         self.attr = attr
 
-    def copy(self):
+    def copy(self) -> "Solution":
         return Solution(self.status,
                         self.opt_val,
                         self.primal_vars,
                         self.dual_vars,
                         self.attr)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Solution(status=%s, opt_val=%s, primal_vars=%s, dual_vars=%s, attr=%s)" % (
           self.status, self.opt_val, self.primal_vars, self.dual_vars, self.attr)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Solution(%s, %s, %s, %s)" % (self.status,
                                              self.primal_vars,
                                              self.dual_vars,

--- a/cvxpy/reductions/solvers/bisection.py
+++ b/cvxpy/reductions/solvers/bisection.py
@@ -33,7 +33,7 @@ def _lower_problem(problem):
     return problems.problem.Problem(Minimize(0), constrs)
 
 
-def _solve(problem, solver):
+def _solve(problem, solver) -> None:
     if problem is None:
         return
     with warnings.catch_warnings():
@@ -42,7 +42,7 @@ def _solve(problem, solver):
         problem.solve(solver=solver)
 
 
-def _infeasible(problem):
+def _infeasible(problem) -> bool:
     return problem is None or problem.status in (s.INFEASIBLE,
                                                  s.INFEASIBLE_INACCURATE)
 

--- a/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
@@ -53,13 +53,13 @@ class CBC(SCS):
         """
         return s.CBC
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         from cylp.cy import CyClpSimplex
         CyClpSimplex  # For flake8
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can Cbc solve the problem?
         """
         # TODO check if is matrix stuffed.

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -32,7 +32,7 @@ import scipy.sparse as sp
 
 class LinearOperator(object):
     """A wrapper for linear operators."""
-    def __init__(self, linear_op, shape):
+    def __init__(self, linear_op, shape) -> None:
         if sp.issparse(linear_op):
             self._matmul = lambda X: linear_op @ X
         else:
@@ -50,7 +50,7 @@ def as_linear_operator(linear_op):
         return LinearOperator(linear_op, linear_op.shape)
 
 
-def as_block_diag_linear_operator(matrices):
+def as_block_diag_linear_operator(matrices) -> LinearOperator:
     """Block diag of SciPy sparse matrices or linear operators."""
     linear_operators = [as_linear_operator(op) for op in matrices]
     nrows = [op.shape[0] for op in linear_operators]

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -34,7 +34,7 @@ _LIN, _QUAD = 0, 1
 _CpxConstr = namedtuple("_CpxConstr", ["constr_type", "index"])
 
 
-def set_parameters(model, solver_opts):
+def set_parameters(model, solver_opts) -> None:
     """Sets CPLEX parameters."""
     # TODO: Parameter support is functional, but perhaps not ideal.
     # The user must pass parameter names as used in the CPLEX Python
@@ -58,7 +58,7 @@ def set_parameters(model, solver_opts):
         raise ValueError("invalid keyword-argument '{0}'".format(kwargs[0]))
 
 
-def hide_solver_output(model):
+def hide_solver_output(model) -> None:
     """Set CPLEX verbosity level (either on or off)."""
     # By default the output will be sent to stdout. Setting the output
     # streams to None will prevent any output from being shown.
@@ -217,12 +217,12 @@ class CPLEX(SCS):
         """The name of the solver. """
         return s.CPLEX
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver."""
         import cplex
         cplex  # For flake8
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can CPLEX solve the problem?
         """
         # TODO check if is matrix stuffed.

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -24,14 +24,16 @@ from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.compr_matrix import compress_matrix
 from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
 from cvxpy.expressions.constants.constant import extremal_eig_near_ref
+from typing import Dict, List, Union
+
 import scipy.sparse as sp
 import scipy
 import numpy as np
 
 
 # Utility method for formatting a ConeDims instance into a dictionary
-# that can be supplied to ecos.
-def dims_to_solver_dict(cone_dims):
+# that can be supplied to cvxopt.
+def dims_to_solver_dict(cone_dims) -> Dict[str, Union[List[int], int]]:
     cones = {
         "l": int(cone_dims.nonneg),
         "q": [int(v) for v in cone_dims.soc],
@@ -67,13 +69,13 @@ class CVXOPT(ECOS):
         """
         return s.CVXOPT
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         import cvxopt
         cvxopt  # For flake8
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can CVXOPT solve the problem?
         """
         # TODO check if is matrix stuffed.
@@ -333,7 +335,7 @@ class CVXOPT(ECOS):
         return s.OPTIMAL
 
     @staticmethod
-    def _restore_solver_options(old_options):
+    def _restore_solver_options(old_options) -> None:
         import cvxopt.solvers
         for key, value in list(cvxopt.solvers.options.items()):
             if key in old_options:

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -30,7 +30,7 @@ class DIFFCP(scs_conif.SCS):
         """
         return s.DIFFCP
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         import diffcp

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -69,7 +69,7 @@ class ECOS(ConicSolver):
     # Order of exponential cone arguments for solver.
     EXP_CONE_ORDER = [0, 2, 1]
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         import ecos

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
@@ -34,7 +34,7 @@ class GLPK(CVXOPT):
         """
         return s.GLPK
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         from cvxopt import glpk
@@ -134,7 +134,7 @@ class GLPK(CVXOPT):
         return solution
 
     @staticmethod
-    def _restore_solver_options(old_options):
+    def _restore_solver_options(old_options) -> None:
         import cvxopt.solvers
         for key, value in list(cvxopt.solvers.options.items()):
             if key in old_options:

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -63,13 +63,13 @@ class GUROBI(SCS):
         """
         return s.GUROBI
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         import gurobipy
         gurobipy  # For flake8
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can Gurobi solve the problem?
         """
         # TODO check if is matrix stuffed.

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -74,7 +74,7 @@ class MOSEK(ConicSolver):
     with this convention, EXP_CONE_ORDER should be should be [2, 1, 0].
     """
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver (updates the set of supported constraints, if applicable).
         """
         import mosek
@@ -88,7 +88,7 @@ class MOSEK(ConicSolver):
         """
         return s.MOSEK
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can the installed version of Mosek solve the problem?
         """
         # TODO check if is matrix stuffed.

--- a/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
@@ -40,7 +40,7 @@ class NAG(ConicSolver):
                   51: s.INFEASIBLE,
                   52: s.UNBOUNDED}
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         from naginterfaces.library import opt
@@ -51,7 +51,7 @@ class NAG(ConicSolver):
         """
         return s.NAG
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can NAG solve the problem?
         """
         if not problem.objective.args[0].is_affine():

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 import cvxpy.settings as s
 from cvxpy.constraints import Zero, NonNeg, PSD, SOC, ExpCone, PowCone3D
+from cvxpy.expressions.expression import Expression
 from cvxpy.reductions.solution import failure_solution, Solution
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers import utilities
@@ -72,7 +73,7 @@ def tri_to_full(lower_tri, n):
     return np.reshape(full, n*n, order="F")
 
 
-def scs_psdvec_to_psdmat(vec, indices):
+def scs_psdvec_to_psdmat(vec: Expression, indices: np.ndarray) -> Expression:
     """
     Return "V" so that "vec[indices] belongs to the SCS-standard PSD cone"
     can be written in natural cvxpy syntax as "V >> 0".
@@ -138,7 +139,7 @@ class SCS(ConicSolver):
         """
         return s.SCS
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         import scs

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -45,7 +45,7 @@ class XPRESS(SCS):
     MIP_CAPABLE = True
     SUPPORTED_CONSTRAINTS = ConicSolver.SUPPORTED_CONSTRAINTS + [SOC]
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Main member of this class: an Xpress problem. Marked with a
         # trailing "_" to denote a member
         self.prob_ = None
@@ -55,13 +55,13 @@ class XPRESS(SCS):
         """
         return s.XPRESS
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         """Imports the solver.
         """
         import xpress
         self.version = xpress.getversion()
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         """Can Xpress solve the problem?
         """
         # TODO check if is matrix stuffed.

--- a/cvxpy/reductions/solvers/constant_solver.py
+++ b/cvxpy/reductions/solvers/constant_solver.py
@@ -9,7 +9,7 @@ class ConstantSolver(Solver):
     # Solver capabilities
     MIP_CAPABLE = True
 
-    def accepts(self, problem):
+    def accepts(self, problem) -> bool:
         return len(problem.variables()) == 0
 
     def apply(self, problem):
@@ -18,13 +18,13 @@ class ConstantSolver(Solver):
     def invert(self, solution, inverse_data):
         return solution
 
-    def name(self):
+    def name(self) -> str:
         return "CONSTANT_SOLVER"
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         return
 
-    def is_installed(self):
+    def is_installed(self) -> bool:
         return True
 
     def solve_via_data(self, data, warm_start, verbose, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -10,7 +10,7 @@ from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
 import numpy as np
 
 
-def constrain_cplex_infty(v):
+def constrain_cplex_infty(v) -> None:
     '''
     Limit values of vector v between +/- infinity as
     defined in the CPLEX package
@@ -33,7 +33,7 @@ class CPLEX(QpSolver):
     def name(self):
         return s.CPLEX
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         import cplex
         cplex
 

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -5,7 +5,7 @@ from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 import numpy as np
 
 
-def constrain_gurobi_infty(v):
+def constrain_gurobi_infty(v) -> None:
     '''
     Limit values of vector v between +/- infinity as
     defined in the Gurobi package
@@ -43,7 +43,7 @@ class GUROBI(QpSolver):
     def name(self):
         return s.GUROBI
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         import gurobipy
         gurobipy
 

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -24,7 +24,7 @@ class OSQP(QpSolver):
     def name(self):
         return s.OSQP
 
-    def import_solver(self):
+    def import_solver(self) -> None:
         import osqp
         osqp
 

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -16,13 +16,13 @@ class XPRESS(QpSolver):
 
     MIP_CAPABLE = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.prob_ = None
 
     def name(self):
         return s.XPRESS
 
-    def import_solver(self):
+    def import_solver(self) -> None:
 
         import xpress
         xpress  # Prevents flake8 warning

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -51,7 +51,7 @@ class Solver(Reduction):
         """
         raise NotImplementedError()
 
-    def is_installed(self):
+    def is_installed(self) -> bool:
         """Is the solver installed?
         """
         try:

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -21,6 +21,7 @@ from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.solver import Solver
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.utilities.debug_tools import build_non_disciplined_error_msg
+from typing import Any, List
 
 
 def _is_lp(self):
@@ -45,7 +46,7 @@ def _solve_as_qp(problem, candidates):
     return candidates['qp_solvers'] and qp2symbolic_qp.accepts(problem)
 
 
-def _reductions_for_problem_class(problem, candidates, gp=False):
+def _reductions_for_problem_class(problem, candidates, gp: bool=False) -> List[Any]:
     """
     Builds a chain that rewrites a problem into an intermediate
     representation suitable for numeric reductions.
@@ -116,7 +117,7 @@ def _reductions_for_problem_class(problem, candidates, gp=False):
     return reductions
 
 
-def construct_solving_chain(problem, candidates, gp=False, enforce_dpp=False):
+def construct_solving_chain(problem, candidates, gp: bool=False, enforce_dpp: bool=False) -> "SolvingChain":
     """Build a reduction chain from a problem to an installed solver.
 
     Note that if the supplied problem has 0 variables, then the solver
@@ -259,14 +260,14 @@ class SolvingChain(Chain):
         The solver, i.e., reductions[-1].
     """
 
-    def __init__(self, problem=None, reductions=[]):
+    def __init__(self, problem=None, reductions=[]) -> None:
         super(SolvingChain, self).__init__(problem=problem,
                                            reductions=reductions)
         if not isinstance(self.reductions[-1], Solver):
             raise ValueError("Solving chains must terminate with a Solver.")
         self.solver = self.reductions[-1]
 
-    def prepend(self, chain):
+    def prepend(self, chain) -> "SolvingChain":
         """
         Create and return a new SolvingChain by concatenating
         chain with this instance.

--- a/cvxpy/reductions/solvers/utilities.py
+++ b/cvxpy/reductions/solvers/utilities.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 """
 Copyright 2013 Steven Diamond
 
@@ -18,7 +20,7 @@ import cvxpy.interface as intf
 import numpy as np
 
 
-def expcone_permutor(n_cones, exp_cone_order):
+def expcone_permutor(n_cones, exp_cone_order) -> np.ndarray:
     order = np.tile(np.array(exp_cone_order), n_cones)  # e.g. [1,0,2, 1,0,2, 1,0,2,...
     offsets = 3 * np.repeat(np.arange(n_cones), 3)  # [0,0,0, 3,3,3, 6,6,6, ...
     perm = order + offsets
@@ -33,7 +35,7 @@ def extract_dual_value(result_vec, offset, constraint):
     return value, offset
 
 
-def get_dual_values(result_vec, parse_func, constraints):
+def get_dual_values(result_vec, parse_func, constraints) -> Dict[Any, Any]:
     """Gets the values of the dual variables.
 
     Parameters

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -56,7 +56,7 @@ def special_index_canon(expr, args):
     return lowered, []
 
 
-def are_args_affine(constraints):
+def are_args_affine(constraints) -> bool:
     return all(arg.is_affine() for constr in constraints
                for arg in constr.args)
 

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -175,10 +175,10 @@ SPARSE_PROJECTION_TOL = 1e-10
 NUM_THREADS = -1
 
 
-def set_num_threads(num_threads):
+def set_num_threads(num_threads: int) -> None:
     global NUM_THREADS
     NUM_THREADS = num_threads
 
 
-def get_num_threads():
+def get_num_threads() -> int:
     return NUM_THREADS

--- a/cvxpy/tests/base_test.py
+++ b/cvxpy/tests/base_test.py
@@ -21,7 +21,7 @@ import numpy as np
 
 class BaseTest(unittest.TestCase):
     # AssertAlmostEqual for lists.
-    def assertItemsAlmostEqual(self, a, b, places=5):
+    def assertItemsAlmostEqual(self, a, b, places: int=5) -> None:
         if np.isscalar(a):
             a = [a]
         else:
@@ -34,7 +34,7 @@ class BaseTest(unittest.TestCase):
             self.assertAlmostEqual(a[i], b[i], places)
 
     # Overridden method to assume lower accuracy.
-    def assertAlmostEqual(self, a, b, places=5, delta=None):
+    def assertAlmostEqual(self, a, b, places: int=5, delta=None) -> None:
         super(BaseTest, self).assertAlmostEqual(a, b, places=places, delta=delta)
 
     def mat_to_list(self, mat):

--- a/cvxpy/tests/ram_limited.py
+++ b/cvxpy/tests/ram_limited.py
@@ -29,7 +29,7 @@ The tests here are run on a case-by-case basis by CVXPY developers.
 """
 
 
-def issue826():
+def issue826() -> None:
     # In GitHub issue #826, it was discovered that cvxcore's C++
     # implementation implicitly limited problem data (such as a
     # constraint matrix) to have at most 2^(32)-1 nonzero entries.

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -21,7 +21,7 @@ from cvxpy.tests.base_test import BaseTest
 
 class SolverTestHelper(object):
 
-    def __init__(self, obj_pair, var_pairs, con_pairs):
+    def __init__(self, obj_pair, var_pairs, con_pairs) -> None:
         self.objective = obj_pair[0]
         self.constraints = [c for c, _ in con_pairs]
         self.prob = cp.Problem(self.objective, self.constraints)
@@ -32,10 +32,10 @@ class SolverTestHelper(object):
         self.expect_prim_vars = [pv for _, pv in var_pairs]
         self.tester = BaseTest()
 
-    def solve(self, solver, **kwargs):
+    def solve(self, solver, **kwargs) -> None:
         self.prob.solve(solver=solver, **kwargs)
 
-    def check_primal_feasibility(self, places):
+    def check_primal_feasibility(self, places) -> None:
         all_cons = [c for c in self.constraints]  # shallow copy
         for x in self.prob.variables():
             attrs = x.attributes
@@ -64,7 +64,7 @@ class SolverTestHelper(object):
                 viol = np.linalg.norm(viol, ord=2)
             self.tester.assertAlmostEqual(viol, 0, places)
 
-    def check_dual_domains(self, places):
+    def check_dual_domains(self, places) -> None:
         # A full "dual feasibility" check would involve checking a stationary Lagrangian.
         # No such test is planned here.
         #
@@ -102,7 +102,7 @@ class SolverTestHelper(object):
             else:
                 raise ValueError('Unknown constraint type %s.' % type(con))
 
-    def check_complementarity(self, places):
+    def check_complementarity(self, places) -> None:
         # TODO: once dual variables are stored for attributes
         #   (e.g. X = Variable(shape=(n,n), PSD=True)), check
         #   complementarity against the dual variable of the
@@ -130,20 +130,20 @@ class SolverTestHelper(object):
                 raise ValueError('Unknown constraint type %s.' % type(con))
             self.tester.assertAlmostEqual(comp, 0, places)
 
-    def verify_objective(self, places):
+    def verify_objective(self, places) -> None:
         actual = self.prob.value
         expect = self.expect_val
         if expect is not None:
             self.tester.assertAlmostEqual(actual, expect, places)
 
-    def verify_primal_values(self, places):
+    def verify_primal_values(self, places) -> None:
         for idx in range(len(self.variables)):
             actual = self.variables[idx].value
             expect = self.expect_prim_vars[idx]
             if expect is not None:
                 self.tester.assertItemsAlmostEqual(actual, expect, places)
 
-    def verify_dual_values(self, places):
+    def verify_dual_values(self, places) -> None:
         for idx in range(len(self.constraints)):
             actual = self.constraints[idx].dual_value
             expect = self.expect_dual_vars[idx]
@@ -157,7 +157,7 @@ class SolverTestHelper(object):
                     self.tester.assertItemsAlmostEqual(actual, expect, places)
 
 
-def lp_0():
+def lp_0() -> SolverTestHelper:
     x = cp.Variable(shape=(2,))
     con_pairs = [(x == 0, None)]
     obj_pair = (cp.Minimize(cp.norm(x, 1) + 1.0), 1)
@@ -166,7 +166,7 @@ def lp_0():
     return sth
 
 
-def lp_1():
+def lp_1() -> SolverTestHelper:
     # Example from
     # http://cvxopt.org/userguide/coneprog.html?highlight=solvers.lp#cvxopt.solvers.lp
     x = cp.Variable(shape=(2,), name='x')
@@ -185,7 +185,7 @@ def lp_1():
     return sth
 
 
-def lp_2():
+def lp_2() -> SolverTestHelper:
     x = cp.Variable(shape=(2,), name='x')
     objective = cp.Minimize(x[0] + 0.5 * x[1])
     constraints = [x[0] >= -100, x[0] <= -10, x[1] == 1]
@@ -198,7 +198,7 @@ def lp_2():
     return sth
 
 
-def lp_3():
+def lp_3() -> SolverTestHelper:
     # an unbounded problem
     x = cp.Variable(5)
     objective = (cp.Minimize(cp.sum(x)), -np.inf)
@@ -208,7 +208,7 @@ def lp_3():
     return sth
 
 
-def lp_4():
+def lp_4() -> SolverTestHelper:
     # an infeasible problem
     x = cp.Variable(5)
     objective = (cp.Minimize(cp.sum(x)), np.inf)
@@ -219,7 +219,7 @@ def lp_4():
     return sth
 
 
-def lp_5():
+def lp_5() -> SolverTestHelper:
     # a problem with redundant equality constraints.
     #
     # 10 variables, 6 equality constraints A @ x == b (two redundant)
@@ -243,7 +243,7 @@ def lp_5():
     return sth
 
 
-def socp_0():
+def socp_0() -> SolverTestHelper:
     x = cp.Variable(shape=(2,))
     obj_pair = (cp.Minimize(cp.norm(x, 2) + 1), 1)
     con_pairs = [(x == 0, None)]
@@ -252,7 +252,7 @@ def socp_0():
     return sth
 
 
-def socp_1():
+def socp_1() -> SolverTestHelper:
     """
     min 3 * x[0] + 2 * x[1] + x[2]
     s.t. norm(x,2) <= y
@@ -282,7 +282,7 @@ def socp_1():
     return sth
 
 
-def socp_2():
+def socp_2() -> SolverTestHelper:
     """
     An (unnecessarily) SOCP-based reformulation of LP_1.
     """
@@ -303,7 +303,7 @@ def socp_2():
     return sth
 
 
-def socp_3(axis):
+def socp_3(axis) -> SolverTestHelper:
     x = cp.Variable(shape=(2,))
     c = np.array([-1, 2])
     root2 = np.sqrt(2)
@@ -337,7 +337,7 @@ def socp_3(axis):
     return sth
 
 
-def sdp_1(objective_sense):
+def sdp_1(objective_sense) -> SolverTestHelper:
     """
     Solve "Example 8.3" from Convex Optimization by Boyd & Vandenberghe.
 
@@ -366,7 +366,7 @@ def sdp_1(objective_sense):
     return sth
 
 
-def sdp_2():
+def sdp_2() -> SolverTestHelper:
     """
     Example SDO2 from MOSEK 9.2 documentation.
     """
@@ -402,7 +402,7 @@ def sdp_2():
     return sth
 
 
-def expcone_1():
+def expcone_1() -> SolverTestHelper:
     """
     min   3 * x[0] + 2 * x[1] + x[2]
     s.t.  0.1 <= x[0] + x[1] + x[2] <= 1
@@ -428,7 +428,7 @@ def expcone_1():
     return sth
 
 
-def expcone_socp_1():
+def expcone_socp_1() -> SolverTestHelper:
     """
     A random risk-parity portfolio optimization problem.
     """
@@ -461,7 +461,7 @@ def expcone_socp_1():
     return sth
 
 
-def pcp_1():
+def pcp_1() -> SolverTestHelper:
     """
     Use a 3D power cone formulation for
 
@@ -500,7 +500,7 @@ def pcp_1():
     return sth
 
 
-def pcp_2():
+def pcp_2() -> SolverTestHelper:
     """
     Reformulate
 
@@ -536,7 +536,7 @@ def pcp_2():
     return sth
 
 
-def mi_lp_0():
+def mi_lp_0() -> SolverTestHelper:
     x = cp.Variable(shape=(2,))
     bool_var = cp.Variable(boolean=True)
     con_pairs = [(x == bool_var, None),
@@ -548,7 +548,7 @@ def mi_lp_0():
     return sth
 
 
-def mi_lp_1():
+def mi_lp_1() -> SolverTestHelper:
     x = cp.Variable(2, name='x')
     boolvar = cp.Variable(boolean=True)
     intvar = cp.Variable(integer=True)
@@ -567,7 +567,7 @@ def mi_lp_1():
     return sth
 
 
-def mi_lp_2():
+def mi_lp_2() -> SolverTestHelper:
     # Instance "knapPI_1_50_1000_1" from "http://www.diku.dk/~pisinger/genhard.c"
     n = 50
     c = 995
@@ -599,7 +599,7 @@ def mi_lp_2():
     return sth
 
 
-def mi_lp_3():
+def mi_lp_3() -> SolverTestHelper:
     # infeasible (but relaxable) test case
     x = cp.Variable(4, boolean=True)
     from cvxpy.expressions.constants import Constant
@@ -619,7 +619,7 @@ def mi_lp_3():
     return sth
 
 
-def mi_socp_1():
+def mi_socp_1() -> SolverTestHelper:
     """
     Formulate the following mixed-integer SOCP with cvxpy
         min 3 * x[0] + 2 * x[1] + x[2] +  y[0] + 2 * y[1]
@@ -643,7 +643,7 @@ def mi_socp_1():
     return sth
 
 
-def mi_socp_2():
+def mi_socp_2() -> SolverTestHelper:
     """
     An (unnecessarily) SOCP-based reformulation of MI_LP_1.
     Doesn't use SOC objects.
@@ -666,7 +666,7 @@ def mi_socp_2():
     return sth
 
 
-def mi_pcp_0():
+def mi_pcp_0() -> SolverTestHelper:
     """
     max  x3 + x4 - x0
     s.t. x0 + x1 + x2 / 2 == 2,
@@ -701,7 +701,7 @@ def mi_pcp_0():
 class StandardTestLPs(object):
 
     @staticmethod
-    def test_lp_0(solver, places=4, duals=True, **kwargs):
+    def test_lp_0(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = lp_0()
         sth.solve(solver, **kwargs)
         sth.verify_primal_values(places)
@@ -710,7 +710,7 @@ class StandardTestLPs(object):
             sth.check_complementarity(places)
 
     @staticmethod
-    def test_lp_1(solver, places=4, duals=True, **kwargs):
+    def test_lp_1(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = lp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -719,7 +719,7 @@ class StandardTestLPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_lp_2(solver, places=4, duals=True, **kwargs):
+    def test_lp_2(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = lp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -728,19 +728,19 @@ class StandardTestLPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_lp_3(solver, places=4, **kwargs):
+    def test_lp_3(solver, places: int=4, **kwargs) -> None:
         sth = lp_3()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
 
     @staticmethod
-    def test_lp_4(solver, places=4, **kwargs):
+    def test_lp_4(solver, places: int=4, **kwargs) -> None:
         sth = lp_4()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
 
     @staticmethod
-    def test_lp_5(solver, places=4, duals=True,  **kwargs):
+    def test_lp_5(solver, places: int=4, duals: bool=True,  **kwargs) -> None:
         sth = lp_5()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -750,28 +750,28 @@ class StandardTestLPs(object):
             sth.check_dual_domains(places)
 
     @staticmethod
-    def test_mi_lp_0(solver, places=4, **kwargs):
+    def test_mi_lp_0(solver, places: int=4, **kwargs) -> None:
         sth = mi_lp_0()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
 
     @staticmethod
-    def test_mi_lp_1(solver, places=4, **kwargs):
+    def test_mi_lp_1(solver, places: int=4, **kwargs) -> None:
         sth = mi_lp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
 
     @staticmethod
-    def test_mi_lp_2(solver, places=4, **kwargs):
+    def test_mi_lp_2(solver, places: int=4, **kwargs) -> None:
         sth = mi_lp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
 
     @staticmethod
-    def test_mi_lp_3(solver, places=4, **kwargs):
+    def test_mi_lp_3(solver, places: int=4, **kwargs) -> None:
         sth = mi_lp_3()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -781,7 +781,7 @@ class StandardTestLPs(object):
 class StandardTestSOCPs(object):
 
     @staticmethod
-    def test_socp_0(solver, places=4, duals=True, **kwargs):
+    def test_socp_0(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = socp_0()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -790,7 +790,7 @@ class StandardTestSOCPs(object):
             sth.check_complementarity(places)
 
     @staticmethod
-    def test_socp_1(solver, places=4, duals=True, **kwargs):
+    def test_socp_1(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -800,7 +800,7 @@ class StandardTestSOCPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_socp_2(solver, places=4, duals=True, **kwargs):
+    def test_socp_2(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = socp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -810,7 +810,7 @@ class StandardTestSOCPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_socp_3ax0(solver, places=3, duals=True, **kwargs):
+    def test_socp_3ax0(solver, places: int=3, duals: bool=True, **kwargs) -> None:
         sth = socp_3(axis=0)
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -820,7 +820,7 @@ class StandardTestSOCPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_socp_3ax1(solver, places=3, duals=True, **kwargs):
+    def test_socp_3ax1(solver, places: int=3, duals: bool=True, **kwargs) -> None:
         sth = socp_3(axis=1)
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -830,14 +830,14 @@ class StandardTestSOCPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_mi_socp_1(solver, places=4, **kwargs):
+    def test_mi_socp_1(solver, places: int=4, **kwargs) -> None:
         sth = mi_socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
 
     @staticmethod
-    def test_mi_socp_2(solver, places=4, **kwargs):
+    def test_mi_socp_2(solver, places: int=4, **kwargs) -> None:
         sth = mi_socp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -847,7 +847,7 @@ class StandardTestSOCPs(object):
 class StandardTestSDPs(object):
 
     @staticmethod
-    def test_sdp_1min(solver, places=4, duals=True, **kwargs):
+    def test_sdp_1min(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = sdp_1('min')
         sth.solve(solver, **kwargs)
         sth.verify_objective(places=2)  # only 2 digits recorded.
@@ -857,7 +857,7 @@ class StandardTestSDPs(object):
             sth.check_dual_domains(places)
 
     @staticmethod
-    def test_sdp_1max(solver, places=4, duals=True, **kwargs):
+    def test_sdp_1max(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = sdp_1('max')
         sth.solve(solver, **kwargs)
         sth.verify_objective(places=2)  # only 2 digits recorded.
@@ -867,7 +867,7 @@ class StandardTestSDPs(object):
             sth.check_dual_domains(places)
 
     @staticmethod
-    def test_sdp_2(solver, places=3, duals=True, **kwargs):
+    def test_sdp_2(solver, places: int=3, duals: bool=True, **kwargs) -> None:
         # places is set to 3 rather than 4, because analytic solution isn't known.
         sth = sdp_2()
         sth.solve(solver, **kwargs)
@@ -882,7 +882,7 @@ class StandardTestSDPs(object):
 class StandardTestECPs(object):
 
     @staticmethod
-    def test_expcone_1(solver, places=4, duals=True, **kwargs):
+    def test_expcone_1(solver, places: int=4, duals: bool=True, **kwargs) -> None:
         sth = expcone_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -895,7 +895,7 @@ class StandardTestECPs(object):
 class StandardTestMixedCPs(object):
 
     @staticmethod
-    def test_exp_soc_1(solver, places=3, duals=True, **kwargs):
+    def test_exp_soc_1(solver, places: int=3, duals: bool=True, **kwargs) -> None:
         sth = expcone_socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -908,7 +908,7 @@ class StandardTestMixedCPs(object):
 class StandardTestPCPs(object):
 
     @staticmethod
-    def test_pcp_1(solver, places=3, duals=True, **kwargs):
+    def test_pcp_1(solver, places: int=3, duals: bool=True, **kwargs) -> None:
         sth = pcp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -918,7 +918,7 @@ class StandardTestPCPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_pcp_2(solver, places=3, duals=True, **kwargs):
+    def test_pcp_2(solver, places: int=3, duals: bool=True, **kwargs) -> None:
         sth = pcp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -928,7 +928,7 @@ class StandardTestPCPs(object):
             sth.verify_dual_values(places)
 
     @staticmethod
-    def test_mi_pcp_0(solver, places=3, **kwargs):
+    def test_mi_pcp_0(solver, places: int=3, **kwargs) -> None:
         sth = mi_pcp_0()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -31,7 +31,7 @@ import scipy.stats
 class TestAtoms(BaseTest):
     """ Unit tests for the atoms module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
 
         self.x = Variable(2, name='x')
@@ -41,7 +41,7 @@ class TestAtoms(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-    def test_add_expr_copy(self):
+    def test_add_expr_copy(self) -> None:
         """Test the copy function for AddExpresion class.
         """
         atom = self.x + self.y
@@ -59,7 +59,7 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[1] is self.B)
         self.assertEqual(copy.get_data(), atom.get_data())
 
-    def test_norm_inf(self):
+    def test_norm_inf(self) -> None:
         """Test the norm_inf class.
         """
         exp = self.x+self.y
@@ -72,7 +72,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.norm_inf(atom).curvature, s.CONVEX)
         self.assertEqual(cp.norm_inf(-atom).curvature, s.CONVEX)
 
-    def test_norm1(self):
+    def test_norm1(self) -> None:
         """Test the norm1 class.
         """
         exp = self.x+self.y
@@ -83,7 +83,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.norm1(atom).curvature, s.CONVEX)
         self.assertEqual(cp.norm1(-atom).curvature, s.CONVEX)
 
-    def test_list_input(self):
+    def test_list_input(self) -> None:
         """Test that list input is rejected.
         """
         with self.assertRaises(Exception) as cm:
@@ -106,14 +106,14 @@ class TestAtoms(BaseTest):
             "The input must be a single CVXPY Expression, not a list. "
             "Combine Expressions using atoms such as bmat, hstack, and vstack."))
 
-    def test_quad_form(self):
+    def test_quad_form(self) -> None:
         """Test quad_form atom.
         """
         P = Parameter((2, 2), symmetric=True)
         expr = cp.quad_form(self.x, P)
         assert not expr.is_dcp()
 
-    def test_power(self):
+    def test_power(self) -> None:
         """Test the power class.
         """
         from fractions import Fraction
@@ -157,7 +157,7 @@ class TestAtoms(BaseTest):
         assert cp.power(-1, 2).value == 1
 
     # Test the geo_mean class.
-    def test_geo_mean(self):
+    def test_geo_mean(self) -> None:
         atom = cp.geo_mean(self.x)
         self.assertEqual(atom.shape, tuple())
         self.assertEqual(atom.curvature, s.CONCAVE)
@@ -177,14 +177,14 @@ class TestAtoms(BaseTest):
         self.assertEqual(copy.get_data(), atom.get_data())
 
     # Test the harmonic_mean class.
-    def test_harmonic_mean(self):
+    def test_harmonic_mean(self) -> None:
         atom = cp.harmonic_mean(self.x)
         self.assertEqual(atom.shape, tuple())
         self.assertEqual(atom.curvature, s.CONCAVE)
         self.assertEqual(atom.sign, s.NONNEG)
 
     # Test the pnorm class.
-    def test_pnorm(self):
+    def test_pnorm(self) -> None:
         atom = cp.pnorm(self.x, p=1.5)
         self.assertEqual(atom.shape, tuple())
         self.assertEqual(atom.curvature, s.CONVEX)
@@ -256,7 +256,7 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[0] is self.y)
         self.assertEqual(copy.get_data(), atom.get_data())
 
-    def test_matrix_norms(self):
+    def test_matrix_norms(self) -> None:
         """
         Matrix 1-norm, 2-norm (sigma_max), infinity-norm,
             Frobenius norm, and nuclear-norm.
@@ -271,7 +271,7 @@ class TestAtoms(BaseTest):
                 self.assertAlmostEqual(atom.value, np.linalg.norm(var.value, ord=p))
         pass
 
-    def test_quad_over_lin(self):
+    def test_quad_over_lin(self) -> None:
         # Test quad_over_lin DCP.
         atom = cp.quad_over_lin(cp.square(self.x), self.a)
         self.assertEqual(atom.curvature, s.CONVEX)
@@ -287,7 +287,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "The second argument to quad_over_lin must be a scalar.")
 
-    def test_elemwise_arg_count(self):
+    def test_elemwise_arg_count(self) -> None:
         """Test arg count for max and min variants.
         """
         with self.assertRaises(Exception) as cm:
@@ -302,7 +302,7 @@ class TestAtoms(BaseTest):
             "__init__() takes at least 3 arguments (2 given)",
             "__init__() missing 1 required positional argument: 'arg2'"))
 
-    def test_matrix_frac(self):
+    def test_matrix_frac(self) -> None:
         """Test for the matrix_frac atom.
         """
         atom = cp.matrix_frac(self.x, self.A)
@@ -319,7 +319,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "The arguments to matrix_frac have incompatible dimensions.")
 
-    def test_max(self):
+    def test_max(self) -> None:
         """Test max.
         """
         # One arg, test sign.
@@ -340,7 +340,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Invalid argument for axis.")
 
-    def test_min(self):
+    def test_min(self) -> None:
         """Test min.
         """
         # One arg, test sign.
@@ -362,7 +362,7 @@ class TestAtoms(BaseTest):
                          "Invalid argument for axis.")
 
     # Test sign logic for maximum.
-    def test_maximum_sign(self):
+    def test_maximum_sign(self) -> None:
         # Two args.
         self.assertEqual(cp.maximum(1, 2).sign, s.NONNEG)
         self.assertEqual(cp.maximum(1, Variable()).sign, s.NONNEG)
@@ -389,7 +389,7 @@ class TestAtoms(BaseTest):
                          (2,))
 
     # Test sign logic for minimum.
-    def test_minimum_sign(self):
+    def test_minimum_sign(self) -> None:
         # Two args.
         self.assertEqual(cp.minimum(1, 2).sign, s.NONNEG)
         self.assertEqual(cp.minimum(1, Variable()).sign, s.UNKNOWN)
@@ -415,7 +415,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.minimum(-1, Variable(2)).shape,
                          (2,))
 
-    def test_sum(self):
+    def test_sum(self) -> None:
         """Test the sum atom.
         """
         self.assertEqual(cp.sum(1).sign, s.NONNEG)
@@ -448,7 +448,7 @@ class TestAtoms(BaseTest):
         A = sp.eye(3)
         self.assertItemsAlmostEqual(cp.sum(A, axis=0).value, [1, 1, 1])
 
-    def test_multiply(self):
+    def test_multiply(self) -> None:
         """Test the multiply atom.
         """
         self.assertEqual(cp.multiply([1, -1], self.x).sign, s.UNKNOWN)
@@ -471,7 +471,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.multiply(self.x, [1, -1]).shape, (2,))
 
     # Test the vstack class.
-    def test_vstack(self):
+    def test_vstack(self) -> None:
         atom = cp.vstack([self.x, self.y, self.x])
         self.assertEqual(atom.name(), "Vstack(x, y, x)")
         self.assertEqual(atom.shape, (3, 2))
@@ -500,7 +500,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(TypeError) as cm:
             cp.vstack()
 
-    def test_reshape(self):
+    def test_reshape(self) -> None:
         """Test the reshape class.
         """
         expr = cp.reshape(self.A, (4, 1))
@@ -557,7 +557,7 @@ class TestAtoms(BaseTest):
         self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
         self.assertItemsAlmostEqual(b, X.value)
 
-    def test_vec(self):
+    def test_vec(self) -> None:
         """Test the vec atom.
         """
         expr = cp.vec(self.C)
@@ -573,7 +573,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(expr.curvature, s.CONVEX)
         self.assertEqual(expr.shape, (1,))
 
-    def test_diag(self):
+    def test_diag(self) -> None:
         """Test the diag atom.
         """
         expr = cp.diag(self.x)
@@ -612,7 +612,7 @@ class TestAtoms(BaseTest):
         self.assertFalse(expr.is_psd())
         self.assertFalse(expr.is_nsd())
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         """Test the trace atom.
         """
         expr = cp.trace(self.A)
@@ -625,7 +625,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Argument to trace must be a square matrix.")
 
-    def test_log1p(self):
+    def test_log1p(self) -> None:
         """Test the log1p atom.
         """
         expr = cp.log1p(1)
@@ -635,13 +635,13 @@ class TestAtoms(BaseTest):
         expr = cp.log1p(-0.5)
         self.assertEqual(expr.sign, s.NONPOS)
 
-    def test_upper_tri(self):
+    def test_upper_tri(self) -> None:
         with self.assertRaises(Exception) as cm:
             cp.upper_tri(self.C)
         self.assertEqual(str(cm.exception),
                          "Argument to upper_tri must be a square matrix.")
 
-    def test_vec_to_upper_tri(self):
+    def test_vec_to_upper_tri(self) -> None:
         from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
         x = Variable(shape=(3,))
         X = vec_to_upper_tri(x)
@@ -663,7 +663,7 @@ class TestAtoms(BaseTest):
         A_actual = vec_to_upper_tri(a, strict=True).value
         assert np.allclose(A_actual, A_expect)
 
-    def test_huber(self):
+    def test_huber(self) -> None:
         # Valid.
         cp.huber(self.x, 1)
 
@@ -706,7 +706,7 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[0] is self.y)
         self.assertEqual(copy.get_data()[0].value, atom.get_data()[0].value)
 
-    def test_sum_largest(self):
+    def test_sum_largest(self) -> None:
         """Test the sum_largest atom and related atoms.
         """
         with self.assertRaises(Exception) as cm:
@@ -748,7 +748,7 @@ class TestAtoms(BaseTest):
         copy = atom.copy()
         self.assertTrue(type(copy) is type(atom))
 
-    def test_sum_smallest(self):
+    def test_sum_smallest(self) -> None:
         """Test the sum_smallest atom and related atoms.
         """
         with self.assertRaises(Exception) as cm:
@@ -761,7 +761,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Second argument must be a positive integer.")
 
-    def test_index(self):
+    def test_index(self) -> None:
         """Test the copy function for index.
         """
         # Test copy with args=None
@@ -782,7 +782,7 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[0] is B)
         self.assertEqual(copy.get_data(), atom.get_data())
 
-    def test_bmat(self):
+    def test_bmat(self) -> None:
         """Test the bmat atom.
         """
         v_np = np.ones((3, 1))
@@ -795,7 +795,7 @@ class TestAtoms(BaseTest):
                                       np.array([[1, 2]]).T])])
         self.assertItemsAlmostEqual(expr, const)
 
-    def test_conv(self):
+    def test_conv(self) -> None:
         """Test the conv atom.
         """
         a = np.ones((3, 1))
@@ -815,7 +815,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "The arguments to conv must resolve to vectors.")
 
-    def test_kron(self):
+    def test_kron(self) -> None:
         """Test the kron atom.
         """
         a = np.ones((3, 2))
@@ -831,7 +831,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "The first argument to kron must be constant.")
 
-    def test_partial_optimize_dcp(self):
+    def test_partial_optimize_dcp(self) -> None:
         """Test DCP properties of partial optimize.
         """
         # Evaluate the 1-norm in the usual way (i.e., in epigraph form).
@@ -850,7 +850,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(g.is_convex(), False)
         self.assertEqual(g.is_concave(), False)
 
-    def test_partial_optimize_eval_1norm(self):
+    def test_partial_optimize_eval_1norm(self) -> None:
         """Test the partial_optimize atom.
         """
         # Evaluate the 1-norm in the usual way (i.e., in epigraph form).
@@ -901,7 +901,7 @@ class TestAtoms(BaseTest):
                           "they must contain all variables in the problem.")
                          )
 
-    def test_partial_optimize_min_1norm(self):
+    def test_partial_optimize_min_1norm(self) -> None:
         # Minimize the 1-norm in the usual way
         dims = 3
         x, t = Variable(dims), Variable(dims)
@@ -915,7 +915,7 @@ class TestAtoms(BaseTest):
         p1.solve()
         self.assertAlmostEqual(p1.value, p2.value)
 
-    def test_partial_optimize_simple_problem(self):
+    def test_partial_optimize_simple_problem(self) -> None:
         x, y = Variable(1), Variable(1)
 
         # Solve the (simple) two-stage problem by "combining" the two stages
@@ -931,7 +931,7 @@ class TestAtoms(BaseTest):
         self.assertAlmostEqual(p1.value, p3.value)
 
     @unittest.skipUnless(len(INSTALLED_MI_SOLVERS) > 0, 'No mixed-integer solver is installed.')
-    def test_partial_optimize_special_var(self):
+    def test_partial_optimize_special_var(self) -> None:
         x, y = Variable(boolean=True), Variable(integer=True)
 
         # Solve the (simple) two-stage problem by "combining" the two stages
@@ -946,7 +946,7 @@ class TestAtoms(BaseTest):
         p3.solve(solver=cp.ECOS_BB)
         self.assertAlmostEqual(p1.value, p3.value)
 
-    def test_partial_optimize_special_constr(self):
+    def test_partial_optimize_special_constr(self) -> None:
         x, y = Variable(1), Variable(1)
 
         # Solve the (simple) two-stage problem by "combining" the two stages
@@ -961,7 +961,7 @@ class TestAtoms(BaseTest):
         p3.solve()
         self.assertAlmostEqual(p1.value, p3.value)
 
-    def test_partial_optimize_params(self):
+    def test_partial_optimize_params(self) -> None:
         """Test partial optimize with parameters.
         """
         x, y = Variable(1), Variable(1)
@@ -980,7 +980,7 @@ class TestAtoms(BaseTest):
         p3.solve()
         self.assertAlmostEqual(p1.value, p3.value)
 
-    def test_partial_optimize_numeric_fn(self):
+    def test_partial_optimize_numeric_fn(self) -> None:
         x, y = Variable(), Variable()
         xval = 4
 
@@ -1012,7 +1012,7 @@ class TestAtoms(BaseTest):
         self.assertAlmostEqual(y.value, 42)
         self.assertAlmostEqual(p2.constraints[0].dual_value, 42)
 
-    def test_partial_optimize_stacked(self):
+    def test_partial_optimize_stacked(self) -> None:
         """Minimize the 1-norm in the usual way
         """
         dims = 3
@@ -1028,7 +1028,7 @@ class TestAtoms(BaseTest):
         p1.solve()
         self.assertAlmostEqual(p1.value, p2.value)
 
-    def test_nonnegative_variable(self):
+    def test_nonnegative_variable(self) -> None:
         """Test the NonNegative Variable class.
         """
         x = Variable(nonneg=True)
@@ -1037,7 +1037,7 @@ class TestAtoms(BaseTest):
         self.assertAlmostEqual(p.value, 8)
         self.assertAlmostEqual(x.value, 3)
 
-    def test_mixed_norm(self):
+    def test_mixed_norm(self) -> None:
         """Test mixed norm.
         """
         y = Variable((5, 5))
@@ -1046,7 +1046,7 @@ class TestAtoms(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 5)
 
-    def test_mat_norms(self):
+    def test_mat_norms(self) -> None:
         """Test that norm1 and normInf match definition for matrices.
         """
         A = np.array([[1, 2], [3, 4]])
@@ -1064,7 +1064,7 @@ class TestAtoms(BaseTest):
         print(result)
         self.assertAlmostEqual(result, cp.norm(A, np.inf).value, places=3)
 
-    def test_indicator(self):
+    def test_indicator(self) -> None:
         x = cp.Variable()
         constraints = [0 <= x, x <= 1]
         expr = cp.transforms.indicator(constraints)
@@ -1073,20 +1073,20 @@ class TestAtoms(BaseTest):
         x.value = 2
         self.assertEqual(expr.value, np.inf)
 
-    def test_log_det(self):
+    def test_log_det(self) -> None:
         # test malformed input
         with self.assertRaises(ValueError) as cm:
             cp.log_det([[1, 2], [3, 4]]).value
         self.assertEqual(str(cm.exception),
                          "Input matrix was not Hermitian/symmetric.")
 
-    def test_lambda_max(self):
+    def test_lambda_max(self) -> None:
         with self.assertRaises(ValueError) as cm:
             cp.lambda_max([[1, 2], [3, 4]]).value
         self.assertEqual(str(cm.exception),
                          "Input matrix was not Hermitian/symmetric.")
 
-    def test_diff(self):
+    def test_diff(self) -> None:
         """Test the diff atom.
         """
         A = cp.Variable((20, 10))
@@ -1096,7 +1096,7 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.diff(A, axis=1).shape,
                          np.diff(B, axis=1).shape)
 
-    def test_log_normcdf(self):
+    def test_log_normcdf(self) -> None:
         self.assertEqual(cp.log_normcdf(self.x).sign, s.NONPOS)
         self.assertEqual(cp.log_normcdf(self.x).curvature, s.CONCAVE)
 

--- a/cvxpy/tests/test_benchmarks.py
+++ b/cvxpy/tests/test_benchmarks.py
@@ -7,7 +7,7 @@ import os
 import time
 
 
-def benchmark(func, iters=1, name=None):
+def benchmark(func, iters: int=1, name=None) -> None:
     vals = []
     for _ in range(iters):
         start = time.time()
@@ -19,7 +19,7 @@ def benchmark(func, iters=1, name=None):
 
 
 class TestBenchmarks(BaseTest):
-    def test_diffcp_sdp_example(self):
+    def test_diffcp_sdp_example(self) -> None:
 
         def randn_symm(n):
             A = np.random.randn(n, n)
@@ -44,7 +44,7 @@ class TestBenchmarks(BaseTest):
             problem.get_problem_data(cp.SCS)
         benchmark(diffcp_sdp, iters=1)
 
-    def test_tv_inpainting(self):
+    def test_tv_inpainting(self) -> None:
         if os.name == "nt":
             self.skipTest("Skipping test due to overflow bug in SciPy < 1.2.0.")
         Uorig = np.random.randn(512, 512, 3)
@@ -70,7 +70,7 @@ class TestBenchmarks(BaseTest):
             problem.get_problem_data(cp.SCS)
         benchmark(tv_inpainting, iters=1)
 
-    def test_least_squares(self):
+    def test_least_squares(self) -> None:
         m = 20
         n = 15
         A = np.random.randn(m, n)
@@ -82,7 +82,7 @@ class TestBenchmarks(BaseTest):
             cp.Problem(cp.Minimize(cost)).get_problem_data(cp.OSQP)
         benchmark(least_squares, iters=1)
 
-    def test_qp(self):
+    def test_qp(self) -> None:
         m = 15
         n = 10
         p = 5
@@ -101,7 +101,7 @@ class TestBenchmarks(BaseTest):
                        cp.matmul(A, x) == b]).get_problem_data(cp.OSQP)
         benchmark(qp, iters=1)
 
-    def test_cone_matrix_stuffing_with_many_constraints(self):
+    def test_cone_matrix_stuffing_with_many_constraints(self) -> None:
         m = 2000
         n = 2000
         A = np.random.randn(m, n)
@@ -121,7 +121,7 @@ class TestBenchmarks(BaseTest):
 
         benchmark(cone_matrix_stuffing_with_many_constraints, iters=1)
 
-    def test_parameterized_cone_matrix_stuffing_with_many_constraints(self):
+    def test_parameterized_cone_matrix_stuffing_with_many_constraints(self) -> None:
         self.skipTest("This benchmark takes too long.")
         m = 2000
         n = 2000
@@ -145,7 +145,7 @@ class TestBenchmarks(BaseTest):
 
         benchmark(parameterized_cone_matrix_stuffing, iters=1)
 
-    def test_small_cone_matrix_stuffing(self):
+    def test_small_cone_matrix_stuffing(self) -> None:
         m = 200
         n = 200
         A = np.random.randn(m, n)
@@ -165,7 +165,7 @@ class TestBenchmarks(BaseTest):
 
         benchmark(small_cone_matrix_stuffing, iters=10)
 
-    def test_small_parameterized_cone_matrix_stuffing(self):
+    def test_small_parameterized_cone_matrix_stuffing(self) -> None:
         m = 200
         n = 200
         A = cp.Parameter((m, n))
@@ -188,7 +188,7 @@ class TestBenchmarks(BaseTest):
 
         benchmark(small_parameterized_cone_matrix_stuffing, iters=1)
 
-    def test_small_lp(self):
+    def test_small_lp(self) -> None:
         m = 200
         n = 200
         A = np.random.randn(m, n)
@@ -206,7 +206,7 @@ class TestBenchmarks(BaseTest):
         benchmark(small_lp, iters=1)
         benchmark(small_lp, iters=1, name="small_lp_second_time")
 
-    def test_small_parameterized_lp(self):
+    def test_small_parameterized_lp(self) -> None:
         m = 200
         n = 200
         A = cp.Parameter((m, n))
@@ -228,7 +228,7 @@ class TestBenchmarks(BaseTest):
         benchmark(small_parameterized_lp, iters=1,
                   name="small_parameterized_lp_second_time")
 
-    def test_parameterized_qp(self):
+    def test_parameterized_qp(self) -> None:
         """Test speed of first solve with QP codepath and SOCP codepath.
         """
         m = 150

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -29,7 +29,7 @@ PY35 = sys.version_info >= (3, 5)
 class TestComplex(BaseTest):
     """ Unit tests for the expression/expression module. """
 
-    def test_variable(self):
+    def test_variable(self) -> None:
         """Test the Variable class.
         """
         x = Variable(2, complex=False)
@@ -54,7 +54,7 @@ class TestComplex(BaseTest):
             z.value = np.array([1., 0.])
         self.assertEqual(str(cm.exception), "Variable value must be imaginary.")
 
-    def test_parameter(self):
+    def test_parameter(self) -> None:
         """Test the parameter class.
         """
         x = Parameter(2, complex=False)
@@ -79,7 +79,7 @@ class TestComplex(BaseTest):
             z.value = np.array([1., 0.])
         self.assertEqual(str(cm.exception), "Parameter value must be imaginary.")
 
-    def test_constant(self):
+    def test_constant(self) -> None:
         """Test the parameter class.
         """
         x = Constant(2)
@@ -93,7 +93,7 @@ class TestComplex(BaseTest):
         assert z.is_complex()
         assert z.is_imag()
 
-    def test_objective(self):
+    def test_objective(self) -> None:
         """Test objectives.
         """
         x = Variable(complex=True)
@@ -105,7 +105,7 @@ class TestComplex(BaseTest):
             cvx.Maximize(x)
         self.assertEqual(str(cm.exception), "The 'maximize' objective must be real valued.")
 
-    def test_arithmetic(self):
+    def test_arithmetic(self) -> None:
         """Test basic arithmetic expressions.
         """
         x = Variable(complex=True)
@@ -141,7 +141,7 @@ class TestComplex(BaseTest):
         assert expr.is_complex()
         assert expr.is_imag()
 
-    def test_real(self):
+    def test_real(self) -> None:
         """Test real.
         """
         A = np.ones((2, 2))
@@ -156,7 +156,7 @@ class TestComplex(BaseTest):
         expr = cvx.imag(x) + cvx.real(x)
         assert expr.is_real()
 
-    def test_imag(self):
+    def test_imag(self) -> None:
         """Test imag.
         """
         A = np.ones((2, 2))
@@ -167,7 +167,7 @@ class TestComplex(BaseTest):
         assert not expr.is_imag()
         self.assertItemsAlmostEqual(expr.value, 2*A)
 
-    def test_conj(self):
+    def test_conj(self) -> None:
         """Test imag.
         """
         A = np.ones((2, 2))
@@ -178,7 +178,7 @@ class TestComplex(BaseTest):
         assert not expr.is_imag()
         self.assertItemsAlmostEqual(expr.value, A - 1j*A)
 
-    def test_affine_atoms_canon(self):
+    def test_affine_atoms_canon(self) -> None:
         """Test canonicalization for affine atoms.
         """
         # Scalar.
@@ -229,7 +229,7 @@ class TestComplex(BaseTest):
         self.assertItemsAlmostEqual(y.value, 1j*np.ones((3, 2)))
         self.assertItemsAlmostEqual(x.value, np.zeros((2, 2)))
 
-    def test_params(self):
+    def test_params(self) -> None:
         """Test with parameters.
         """
         p = cvx.Parameter(imag=True, value=1j)
@@ -240,7 +240,7 @@ class TestComplex(BaseTest):
         val = np.ones(2)*np.sqrt(2)
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
 
-    def test_missing_imag(self):
+    def test_missing_imag(self) -> None:
         """Test problems where imaginary is missing.
         """
         Z = Variable((2, 2), hermitian=True)
@@ -255,7 +255,7 @@ class TestComplex(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 0)
 
-    def test_abs(self):
+    def test_abs(self) -> None:
         """Test with absolute value.
         """
         x = Variable(2, complex=True)
@@ -265,7 +265,7 @@ class TestComplex(BaseTest):
         val = np.ones(2)*np.sqrt(2)
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
 
-    def test_soc(self):
+    def test_soc(self) -> None:
         """Test with SOC.
         """
         x = Variable(2, complex=True)
@@ -275,7 +275,7 @@ class TestComplex(BaseTest):
         self.assertAlmostEqual(result, 2*np.sqrt(2))
         self.assertItemsAlmostEqual(x.value, [2j, 2j])
 
-    def test_pnorm(self):
+    def test_pnorm(self) -> None:
         """Test complex with pnorm.
         """
         x = Variable((1, 2), complex=True)
@@ -293,7 +293,7 @@ class TestComplex(BaseTest):
         val = np.ones((2, 2))
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
 
-    def test_matrix_norms(self):
+    def test_matrix_norms(self) -> None:
         """Test matrix norms.
         """
         P = np.arange(8) - 2j*np.arange(8)
@@ -310,7 +310,7 @@ class TestComplex(BaseTest):
         result = prob.solve(solver=cvx.SCS, eps=1e-4)
         self.assertAlmostEqual(result, norm_nuc, places=1)
 
-    def test_log_det(self):
+    def test_log_det(self) -> None:
         """Test log det.
         """
         P = np.arange(9) - 2j*np.arange(9)
@@ -322,7 +322,7 @@ class TestComplex(BaseTest):
         result = prob.solve(solver=cvx.SCS, eps=1e-6)
         self.assertAlmostEqual(result, value, places=2)
 
-    def test_eigval_atoms(self):
+    def test_eigval_atoms(self) -> None:
         """Test eigenvalue atoms.
         """
         P = np.arange(9) - 2j*np.arange(9)
@@ -350,7 +350,7 @@ class TestComplex(BaseTest):
             result = prob.solve(solver=cvx.SCS, eps=1e-6)
             self.assertAlmostEqual(result, value, places=3)
 
-    def test_quad_form(self):
+    def test_quad_form(self) -> None:
         """Test quad_form atom.
         """
         # Create a random positive definite Hermitian matrix for all tests.
@@ -385,7 +385,7 @@ class TestComplex(BaseTest):
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization)
 
-    def test_matrix_frac(self):
+    def test_matrix_frac(self) -> None:
         """Test matrix_frac atom.
         """
         P = np.array([[10, 1j], [-1j, 10]])
@@ -414,7 +414,7 @@ class TestComplex(BaseTest):
         result = prob.solve(solver=cvx.SCS, eps=1e-5, max_iters=7500)
         self.assertAlmostEqual(result, value, places=3)
 
-    def test_quad_over_lin(self):
+    def test_quad_over_lin(self) -> None:
         """Test quad_over_lin atom.
         """
         P = np.array([[10, 1j], [-1j, 10]])
@@ -434,7 +434,7 @@ class TestComplex(BaseTest):
         self.assertAlmostEqual(result, 0, places=3)
         self.assertItemsAlmostEqual(X.value, P, places=3)
 
-    def test_hermitian(self):
+    def test_hermitian(self) -> None:
         """Test Hermitian variables.
         """
         X = Variable((2, 2), hermitian=True)
@@ -443,7 +443,7 @@ class TestComplex(BaseTest):
         prob.solve()
         self.assertItemsAlmostEqual(X.value, [2, 1-1j, 1+1j, 3])
 
-    def test_psd(self):
+    def test_psd(self) -> None:
         """Test Hermitian variables.
         """
         X = Variable((2, 2), hermitian=True)
@@ -452,7 +452,7 @@ class TestComplex(BaseTest):
         prob.solve()
         assert prob.status is cvx.INFEASIBLE
 
-    def test_promote(self):
+    def test_promote(self) -> None:
         """Test promotion of complex variables.
         """
         v = Variable(complex=True)
@@ -462,7 +462,7 @@ class TestComplex(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 4.0)
 
-    def test_sparse(self):
+    def test_sparse(self) -> None:
         """Test problem with complex sparse matrix.
         """
         # define sparse matrix [[0, 1j],[-1j,0]]
@@ -490,7 +490,7 @@ class TestComplex(BaseTest):
         prob.solve()
         self.assertItemsAlmostEqual(rho.value, rho_sparse)
 
-    def test_special_idx(self):
+    def test_special_idx(self) -> None:
         """Test with special index.
         """
         c = [0, 1]
@@ -508,7 +508,7 @@ class TestComplex(BaseTest):
         prob = cvx.Problem(obj, constraints)
         prob.solve()
 
-    def test_validation(self):
+    def test_validation(self) -> None:
         """Test that complex arguments are rejected.
         """
         x = Variable(complex=True)
@@ -555,7 +555,7 @@ class TestComplex(BaseTest):
                 atom(x)
             self.assertEqual(str(cm.exception), "pnorm(x, p) cannot have x complex for p < 1.")
 
-    def test_diag(self):
+    def test_diag(self) -> None:
         """Test diag of mat, and of vector.
         """
         X = cvx.Variable((2, 2), complex=True)
@@ -573,7 +573,7 @@ class TestComplex(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 2)
 
-    def test_complex_qp(self):
+    def test_complex_qp(self) -> None:
         """Test a QP with a complex variable.
         """
         A0 = np.array([0+1j, 2-1j])

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -37,7 +37,7 @@ from cvxpy.tests.solver_test_helpers import (
 
 class TestECOS(BaseTest):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -50,7 +50,7 @@ class TestECOS(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_ecos_options(self):
+    def test_ecos_options(self) -> None:
         """Test that all the ECOS solver options work.
         """
         # Test ecos
@@ -66,50 +66,50 @@ class TestECOS(BaseTest):
         self.assertAlmostEqual(prob.value, 1.0)
         self.assertItemsAlmostEqual(self.x.value, [0, 0])
 
-    def test_ecos_lp_0(self):
+    def test_ecos_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='ECOS')
 
-    def test_ecos_lp_1(self):
+    def test_ecos_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='ECOS')
 
-    def test_ecos_lp_2(self):
+    def test_ecos_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='ECOS')
 
-    def test_ecos_lp_3(self):
+    def test_ecos_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='ECOS')
 
-    def test_ecos_lp_4(self):
+    def test_ecos_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='ECOS')
 
-    def test_ecos_lp_5(self):
+    def test_ecos_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='ECOS')
 
-    def test_ecos_socp_0(self):
+    def test_ecos_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='ECOS')
 
-    def test_ecos_socp_1(self):
+    def test_ecos_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='ECOS')
 
-    def test_ecos_socp_2(self):
+    def test_ecos_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='ECOS')
 
-    def test_ecos_socp_3(self):
+    def test_ecos_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='ECOS')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='ECOS')
 
-    def test_ecos_expcone_1(self):
+    def test_ecos_expcone_1(self) -> None:
         StandardTestECPs.test_expcone_1(solver='ECOS')
 
-    def test_ecos_exp_soc_1(self):
+    def test_ecos_exp_soc_1(self) -> None:
         StandardTestMixedCPs.test_exp_soc_1(solver='ECOS')
 
 
 class TestSCS(BaseTest):
 
     """ Unit tests for SCS. """
-    def setUp(self):
+    def setUp(self) -> None:
         self.x = cp.Variable(2, name='x')
         self.y = cp.Variable(2, name='y')
 
@@ -118,14 +118,14 @@ class TestSCS(BaseTest):
         self.C = cp.Variable((3, 2), name='C')
 
     # Overridden method to assume lower accuracy.
-    def assertItemsAlmostEqual(self, a, b, places=2):
+    def assertItemsAlmostEqual(self, a, b, places: int=2) -> None:
         super(TestSCS, self).assertItemsAlmostEqual(a, b, places=places)
 
     # Overridden method to assume lower accuracy.
-    def assertAlmostEqual(self, a, b, places=2):
+    def assertAlmostEqual(self, a, b, places: int=2) -> None:
         super(TestSCS, self).assertAlmostEqual(a, b, places=places)
 
-    def test_scs_options(self):
+    def test_scs_options(self) -> None:
         """Test that all the SCS solver options work.
         """
         # Test SCS
@@ -141,7 +141,7 @@ class TestSCS(BaseTest):
         self.assertAlmostEqual(prob.value, 1.0, places=2)
         self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
 
-    def test_log_problem(self):
+    def test_log_problem(self) -> None:
         # Log in objective.
         obj = cp.Maximize(cp.sum(cp.log(self.x)))
         constr = [self.x <= [1, math.e]]
@@ -164,7 +164,7 @@ class TestSCS(BaseTest):
         p = cp.Problem(obj, constr)
         result = p.solve(solver=cp.SCS)
 
-    def test_sigma_max(self):
+    def test_sigma_max(self) -> None:
         """Test sigma_max.
         """
         const = cp.Constant([[1, 2, 3], [4, 5, 6]])
@@ -174,7 +174,7 @@ class TestSCS(BaseTest):
         self.assertAlmostEqual(result, cp.norm(const, 2).value)
         self.assertItemsAlmostEqual(self.C.value, const.value)
 
-    def test_sdp_var(self):
+    def test_sdp_var(self) -> None:
         """Test sdp var.
         """
         const = cp.Constant([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -183,7 +183,7 @@ class TestSCS(BaseTest):
         prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, cp.INFEASIBLE)
 
-    def test_complex_matrices(self):
+    def test_complex_matrices(self) -> None:
         """Test complex matrices.
         """
         # Complex-valued matrix
@@ -211,7 +211,7 @@ class TestSCS(BaseTest):
         self.assertEqual(constraints[2].dual_value.shape, (2, 2))
         self.assertAlmostEqual(sol_scs, n1)
 
-    def test_kl_div(self):
+    def test_kl_div(self) -> None:
         """Test a problem with kl_div.
         """
         kK = 50
@@ -236,7 +236,7 @@ class TestSCS(BaseTest):
         klprob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
-    def test_entr(self):
+    def test_entr(self) -> None:
         """Test a problem with entr.
         """
         for n in [5, 10, 25]:
@@ -247,7 +247,7 @@ class TestSCS(BaseTest):
             p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
 
-    def test_exp(self):
+    def test_exp(self) -> None:
         """Test a problem with exp.
         """
         for n in [5, 10, 25]:
@@ -258,7 +258,7 @@ class TestSCS(BaseTest):
             p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
 
-    def test_log(self):
+    def test_log(self) -> None:
         """Test a problem with log.
         """
         for n in [5, 10, 25]:
@@ -269,7 +269,7 @@ class TestSCS(BaseTest):
             p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
 
-    def test_solve_problem_twice(self):
+    def test_solve_problem_twice(self) -> None:
         """Test a problem with log.
         """
         n = 5
@@ -284,7 +284,7 @@ class TestSCS(BaseTest):
         second_value = x.value
         self.assertItemsAlmostEqual(first_value, second_value)
 
-    def test_warm_start(self):
+    def test_warm_start(self) -> None:
         """Test warm starting.
         """
         x = cp.Variable(10)
@@ -297,7 +297,7 @@ class TestSCS(BaseTest):
         self.assertAlmostEqual(result2, result, places=2)
         print(time > time2)
 
-    def test_warm_start_diffcp(self):
+    def test_warm_start_diffcp(self) -> None:
         """Test warm starting in diffcvx.
         """
         try:
@@ -312,7 +312,7 @@ class TestSCS(BaseTest):
         result2 = prob.solve(solver=cp.DIFFCP, warm_start=True, eps=1e-4)
         self.assertAlmostEqual(result2, result, places=2)
 
-    def test_psd_constraint(self):
+    def test_psd_constraint(self) -> None:
         """Test PSD constraint.
         """
         s = cp.Variable((2, 2))
@@ -328,125 +328,125 @@ class TestSCS(BaseTest):
         eigs = np.linalg.eig(s + s.T)[0]
         self.assertEqual(np.all(eigs >= 0), True)
 
-    def test_scs_lp_3(self):
+    def test_scs_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='SCS')
 
-    def test_scs_lp_4(self):
+    def test_scs_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='SCS')
 
-    def test_scs_lp_5(self):
+    def test_scs_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='SCS')
 
-    def test_scs_socp_1(self):
+    def test_scs_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='SCS')
 
-    def test_scs_socp_3(self):
+    def test_scs_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='SCS')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='SCS')
 
-    def test_scs_sdp_1min(self):
+    def test_scs_sdp_1min(self) -> None:
         StandardTestSDPs.test_sdp_1min(solver='SCS')
 
-    def test_scs_sdp_2(self):
+    def test_scs_sdp_2(self) -> None:
         StandardTestSDPs.test_sdp_2(solver='SCS', eps=1e-8)
 
-    def test_scs_expcone_1(self):
+    def test_scs_expcone_1(self) -> None:
         StandardTestECPs.test_expcone_1(solver='SCS')
 
-    def test_scs_exp_soc_1(self):
+    def test_scs_exp_soc_1(self) -> None:
         StandardTestMixedCPs.test_exp_soc_1(solver='SCS')
 
-    def test_scs_pcp_1(self):
+    def test_scs_pcp_1(self) -> None:
         StandardTestPCPs.test_pcp_1(solver='SCS', eps=1e-8)
 
-    def test_scs_pcp_2(self):
+    def test_scs_pcp_2(self) -> None:
         StandardTestPCPs.test_pcp_2(solver='SCS', eps=1e-8)
 
 
 @unittest.skipUnless('MOSEK' in INSTALLED_SOLVERS, 'MOSEK is not installed.')
 class TestMosek(unittest.TestCase):
 
-    def test_mosek_lp_0(self):
+    def test_mosek_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='MOSEK')
 
-    def test_mosek_lp_1(self):
+    def test_mosek_lp_1(self) -> None:
         # default settings
         StandardTestLPs.test_lp_1(solver='MOSEK')
         # require a basic feasible solution
         StandardTestLPs.test_lp_1(solver='MOSEK', places=6, bfs=True)
 
-    def test_mosek_lp_2(self):
+    def test_mosek_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='MOSEK')
 
-    def test_mosek_lp_3(self):
+    def test_mosek_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='MOSEK')
 
-    def test_mosek_lp_4(self):
+    def test_mosek_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='MOSEK')
 
-    def test_mosek_lp_5(self):
+    def test_mosek_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='MOSEK')
 
-    def test_mosek_socp_0(self):
+    def test_mosek_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='MOSEK')
 
-    def test_mosek_socp_1(self):
+    def test_mosek_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='MOSEK')
 
-    def test_mosek_socp_2(self):
+    def test_mosek_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='MOSEK')
 
-    def test_mosek_socp_3(self):
+    def test_mosek_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='MOSEK')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='MOSEK')
 
-    def test_mosek_sdp_1(self):
+    def test_mosek_sdp_1(self) -> None:
         # minimization
         StandardTestSDPs.test_sdp_1min(solver='MOSEK')
         # maximization
         StandardTestSDPs.test_sdp_1max(solver='MOSEK')
 
-    def test_mosek_sdp_2(self):
+    def test_mosek_sdp_2(self) -> None:
         StandardTestSDPs.test_sdp_2(solver='MOSEK')
 
-    def test_mosek_expcone_1(self):
+    def test_mosek_expcone_1(self) -> None:
         StandardTestECPs.test_expcone_1(solver='MOSEK')
 
-    def test_mosek_exp_soc_1(self):
+    def test_mosek_exp_soc_1(self) -> None:
         StandardTestMixedCPs.test_exp_soc_1(solver='MOSEK')
 
-    def test_mosek_pcp_1(self):
+    def test_mosek_pcp_1(self) -> None:
         StandardTestPCPs.test_pcp_1(solver='MOSEK')
 
-    def test_mosek_pcp_2(self):
+    def test_mosek_pcp_2(self) -> None:
         StandardTestPCPs.test_pcp_2(solver='MOSEK')
 
-    def test_mosek_mi_lp_0(self):
+    def test_mosek_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='MOSEK')
 
-    def test_mosek_mi_lp_1(self):
+    def test_mosek_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver='MOSEK')
 
-    def test_mosek_mi_lp_2(self):
+    def test_mosek_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='MOSEK')
 
-    def test_mosek_mi_lp_3(self):
+    def test_mosek_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='MOSEK')
 
-    def test_mosek_mi_socp_1(self):
+    def test_mosek_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='MOSEK')
 
-    def test_mosek_mi_socp_2(self):
+    def test_mosek_mi_socp_2(self) -> None:
         StandardTestSOCPs.test_mi_socp_2(solver='MOSEK')
 
-    def test_mosek_mi_pcp_0(self):
+    def test_mosek_mi_pcp_0(self) -> None:
         StandardTestPCPs.test_mi_pcp_0(solver='MOSEK')
 
-    def test_mosek_params(self):
+    def test_mosek_params(self) -> None:
         if cp.MOSEK in INSTALLED_SOLVERS:
             import mosek
             n = 10
@@ -481,7 +481,7 @@ class TestMosek(unittest.TestCase):
 @unittest.skipUnless('CVXOPT' in INSTALLED_SOLVERS, 'CVXOPT is not installed.')
 class TestCVXOPT(BaseTest):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -494,7 +494,7 @@ class TestCVXOPT(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_cvxopt_options(self):
+    def test_cvxopt_options(self) -> None:
         """Test that all the CVXOPT solver options work.
         """
         # 'maxiters'
@@ -527,55 +527,55 @@ class TestCVXOPT(BaseTest):
             prob.solve(solver='CVXOPT', kktsolver=setup_dummy_factor)
         self.assertEqual(msg, str(nix.exception))
 
-    def test_cvxopt_lp_0(self):
+    def test_cvxopt_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='CVXOPT')
 
-    def test_cvxopt_lp_1(self):
+    def test_cvxopt_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='CVXOPT')
 
-    def test_cvxopt_lp_2(self):
+    def test_cvxopt_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='CVXOPT')
 
-    def test_cvxopt_lp_3(self):
+    def test_cvxopt_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='CVXOPT')
 
-    def test_cvxopt_lp_4(self):
+    def test_cvxopt_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='CVXOPT')
 
-    def test_cvxopt_lp_5(self):
+    def test_cvxopt_lp_5(self) -> None:
         from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
         StandardTestLPs.test_lp_5(solver='CVXOPT', kktsolver=setup_ldl_factor)
         StandardTestLPs.test_lp_5(solver='CVXOPT', kktsolver='chol')
 
-    def test_cvxopt_socp_0(self):
+    def test_cvxopt_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='CVXOPT')
 
-    def test_cvxopt_socp_1(self):
+    def test_cvxopt_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='CVXOPT')
 
-    def test_cvxopt_socp_2(self):
+    def test_cvxopt_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='CVXOPT')
 
-    def test_cvxopt_socp_3(self):
+    def test_cvxopt_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='CVXOPT')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='CVXOPT')
 
-    def test_cvxopt_sdp_1(self):
+    def test_cvxopt_sdp_1(self) -> None:
         # minimization
         StandardTestSDPs.test_sdp_1min(solver='CVXOPT')
         # maximization
         StandardTestSDPs.test_sdp_1max(solver='CVXOPT')
 
-    def test_cvxopt_sdp_2(self):
+    def test_cvxopt_sdp_2(self) -> None:
         StandardTestSDPs.test_sdp_2(solver='CVXOPT')
 
 
 @unittest.skipUnless('CBC' in INSTALLED_SOLVERS, 'CBC is not installed.')
 class TestCBC(BaseTest):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -588,7 +588,7 @@ class TestCBC(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_options(self):
+    def test_options(self) -> None:
         """Test that all the cvx.CBC solver options work.
         """
         prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1)),
@@ -609,68 +609,68 @@ class TestCBC(BaseTest):
                 prob.solve(solver=cp.CBC)
                 self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.CBC)
 
-    def test_cbc_lp_0(self):
+    def test_cbc_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='CBC', duals=False)
 
-    def test_cbc_lp_1(self):
+    def test_cbc_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='CBC', duals=False)
 
-    def test_cbc_lp_2(self):
+    def test_cbc_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='CBC', duals=False)
 
-    def test_cbc_lp_3(self):
+    def test_cbc_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='CBC')
 
-    def test_cbc_lp_4(self):
+    def test_cbc_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='CBC')
 
-    def test_cbc_lp_5(self):
+    def test_cbc_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='CBC')
 
-    def test_cbc_mi_lp_0(self):
+    def test_cbc_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='CBC')
 
-    def test_cbc_mi_lp_1(self):
+    def test_cbc_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver='CBC')
 
-    def test_cbc_mi_lp_2(self):
+    def test_cbc_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='CBC')
 
-    def test_cbc_mi_lp_3(self):
+    def test_cbc_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CBC')
 
 
 @unittest.skipUnless('GLPK' in INSTALLED_SOLVERS, 'GLPK is not installed.')
 class TestGLPK(unittest.TestCase):
 
-    def test_glpk_lp_0(self):
+    def test_glpk_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='GLPK')
 
-    def test_glpk_lp_1(self):
+    def test_glpk_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='GLPK')
 
-    def test_glpk_lp_2(self):
+    def test_glpk_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='GLPK')
 
-    def test_glpk_lp_3(self):
+    def test_glpk_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='GLPK')
 
-    def test_glpk_lp_4(self):
+    def test_glpk_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='GLPK')
 
-    def test_glpk_lk_5(self):
+    def test_glpk_lk_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='GLPK')
 
-    def test_glpk_mi_lp_0(self):
+    def test_glpk_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='GLPK_MI')
 
-    def test_glpk_mi_lp_1(self):
+    def test_glpk_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver='GLPK_MI')
 
-    def test_glpk_mi_lp_2(self):
+    def test_glpk_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='GLPK_MI')
 
-    def test_glpk_mi_lp_3(self):
+    def test_glpk_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='GLPK_MI')
 
 
@@ -678,7 +678,7 @@ class TestGLPK(unittest.TestCase):
 class TestCPLEX(BaseTest):
     """ Unit tests for solver specific behavior. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -691,7 +691,7 @@ class TestCPLEX(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_cplex_warm_start(self):
+    def test_cplex_warm_start(self) -> None:
         """Make sure that warm starting CPLEX behaves as expected
            Note: This only checks output, not whether or not CPLEX is warm starting internally
         """
@@ -758,7 +758,7 @@ class TestCPLEX(BaseTest):
                 prob.solve(solver=cp.CPLEX, warm_start=True)
             self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.CPLEX)
 
-    def test_cplex_params(self):
+    def test_cplex_params(self) -> None:
         if cp.CPLEX in INSTALLED_SOLVERS:
             n, m = 10, 4
             np.random.seed(0)
@@ -790,28 +790,28 @@ class TestCPLEX(BaseTest):
             }
             problem.solve(solver=cp.CPLEX, cplex_params=cplex_params)
 
-    def test_cplex_lp_0(self):
+    def test_cplex_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='CPLEX')
 
-    def test_cplex_lp_1(self):
+    def test_cplex_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='CPLEX')
 
-    def test_cplex_lp_2(self):
+    def test_cplex_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='CPLEX')
 
-    def test_cplex_lp_3(self):
+    def test_cplex_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='CPLEX')
 
-    def test_cplex_lp_4(self):
+    def test_cplex_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='CPLEX')
 
-    def test_cplex_lp_5(self):
+    def test_cplex_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='CPLEX')
 
-    def test_cplex_socp_0(self):
+    def test_cplex_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='CPLEX')
 
-    def test_cplex_socp_1(self):
+    def test_cplex_socp_1(self) -> None:
         # Parameters are set due to a minor dual-variable related
         # presolve bug in CPLEX, which will be fixed in the next
         # CPLEX release.
@@ -820,31 +820,31 @@ class TestCPLEX(BaseTest):
                                           "preprocessing.presolve": 0,
                                           "preprocessing.reduce": 2})
 
-    def test_cplex_socp_2(self):
+    def test_cplex_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='CPLEX')
 
-    def test_cplex_socp_3(self):
+    def test_cplex_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='CPLEX')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='CPLEX')
 
-    def test_cplex_mi_lp_0(self):
+    def test_cplex_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='CPLEX')
 
-    def test_cplex_mi_lp_1(self):
+    def test_cplex_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver='CPLEX')
 
-    def test_cplex_mi_lp_2(self):
+    def test_cplex_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='CPLEX')
 
-    def test_cplex_mi_lp_3(self):
+    def test_cplex_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CPLEX')
 
-    def test_cplex_mi_socp_1(self):
+    def test_cplex_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='CPLEX', places=3)
 
-    def test_cplex_mi_socp_2(self):
+    def test_cplex_mi_socp_2(self) -> None:
         StandardTestSOCPs.test_mi_socp_2(solver='CPLEX')
 
 
@@ -852,7 +852,7 @@ class TestCPLEX(BaseTest):
 class TestGUROBI(BaseTest):
     """ Unit tests for solver specific behavior. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -865,7 +865,7 @@ class TestGUROBI(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_gurobi_warm_start(self):
+    def test_gurobi_warm_start(self) -> None:
         """Make sure that warm starting Gurobi behaves as expected
            Note: This only checks output, not whether or not Gurobi is warm starting internally
         """
@@ -933,7 +933,7 @@ class TestGUROBI(BaseTest):
                 prob.solve(solver=cp.GUROBI, warm_start=True)
             self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.GUROBI)
 
-    def test_gurobi_time_limit_no_solution(self):
+    def test_gurobi_time_limit_no_solution(self) -> None:
         """Make sure that if Gurobi terminates due to a time limit before finding a solution:
             1) no error is raised,
             2) solver stats are returned.
@@ -972,62 +972,62 @@ class TestGUROBI(BaseTest):
                 prob.solve(solver=cp.GUROBI, TimeLimit=0)
             self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.GUROBI)
 
-    def test_gurobi_lp_0(self):
+    def test_gurobi_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='GUROBI')
 
-    def test_gurobi_lp_1(self):
+    def test_gurobi_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='GUROBI')
 
-    def test_gurobi_lp_2(self):
+    def test_gurobi_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='GUROBI')
 
-    def test_gurobi_lp_3(self):
+    def test_gurobi_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='GUROBI')
 
-    def test_gurobi_lp_4(self):
+    def test_gurobi_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='GUROBI')
 
-    def test_gurobi_lp_5(self):
+    def test_gurobi_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='GUROBI')
 
-    def test_gurobi_socp_0(self):
+    def test_gurobi_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='GUROBI')
 
-    def test_gurobi_socp_1(self):
+    def test_gurobi_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='GUROBI')
 
-    def test_gurobi_socp_2(self):
+    def test_gurobi_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='GUROBI')
 
-    def test_gurobi_socp_3(self):
+    def test_gurobi_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='GUROBI')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='GUROBI')
 
-    def test_gurobi_mi_lp_0(self):
+    def test_gurobi_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='GUROBI')
 
-    def test_gurobi_mi_lp_1(self):
+    def test_gurobi_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver='GUROBI')
 
-    def test_gurobi_mi_lp_2(self):
+    def test_gurobi_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='GUROBI')
 
-    def test_gurobi_mi_lp_3(self):
+    def test_gurobi_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='GUROBI')
 
-    def test_gurobi_mi_socp_1(self):
+    def test_gurobi_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='GUROBI', places=2)
 
-    def test_gurobi_mi_socp_2(self):
+    def test_gurobi_mi_socp_2(self) -> None:
         StandardTestSOCPs.test_mi_socp_2(solver='GUROBI')
 
 
 @unittest.skipUnless('XPRESS' in INSTALLED_SOLVERS, 'XPRESS is not installed.')
 class TestXPRESS(BaseTest):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -1040,7 +1040,7 @@ class TestXPRESS(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_xpress_warm_start(self):
+    def test_xpress_warm_start(self) -> None:
         """Make sure that warm starting Xpress behaves as expected
            Note: Xpress does not have warmstart yet, it will re-solve problem from scratch
         """
@@ -1108,7 +1108,7 @@ class TestXPRESS(BaseTest):
                 prob.solve(solver=cp.XPRESS, warm_start=True)
             self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.XPRESS)
 
-    def test_xpress_params(self):
+    def test_xpress_params(self) -> None:
         if cp.XPRESS in INSTALLED_SOLVERS:
             n, m = 10, 4
             np.random.seed(0)
@@ -1128,80 +1128,80 @@ class TestXPRESS(BaseTest):
             }
             problem.solve(solver=cp.XPRESS, solver_opts=params)
 
-    def test_xpress_lp_0(self):
+    def test_xpress_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='XPRESS')
 
-    def test_xpress_lp_1(self):
+    def test_xpress_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='XPRESS')
 
-    def test_xpress_lp_2(self):
+    def test_xpress_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='XPRESS')
 
-    def test_xpress_lp_3(self):
+    def test_xpress_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='XPRESS')
 
-    def test_xpress_lp_4(self):
+    def test_xpress_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='XPRESS')
 
-    def test_xpress_socp_0(self):
+    def test_xpress_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='XPRESS')
 
-    def test_xpress_socp_1(self):
+    def test_xpress_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='XPRESS')
 
-    def test_xpress_socp_2(self):
+    def test_xpress_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='XPRESS')
 
-    def test_xpress_mi_lp_0(self):
+    def test_xpress_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='XPRESS')
 
-    def test_xpress_mi_lp_1(self):
+    def test_xpress_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver='XPRESS')
 
-    def test_xpress_mi_lp_2(self):
+    def test_xpress_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='XPRESS')
 
-    def test_xpress_mi_lp_3(self):
+    def test_xpress_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='XPRESS')
 
-    def test_xpress_mi_socp_1(self):
+    def test_xpress_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='XPRESS')
 
-    def test_xpress_mi_socp_2(self):
+    def test_xpress_mi_socp_2(self) -> None:
         StandardTestSOCPs.test_mi_socp_2(solver='XPRESS')
 
 
 @unittest.skipUnless('NAG' in INSTALLED_SOLVERS, 'NAG is not installed.')
 class TestNAG(unittest.TestCase):
 
-    def test_nag_lp_0(self):
+    def test_nag_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='NAG')
 
-    def test_nag_lp_1(self):
+    def test_nag_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='NAG')
 
-    def test_nag_lp_2(self):
+    def test_nag_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='NAG')
 
-    def test_nag_lp_3(self):
+    def test_nag_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='NAG')
 
-    def test_nag_lp_4(self):
+    def test_nag_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='NAG')
 
-    def test_nag_lp_5(self):
+    def test_nag_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='NAG')
 
-    def test_nag_socp_0(self):
+    def test_nag_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='NAG')
 
-    def test_nag_socp_1(self):
+    def test_nag_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='NAG')
 
-    def test_nag_socp_2(self):
+    def test_nag_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='NAG')
 
-    def test_nag_socp_3(self):
+    def test_nag_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='NAG')
         # axis 1
@@ -1211,46 +1211,46 @@ class TestNAG(unittest.TestCase):
 @unittest.skipUnless("SCIP" in INSTALLED_SOLVERS, "SCIP is not installed.")
 class TestSCIP(unittest.TestCase):
 
-    def test_scip_lp_0(self):
+    def test_scip_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver="SCIP")
 
-    def test_scip_lp_1(self):
+    def test_scip_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver="SCIP")
 
-    def test_scip_lp_2(self):
+    def test_scip_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver="SCIP", duals=False)
 
-    def test_scip_lp_3(self):
+    def test_scip_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver="SCIP")
 
-    def test_scip_lp_4(self):
+    def test_scip_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver="SCIP")
 
-    def test_scip_socp_0(self):
+    def test_scip_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver="SCIP")
 
-    def test_scip_socp_1(self):
+    def test_scip_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver="SCIP", places=3, duals=False)
 
-    def test_scip_socp_2(self):
+    def test_scip_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver="SCIP", places=2)
 
-    def test_scip_socp_3(self):
+    def test_scip_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver="SCIP")
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver="SCIP")
 
-    def test_scip_mi_lp_0(self):
+    def test_scip_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver="SCIP")
 
-    def test_scip_mi_lp_1(self):
+    def test_scip_mi_lp_1(self) -> None:
         StandardTestLPs.test_mi_lp_1(solver="SCIP")
 
-    def test_scip_mi_lp_2(self):
+    def test_scip_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver="SCIP")
 
-    def test_scip_mi_lp_3(self):
+    def test_scip_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver="SCIP")
 
     def get_simple_problem(self):
@@ -1266,25 +1266,25 @@ class TestSCIP(unittest.TestCase):
         prob = cp.Problem(obj, constraints)
         return prob
 
-    def test_scip_test_params__no_params_set(self):
+    def test_scip_test_params__no_params_set(self) -> None:
         prob = self.get_simple_problem()
         prob.solve(solver="SCIP")
         # Important that passes without raising an error also check obj.
         assert prob.value == 3
 
-    def test_scip_test_params__valid_params(self):
+    def test_scip_test_params__valid_params(self) -> None:
         prob = self.get_simple_problem()
         prob.solve(solver="SCIP", gp=False)
         # Important that passes without raising an error also check obj.
         assert prob.value == 3
 
-    def test_scip_test_params__valid_scip_params(self):
+    def test_scip_test_params__valid_scip_params(self) -> None:
         prob = self.get_simple_problem()
         prob.solve(solver="SCIP", scip_params={"lp/fastmip": 1, "limits/gap": 0.1})
         # Important that passes without raising an error also check obj.
         assert prob.value == 3
 
-    def test_scip_test_params__invalid_params(self):
+    def test_scip_test_params__invalid_params(self) -> None:
         prob = self.get_simple_problem()
         # Since an invalid NON-scip param is passed, an error is expected
         # to be raised when calling solve.
@@ -1293,7 +1293,7 @@ class TestSCIP(unittest.TestCase):
             exc = "One or more solver params in ['a'] are not valid: 'Not a valid parameter name'"
             assert ke.exception == exc
 
-    def test_scip_test_params__invalid_scip_params(self):
+    def test_scip_test_params__invalid_scip_params(self) -> None:
         prob = self.get_simple_problem()
         # Since an invalid SCIP param is passed, an error is expected
         # to be raised when calling solve.
@@ -1305,7 +1305,7 @@ class TestSCIP(unittest.TestCase):
 
 class TestAllSolvers(BaseTest):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = cp.Variable(name='a')
         self.b = cp.Variable(name='b')
         self.c = cp.Variable(name='c')
@@ -1318,7 +1318,7 @@ class TestAllSolvers(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def test_installed_solvers(self):
+    def test_installed_solvers(self) -> None:
         """Test the list of installed solvers.
         """
         from cvxpy.reductions.solvers.defines import (SOLVER_MAP_CONIC, SOLVER_MAP_QP,
@@ -1343,7 +1343,7 @@ class TestAllSolvers(BaseTest):
                     prob.solve(solver=solver)
                 self.assertEqual(str(cm.exception), "The solver %s is not installed." % solver)
 
-    def test_mixed_integer_behavior(self):
+    def test_mixed_integer_behavior(self) -> None:
         x = cp.Variable(2, name='x', integer=True)
         objective = cp.Minimize(cp.sum(x))
         prob = cp.Problem(objective, [x >= 0])
@@ -1361,7 +1361,7 @@ class TestAllSolvers(BaseTest):
 
 class TestECOS_BB(unittest.TestCase):
 
-    def test_ecos_bb_explicit_only(self):
+    def test_ecos_bb_explicit_only(self) -> None:
         """Test that ECOS_BB isn't chosen by default.
         """
         x = cp.Variable(1, name='x', integer=True)
@@ -1374,56 +1374,56 @@ class TestECOS_BB(unittest.TestCase):
             except SolverError:
                 pass
 
-    def test_ecos_bb_lp_0(self):
+    def test_ecos_bb_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='ECOS_BB')
 
-    def test_ecos_bb_lp_1(self):
+    def test_ecos_bb_lp_1(self) -> None:
         # default settings
         StandardTestLPs.test_lp_1(solver='ECOS_BB')
         # require a basic feasible solution
         StandardTestLPs.test_lp_1(solver='ECOS_BB')
 
-    def test_ecos_bb_lp_2(self):
+    def test_ecos_bb_lp_2(self) -> None:
         StandardTestLPs.test_lp_2(solver='ECOS_BB')
 
-    def test_ecos_bb_lp_3(self):
+    def test_ecos_bb_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='ECOS_BB')
 
-    def test_ecos_bb_lp_4(self):
+    def test_ecos_bb_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='ECOS_BB')
 
-    def test_ecos_bb_lp_5(self):
+    def test_ecos_bb_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='ECOS_BB')
 
-    def test_ecos_bb_socp_0(self):
+    def test_ecos_bb_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='ECOS_BB')
 
-    def test_ecos_bb_socp_1(self):
+    def test_ecos_bb_socp_1(self) -> None:
         StandardTestSOCPs.test_socp_1(solver='ECOS_BB')
 
-    def test_ecos_bb_socp_2(self):
+    def test_ecos_bb_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='ECOS_BB')
 
-    def test_ecos_bb_socp_3(self):
+    def test_ecos_bb_socp_3(self) -> None:
         # axis 0
         StandardTestSOCPs.test_socp_3ax0(solver='ECOS_BB')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='ECOS_BB')
 
-    def test_ecos_bb_expcone_1(self):
+    def test_ecos_bb_expcone_1(self) -> None:
         StandardTestECPs.test_expcone_1(solver='ECOS_BB')
 
-    def test_ecos_bb_exp_soc_1(self):
+    def test_ecos_bb_exp_soc_1(self) -> None:
         StandardTestMixedCPs.test_exp_soc_1(solver='ECOS_BB')
 
-    def test_ecos_bb_mi_lp_0(self):
+    def test_ecos_bb_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='ECOS_BB')
 
-    def test_ecos_bb_mi_lp_2(self):
+    def test_ecos_bb_mi_lp_2(self) -> None:
         StandardTestLPs.test_mi_lp_2(solver='ECOS_BB')
 
-    def test_ecos_bb_mi_lp_3(self):
+    def test_ecos_bb_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='ECOS_BB')
 
-    def test_ecos_bb_mi_socp_1(self):
+    def test_ecos_bb_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='ECOS_BB')

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -279,7 +279,7 @@ atoms_maximize = [
 ]
 
 
-def check_solver(prob, solver_name):
+def check_solver(prob, solver_name) -> bool:
     """Can the solver solve the problem?
     """
     try:
@@ -296,7 +296,7 @@ def check_solver(prob, solver_name):
 
 
 # Tests numeric version of atoms.
-def run_atom(atom, problem, obj_val, solver, verbose=False):
+def run_atom(atom, problem, obj_val, solver, verbose: bool=False) -> None:
     assert problem.is_dcp()
     print(problem)
     if verbose:
@@ -340,7 +340,7 @@ atoms_maximize = [(a, cp.Maximize) for a in atoms_maximize]
 
 
 @pytest.mark.parametrize("atom_info, objective_type", atoms_minimize + atoms_maximize)
-def test_constant_atoms(atom_info, objective_type):
+def test_constant_atoms(atom_info, objective_type) -> None:
 
     atom, size, args, obj_val = atom_info
 

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -26,7 +26,7 @@ import numpy as np
 class TestConstraints(BaseTest):
     """ Unit tests for the expression/expression module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
         self.b = Variable(name='b')
 
@@ -38,7 +38,7 @@ class TestConstraints(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-    def test_equality(self):
+    def test_equality(self) -> None:
         """Test the Equality class.
         """
         constr = self.x == self.z
@@ -81,7 +81,7 @@ class TestConstraints(BaseTest):
         self.assertTrue(type(copy) is type(constr))
         self.assertTrue(copy.args[0] is self.A)
 
-    def test_inequality(self):
+    def test_inequality(self) -> None:
         """Test the Inequality class.
         """
         constr = self.x <= self.z
@@ -125,7 +125,7 @@ class TestConstraints(BaseTest):
         self.assertTrue(type(copy) is type(constr))
         self.assertTrue(copy.args[0] is self.A)
 
-    def test_psd_constraint(self):
+    def test_psd_constraint(self) -> None:
         """Test the PSD constraint <<.
         """
         constr = self.A >> self.B
@@ -162,7 +162,7 @@ class TestConstraints(BaseTest):
         self.assertTrue(type(copy) is type(constr))
         self.assertTrue(copy.args[0] is self.B)
 
-    def test_nsd_constraint(self):
+    def test_nsd_constraint(self) -> None:
         """Test the PSD constraint <<.
         """
         constr = self.A << self.B
@@ -183,7 +183,7 @@ class TestConstraints(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Non-square matrix in positive definite constraint.")
 
-    def test_geq(self):
+    def test_geq(self) -> None:
         """Test the >= operator.
         """
         constr = self.z >= self.x
@@ -195,7 +195,7 @@ class TestConstraints(BaseTest):
             (self.y >= self.x)
 
     # Test the SOC class.
-    def test_soc_constraint(self):
+    def test_soc_constraint(self) -> None:
         exp = self.x + self.z
         scalar_exp = self.a + self.b
         constr = SOC(scalar_exp, exp)
@@ -208,7 +208,7 @@ class TestConstraints(BaseTest):
             SOC(Variable(1), Variable((1, 4)))
         self.assertEqual(str(cm.exception), error_str)
 
-    def test_pow3d_constraint(self):
+    def test_pow3d_constraint(self) -> None:
         n = 3
         np.random.seed(0)
         alpha = 0.275
@@ -233,7 +233,7 @@ class TestConstraints(BaseTest):
         with self.assertRaises(ValueError):
             con = PowCone3D(x, y, z, -0.00001)
 
-    def test_pownd_constraint(self):
+    def test_pownd_constraint(self) -> None:
         n = 4
         W, z = Variable(n), Variable()
         np.random.seed(0)
@@ -259,7 +259,7 @@ class TestConstraints(BaseTest):
         self.assertGreaterEqual(viol, 0.01)
         self.assertLessEqual(viol, 0.06)
 
-    def test_chained_constraints(self):
+    def test_chained_constraints(self) -> None:
         """Tests that chaining constraints raises an error.
         """
         error_str = ("Cannot evaluate the truth value of a constraint or "
@@ -276,7 +276,7 @@ class TestConstraints(BaseTest):
             (self.z <= self.x).__bool__()
         self.assertEqual(str(cm.exception), error_str)
 
-    def test_nonpos(self):
+    def test_nonpos(self) -> None:
         """Tests the NonPos constraint for correctness.
         """
         n = 3
@@ -292,7 +292,7 @@ class TestConstraints(BaseTest):
         prob.solve(solver=cp.OSQP)
         self.assertItemsAlmostEqual(x.value, c)
 
-    def test_nonpos_dual(self):
+    def test_nonpos_dual(self) -> None:
         """Test dual variables work for NonPos.
         """
         n = 3

--- a/cvxpy/tests/test_convolution.py
+++ b/cvxpy/tests/test_convolution.py
@@ -25,7 +25,7 @@ import numpy as np
 class TestConvolution(BaseTest):
     """ Unit tests for convolution. """
 
-    def test_1D_conv(self):
+    def test_1D_conv(self) -> None:
         """Test 1D convolution.
         """
         n = 3
@@ -54,7 +54,7 @@ class TestConvolution(BaseTest):
         # result = prob.solve(solver=SCS, expr_tree=True, verbose=True)
         # self.assertAlmostEqual(result, 0, places=1)
 
-    def prob_mat_vs_mul_funcs(self, prob):
+    def prob_mat_vs_mul_funcs(self, prob) -> None:
         data, dims = prob.get_problem_data(solver=cvx.SCS)
         A = data["A"]
         objective, constr_map, dims, solver = prob.canonicalize(cvx.SCS)
@@ -97,7 +97,7 @@ class TestConvolution(BaseTest):
 
         return matrix
 
-    def test_conv_prob(self):
+    def test_conv_prob(self) -> None:
         """Test a problem with convolution.
         """
         import numpy as np

--- a/cvxpy/tests/test_curvature.py
+++ b/cvxpy/tests/test_curvature.py
@@ -23,7 +23,7 @@ from cvxpy.settings import UNKNOWN, QUASILINEAR
 class TestCurvature(unittest.TestCase):
     """ Unit tests for the expression/curvature class. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.cvx = Variable()**2
         self.ccv = Variable()**0.5
         self.aff = Variable()
@@ -35,21 +35,21 @@ class TestCurvature(unittest.TestCase):
         self.zero = Constant(0)
         self.unknown_sign = self.pos + self.neg
 
-    def test_add(self):
+    def test_add(self) -> None:
         self.assertEqual((self.const + self.cvx).curvature, self.cvx.curvature)
         self.assertEqual((self.unknown_curv + self.ccv).curvature, UNKNOWN)
         self.assertEqual((self.cvx + self.ccv).curvature, UNKNOWN)
         self.assertEqual((self.cvx + self.cvx).curvature, self.cvx.curvature)
         self.assertEqual((self.aff + self.ccv).curvature, self.ccv.curvature)
 
-    def test_sub(self):
+    def test_sub(self) -> None:
         self.assertEqual((self.const - self.cvx).curvature, self.ccv.curvature)
         self.assertEqual((self.unknown_curv - self.ccv).curvature, UNKNOWN)
         self.assertEqual((self.cvx - self.ccv).curvature, self.cvx.curvature)
         self.assertEqual((self.cvx - self.cvx).curvature, UNKNOWN)
         self.assertEqual((self.aff - self.ccv).curvature, self.cvx.curvature)
 
-    def test_sign_mult(self):
+    def test_sign_mult(self) -> None:
         self.assertEqual((self.zero * self.cvx).curvature, self.aff.curvature)
         self.assertEqual((self.neg*self.cvx).curvature, self.ccv.curvature)
         self.assertEqual((self.neg*self.ccv).curvature, self.cvx.curvature)
@@ -59,12 +59,12 @@ class TestCurvature(unittest.TestCase):
         self.assertEqual((self.unknown_sign*self.const).curvature, self.const.curvature)
         self.assertEqual((self.unknown_sign*self.ccv).curvature, UNKNOWN)
 
-    def test_neg(self):
+    def test_neg(self) -> None:
         self.assertEqual((-self.cvx).curvature, self.ccv.curvature)
         self.assertEqual((-self.aff).curvature, self.aff.curvature)
 
     # Tests the is_affine, is_convex, and is_concave methods
-    def test_is_curvature(self):
+    def test_is_curvature(self) -> None:
         assert self.const.is_affine()
         assert self.aff.is_affine()
         assert not self.cvx.is_affine()

--- a/cvxpy/tests/test_custom_solver.py
+++ b/cvxpy/tests/test_custom_solver.py
@@ -14,7 +14,7 @@ class CustomConicSolverCalled(Exception):
 
 
 class CustomQPSolver(OSQP):
-    def name(self):
+    def name(self) -> str:
         return "CUSTOM_QP_SOLVER"
 
     def solve_via_data(self, *args, **kwargs):
@@ -22,7 +22,7 @@ class CustomQPSolver(OSQP):
 
 
 class CustomConicSolver(SCS):
-    def name(self):
+    def name(self) -> str:
         return "CUSTOM_CONIC_SOLVER"
 
     def solve_via_data(self, *args, **kwargs):
@@ -30,60 +30,60 @@ class CustomConicSolver(SCS):
 
 
 class ConflictingCustomSolver(OSQP):
-    def name(self):
+    def name(self) -> str:
         return "OSQP"
 
 
 class TestCustomSolvers(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.custom_qp_solver = CustomQPSolver()
         self.custom_conic_solver = CustomConicSolver()
 
-    def test_custom_continuous_qp_solver_can_solve_continuous_qp(self):
+    def test_custom_continuous_qp_solver_can_solve_continuous_qp(self) -> None:
         with self.assertRaises(CustomQPSolverCalled):
             self.solve_example_qp(solver=self.custom_qp_solver)
 
-    def test_custom_mip_qp_solver_can_solve_mip_qp(self):
+    def test_custom_mip_qp_solver_can_solve_mip_qp(self) -> None:
         self.custom_qp_solver.MIP_CAPABLE = True
         with self.assertRaises(CustomQPSolverCalled):
             self.solve_example_mixed_integer_qp(solver=self.custom_qp_solver)
 
-    def test_custom_continuous_qp_solver_cannot_solve_mip_qp(self):
+    def test_custom_continuous_qp_solver_cannot_solve_mip_qp(self) -> None:
         self.custom_conic_solver.MIP_CAPABLE = False
         with self.assertRaises(cp.error.SolverError):
             self.solve_example_mixed_integer_qp(solver=self.custom_qp_solver)
 
-    def test_custom_qp_solver_cannot_solve_socp(self):
+    def test_custom_qp_solver_cannot_solve_socp(self) -> None:
         with self.assertRaises(cp.error.SolverError):
             self.solve_example_socp(solver=self.custom_qp_solver)
 
-    def test_custom_continuous_conic_solver_can_solve_continuous_socp(self):
+    def test_custom_continuous_conic_solver_can_solve_continuous_socp(self) -> None:
         with self.assertRaises(CustomConicSolverCalled):
             self.solve_example_socp(solver=self.custom_conic_solver)
 
-    def test_custom_mip_conic_solver_can_solve_mip_socp(self):
+    def test_custom_mip_conic_solver_can_solve_mip_socp(self) -> None:
         self.custom_conic_solver.MIP_CAPABLE = True
         with self.assertRaises(CustomConicSolverCalled):
             self.solve_example_mixed_integer_socp(solver=self.custom_conic_solver)
 
-    def test_custom_continuous_conic_solver_cannot_solve_mip_socp(self):
+    def test_custom_continuous_conic_solver_cannot_solve_mip_socp(self) -> None:
         self.custom_conic_solver.MIP_CAPABLE = False
         with self.assertRaises(cp.error.SolverError):
             self.solve_example_mixed_integer_qp(solver=self.custom_conic_solver)
 
-    def test_custom_conflicting_solver_fails(self):
+    def test_custom_conflicting_solver_fails(self) -> None:
         with self.assertRaises(cp.error.SolverError):
             self.solve_example_qp(solver=ConflictingCustomSolver())
 
     @staticmethod
-    def solve_example_qp(solver):
+    def solve_example_qp(solver) -> None:
         x = cp.Variable()
         quadratic = cp.sum_squares(x)
         problem = cp.Problem(cp.Minimize(quadratic))
         problem.solve(solver=solver)
 
     @staticmethod
-    def solve_example_mixed_integer_qp(solver):
+    def solve_example_mixed_integer_qp(solver) -> None:
         x = cp.Variable()
         z = cp.Variable(integer=True)
         quadratic = cp.sum_squares(x + z)
@@ -91,7 +91,7 @@ class TestCustomSolvers(unittest.TestCase):
         problem.solve(solver=solver)
 
     @staticmethod
-    def solve_example_socp(solver):
+    def solve_example_socp(solver) -> None:
         x = cp.Variable(2)
         y = cp.Variable()
         quadratic = cp.sum_squares(x)
@@ -99,7 +99,7 @@ class TestCustomSolvers(unittest.TestCase):
         problem.solve(solver=solver)
 
     @staticmethod
-    def solve_example_mixed_integer_socp(solver):
+    def solve_example_mixed_integer_socp(solver) -> None:
         x = cp.Variable(2)
         y = cp.Variable()
         z = cp.Variable(integer=True)

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -7,7 +7,7 @@ import warnings
 warnings.filterwarnings("ignore")
 
 
-def perturbcheck(problem, gp=False, delta=1e-5, atol=1e-8, eps=1e-10, **kwargs):
+def perturbcheck(problem, gp: bool=False, delta: float=1e-5, atol: float=1e-8, eps: float=1e-10, **kwargs) -> None:
     """Checks the analytical derivative against a numerical computation."""
     np.random.seed(0)
     if not problem.parameters():
@@ -41,7 +41,7 @@ def perturbcheck(problem, gp=False, delta=1e-5, atol=1e-8, eps=1e-10, **kwargs):
         param.value = old_values[param]
 
 
-def gradcheck(problem, gp=False, delta=1e-5, atol=1e-5, eps=1e-10, **kwargs):
+def gradcheck(problem, gp: bool=False, delta: float=1e-5, atol: float=1e-5, eps: float=1e-10, **kwargs) -> None:
     """Checks the analytical adjoint derivative against a numerical computation."""
     size = sum(p.size for p in problem.parameters())
     values = np.zeros(size)
@@ -87,14 +87,14 @@ def gradcheck(problem, gp=False, delta=1e-5, atol=1e-5, eps=1e-10, **kwargs):
 
 class TestBackward(BaseTest):
     """Test problem.backward() and problem.derivative()."""
-    def setUp(self):
+    def setUp(self) -> None:
         try:
             import diffcp
             diffcp  # for flake8
         except ImportError:
             self.skipTest("diffcp not installed.")
 
-    def test_scalar_quadratic(self):
+    def test_scalar_quadratic(self) -> None:
         b = cp.Parameter()
         x = cp.Variable()
         quadratic = cp.square(x - 2 * b)
@@ -118,7 +118,7 @@ class TestBackward(BaseTest):
         problem.derivative()
         self.assertAlmostEqual(x.delta, 2e-3)
 
-    def test_l1_square(self):
+    def test_l1_square(self) -> None:
         np.random.seed(0)
         n = 3
         x = cp.Variable(n)
@@ -134,7 +134,7 @@ class TestBackward(BaseTest):
         gradcheck(problem)
         perturbcheck(problem)
 
-    def test_l1_rectangle(self):
+    def test_l1_rectangle(self) -> None:
         np.random.seed(0)
         m, n = 3, 2
         x = cp.Variable(n)
@@ -149,7 +149,7 @@ class TestBackward(BaseTest):
         gradcheck(problem)
         perturbcheck(problem)
 
-    def test_least_squares(self):
+    def test_least_squares(self) -> None:
         np.random.seed(0)
         m, n = 20, 5
         A = cp.Parameter((m, n))
@@ -163,7 +163,7 @@ class TestBackward(BaseTest):
         gradcheck(problem)
         perturbcheck(problem)
 
-    def test_logistic_regression(self):
+    def test_logistic_regression(self) -> None:
         np.random.seed(0)
         N, n = 5, 2
         X_np = np.random.randn(N, n)
@@ -190,7 +190,7 @@ class TestBackward(BaseTest):
         gradcheck(problem, atol=1e-1, eps=1e-8)
         perturbcheck(problem, atol=1e-4)
 
-    def test_entropy_maximization(self):
+    def test_entropy_maximization(self) -> None:
         np.random.seed(0)
         n, m, p = 5, 3, 2
 
@@ -216,7 +216,7 @@ class TestBackward(BaseTest):
         gradcheck(problem, atol=1e-2, eps=1e-8)
         perturbcheck(problem, atol=1e-4)
 
-    def test_lml(self):
+    def test_lml(self) -> None:
         np.random.seed(0)
         k = 2
         x = cp.Parameter(4)
@@ -230,7 +230,7 @@ class TestBackward(BaseTest):
         gradcheck(problem, atol=1e-2)
         perturbcheck(problem, atol=1e-4)
 
-    def test_sdp(self):
+    def test_sdp(self) -> None:
         np.random.seed(0)
         n = 3
         p = 3
@@ -250,7 +250,7 @@ class TestBackward(BaseTest):
         gradcheck(problem, atol=1e-3)
         perturbcheck(problem)
 
-    def test_forget_requires_grad(self):
+    def test_forget_requires_grad(self) -> None:
         np.random.seed(0)
         m, n = 20, 5
         A = cp.Parameter((m, n))
@@ -270,7 +270,7 @@ class TestBackward(BaseTest):
                                     "solve with `requires_grad=True`"):
             problem.derivative()
 
-    def test_infeasible(self):
+    def test_infeasible(self) -> None:
         x = cp.Variable()
         param = cp.Parameter()
         problem = cp.Problem(cp.Minimize(param), [x >= 1, x <= -1])
@@ -285,7 +285,7 @@ class TestBackward(BaseTest):
                                                     "infeasible/unbounded.*"):
                 problem.derivative()
 
-    def test_unbounded(self):
+    def test_unbounded(self) -> None:
         x = cp.Variable()
         param = cp.Parameter()
         problem = cp.Problem(cp.Minimize(x), [x <= param])
@@ -300,7 +300,7 @@ class TestBackward(BaseTest):
                                                     "infeasible/unbounded.*"):
                 problem.derivative()
 
-    def test_unsupported_solver(self):
+    def test_unsupported_solver(self) -> None:
         x = cp.Variable()
         param = cp.Parameter()
         problem = cp.Problem(cp.Minimize(x), [x <= param])
@@ -310,7 +310,7 @@ class TestBackward(BaseTest):
                                     "only supported solver is SCS.*"):
             problem.solve(cp.ECOS, requires_grad=True)
 
-    def test_zero_in_problem_data(self):
+    def test_zero_in_problem_data(self) -> None:
         x = cp.Variable()
         param = cp.Parameter()
         param.value = 0.0
@@ -322,14 +322,14 @@ class TestBackward(BaseTest):
 
 class TestBackwardDgp(BaseTest):
     """Test problem.backward() and problem.derivative()."""
-    def setUp(self):
+    def setUp(self) -> None:
         try:
             import diffcp
             diffcp  # for flake8
         except ImportError:
             self.skipTest("diffcp not installed.")
 
-    def test_one_minus_analytic(self):
+    def test_one_minus_analytic(self) -> None:
         # construct a problem with solution
         # x^\star(\alpha) = 1 - \alpha^2, and derivative
         # x^\star'(\alpha) = -2\alpha
@@ -363,7 +363,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-3)
 
-    def test_analytic_param_in_exponent(self):
+    def test_analytic_param_in_exponent(self) -> None:
         # construct a problem with solution
         # x^\star(\alpha) = 1 - 2^alpha, and derivative
         # x^\star'(\alpha) = -log(2) * 2^\alpha
@@ -398,7 +398,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-3)
 
-    def test_param_used_twice(self):
+    def test_param_used_twice(self) -> None:
         # construct a problem with solution
         # x^\star(\alpha) = 1 - \alpha^2 - alpha^3, and derivative
         # x^\star'(\alpha) = -2\alpha - 3\alpha^2
@@ -420,7 +420,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-3)
 
-    def test_param_used_in_exponent_and_elsewhere(self):
+    def test_param_used_in_exponent_and_elsewhere(self) -> None:
         # construct a problem with solution
         # x^\star(\alpha) = 1 - 0.3^alpha - alpha^2, and derivative
         # x^\star'(\alpha) = -log(0.3) * 0.2^\alpha - 2*alpha
@@ -439,7 +439,7 @@ class TestBackwardDgp(BaseTest):
         self.assertAlmostEqual(alpha.gradient, -np.log(base)*base**(0.5) - 2*0.5)
         self.assertAlmostEqual(x.delta, alpha.gradient*1e-5, places=3)
 
-    def test_basic_gp(self):
+    def test_basic_gp(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         z = cp.Variable(pos=True)
@@ -456,7 +456,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-3)
 
-    def test_maximum(self):
+    def test_maximum(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         a = cp.Parameter(value=0.5)
@@ -472,7 +472,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-3)
 
-    def test_max(self):
+    def test_max(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         a = cp.Parameter(value=0.5)
@@ -488,7 +488,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True)
         perturbcheck(problem, gp=True)
 
-    def test_div(self):
+    def test_div(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         a = cp.Parameter(pos=True, value=3)
@@ -497,7 +497,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True)
         perturbcheck(problem, gp=True)
 
-    def test_one_minus_pos(self):
+    def test_one_minus_pos(self) -> None:
         x = cp.Variable(pos=True)
         a = cp.Parameter(pos=True, value=3)
         b = cp.Parameter(pos=True, value=0.1)
@@ -507,7 +507,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-4)
         perturbcheck(problem, gp=True, atol=1e-4)
 
-    def test_paper_example_one_minus_pos(self):
+    def test_paper_example_one_minus_pos(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         a = cp.Parameter(pos=True, value=2)
@@ -519,7 +519,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-3)
 
-    def test_matrix_constraint(self):
+    def test_matrix_constraint(self) -> None:
         X = cp.Variable((2, 2), pos=True)
         a = cp.Parameter(pos=True, value=0.1)
         obj = cp.Minimize(cp.geo_mean(cp.vec(X)))
@@ -529,7 +529,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True)
         perturbcheck(problem, gp=True)
 
-    def test_paper_example_exp_log(self):
+    def test_paper_example_exp_log(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         a = cp.Parameter(pos=True, value=0.2)
@@ -540,7 +540,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-2)
         perturbcheck(problem, gp=True, atol=1e-2)
 
-    def test_matrix_completion(self):
+    def test_matrix_completion(self) -> None:
         X = cp.Variable((3, 3), pos=True)
         # TODO(akshayka): pf matrix completion not differentiable ...?
         # I could believe that ... or a bug?
@@ -558,7 +558,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-3)
         perturbcheck(problem, gp=True, atol=1e-4)
 
-    def test_rank_one_nmf(self):
+    def test_rank_one_nmf(self) -> None:
         X = cp.Variable((3, 3), pos=True)
         x = cp.Variable((3,), pos=True)
         y = cp.Variable((3,), pos=True)
@@ -584,7 +584,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-2)
         perturbcheck(problem, gp=True, atol=1e-2)
 
-    def test_documentation_prob(self):
+    def test_documentation_prob(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         z = cp.Variable(pos=True)
@@ -600,7 +600,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-2)
         perturbcheck(problem, gp=True, atol=1e-2)
 
-    def test_sum_squares_vector(self):
+    def test_sum_squares_vector(self) -> None:
         alpha = cp.Parameter(shape=(2,), pos=True, value=[1.0, 1.0])
         beta = cp.Parameter(pos=True, value=20)
         kappa = cp.Parameter(pos=True, value=10)
@@ -612,7 +612,7 @@ class TestBackwardDgp(BaseTest):
         gradcheck(problem, gp=True, atol=1e-1)
         perturbcheck(problem, gp=True, atol=1e-1)
 
-    def test_sum_matrix(self):
+    def test_sum_matrix(self) -> None:
         w = cp.Variable((2, 2), pos=True)
         h = cp.Variable((2, 2), pos=True)
         alpha = cp.Parameter(pos=True, value=1.0)

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 class TestDgp(BaseTest):
-    def test_product(self):
+    def test_product(self) -> None:
         x = cvxpy.Variable((), pos=True)
         y = cvxpy.Variable((), pos=True)
         prod = x * y
@@ -27,7 +27,7 @@ class TestDgp(BaseTest):
         self.assertTrue(not prod.is_log_log_convex())
         self.assertTrue(not prod.is_log_log_concave())
 
-    def test_product_with_unconstrained_variables_is_not_dgp(self):
+    def test_product_with_unconstrained_variables_is_not_dgp(self) -> None:
         x = cvxpy.Variable()
         y = cvxpy.Variable()
         prod = x * y
@@ -41,7 +41,7 @@ class TestDgp(BaseTest):
         self.assertTrue(not prod.is_log_log_convex())
         self.assertTrue(not prod.is_log_log_concave())
 
-    def test_division(self):
+    def test_division(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         div = x / y
@@ -62,7 +62,7 @@ class TestDgp(BaseTest):
         self.assertFalse(div.is_log_log_concave())
         self.assertFalse(div.is_dgp())
 
-    def test_add(self):
+    def test_add(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         expr = x + y
@@ -74,7 +74,7 @@ class TestDgp(BaseTest):
         self.assertTrue(posynomial.is_dgp())
         self.assertTrue(posynomial.is_log_log_convex())
 
-    def test_add_with_unconstrained_variables_is_not_dgp(self):
+    def test_add_with_unconstrained_variables_is_not_dgp(self) -> None:
         x = cvxpy.Variable()
         y = cvxpy.Variable(pos=True)
         expr = x + y
@@ -87,7 +87,7 @@ class TestDgp(BaseTest):
         self.assertTrue(not posynomial.is_log_log_convex())
         self.assertTrue(not posynomial.is_log_log_concave())
 
-    def test_monomials(self):
+    def test_monomials(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         z = cvxpy.Variable(pos=True)
@@ -101,7 +101,7 @@ class TestDgp(BaseTest):
         self.assertTrue(not monomial.is_log_log_convex())
         self.assertTrue(not monomial.is_log_log_concave())
 
-    def test_maximum(self):
+    def test_maximum(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         z = cvxpy.Variable(pos=True)
@@ -122,7 +122,7 @@ class TestDgp(BaseTest):
         self.assertTrue(expr.is_dgp())
         self.assertTrue(expr.is_log_log_convex())
 
-    def test_minimum(self):
+    def test_minimum(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         z = cvxpy.Variable(pos=True)
@@ -144,12 +144,12 @@ class TestDgp(BaseTest):
         self.assertTrue(not expr.is_log_log_convex())
         self.assertTrue(expr.is_log_log_concave())
 
-    def test_constant(self):
+    def test_constant(self) -> None:
         x = cvxpy.Constant(1.0)
         self.assertTrue(x.is_dgp())
         self.assertFalse((-1.0*x).is_dgp())
 
-    def test_geo_mean(self):
+    def test_geo_mean(self) -> None:
         x = cvxpy.Variable(3, pos=True)
         p = [1, 2, 0.5]
         geo_mean = cvxpy.geo_mean(x, p)
@@ -158,11 +158,11 @@ class TestDgp(BaseTest):
         self.assertTrue(geo_mean.is_log_log_convex())
         self.assertTrue(geo_mean.is_log_log_concave())
 
-    def test_builtin_sum(self):
+    def test_builtin_sum(self) -> None:
         x = cvxpy.Variable(2, pos=True)
         self.assertTrue(sum(x).is_log_log_convex())
 
-    def test_gmatmul(self):
+    def test_gmatmul(self) -> None:
         x = cvxpy.Variable(2, pos=True)
         A = cvxpy.Variable((2, 2))
         with self.assertRaises(Exception) as cm:
@@ -198,7 +198,7 @@ class TestDgp(BaseTest):
         self.assertFalse(gmatmul.is_incr(0))
         self.assertFalse(gmatmul.is_decr(0))
 
-    def test_power_sign(self):
+    def test_power_sign(self) -> None:
         x = cvxpy.Variable(pos=True)
         self.assertTrue((x**1).is_nonneg())
         self.assertFalse((x**1).is_nonpos())

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -13,7 +13,7 @@ SOLVER = cvxpy.ECOS
 
 
 class TestDgp2Dcp(BaseTest):
-    def test_unconstrained_monomial(self):
+    def test_unconstrained_monomial(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         prod = x * y
@@ -53,7 +53,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(dgp.value, float("inf"))
         self.assertEqual(dgp.status, "unbounded")
 
-    def test_basic_equality_constraint(self):
+    def test_basic_equality_constraint(self) -> None:
         x = cvxpy.Variable(pos=True)
         dgp = cvxpy.Problem(cvxpy.Minimize(x), [x == 1.0])
         dgp2dcp = cvxpy.reductions.Dgp2Dcp(dgp)
@@ -72,14 +72,14 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(dgp.value, 1.0)
         self.assertAlmostEqual(x.value, 1.0)
 
-    def test_basic_gp(self):
+    def test_basic_gp(self) -> None:
         x, y, z = cvxpy.Variable((3,), pos=True)
         constraints = [2*x*y + 2*x*z + 2*y*z <= 1.0, x >= 2*y]
         problem = cvxpy.Problem(cvxpy.Minimize(1/(x*y*z)), constraints)
         problem.solve(SOLVER, gp=True)
         self.assertAlmostEqual(15.59, problem.value, places=2)
 
-    def test_maximum(self):
+    def test_maximum(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
 
@@ -101,7 +101,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(dgp.value, 6.0, places=4)
         self.assertAlmostEqual(x.value, 1.0)
 
-    def test_prod(self):
+    def test_prod(self) -> None:
         X = np.arange(12).reshape((4, 3))
         np.testing.assert_almost_equal(np.prod(X), cvxpy.prod(X).value)
         np.testing.assert_almost_equal(
@@ -159,7 +159,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertTrue(cvxpy.prod([m, 1/posy1]).is_log_log_concave())
         self.assertFalse(cvxpy.prod([m, 1/posy1]).is_log_log_convex())
 
-    def test_max(self):
+    def test_max(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
 
@@ -181,7 +181,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(dgp.value, 6.0, places=4)
         self.assertAlmostEqual(x.value, 1.0)
 
-    def test_minimum(self):
+    def test_minimum(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
 
@@ -197,7 +197,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(x.value, 1.0)
         self.assertAlmostEqual(y.value, 4.0)
 
-    def test_min(self):
+    def test_min(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
 
@@ -213,7 +213,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(x.value, 1.0)
         self.assertAlmostEqual(y.value, 4.0)
 
-    def test_sum_largest(self):
+    def test_sum_largest(self) -> None:
         self.skipTest("Enable test once sum_largest is implemented.")
         x = cvxpy.Variable((4,), pos=True)
         obj = cvxpy.Minimize(cvxpy.sum_largest(x, 3))
@@ -289,7 +289,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual((x[0] * x[1]).value, 16.0, places=2)
         self.assertAlmostEqual(x[3].value, 0.0, places=2)
 
-    def test_div(self):
+    def test_div(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         p = cvxpy.Problem(cvxpy.Minimize(x * y),
@@ -298,7 +298,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(y.value, 1.0)
         self.assertAlmostEqual(x.value, 1.0 / 3.0)
 
-    def test_geo_mean(self):
+    def test_geo_mean(self) -> None:
         x = cvxpy.Variable(3, pos=True)
         p = [1, 2, 0.5]
         geo_mean = cvxpy.geo_mean(x, p)
@@ -315,7 +315,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertEqual(dgp.value, 0.0)
         self.assertEqual(dgp.status, "unbounded")
 
-    def test_solving_non_dgp_problem_raises_error(self):
+    def test_solving_non_dgp_problem_raises_error(self) -> None:
         problem = cvxpy.Problem(cvxpy.Minimize(-1.0 * cvxpy.Variable()), [])
         with self.assertRaisesRegex(error.DGPError,
                                     r"Problem does not follow DGP "
@@ -325,7 +325,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertEqual(problem.status, "unbounded")
         self.assertEqual(problem.value, -float("inf"))
 
-    def test_solving_non_dcp_problem_raises_error(self):
+    def test_solving_non_dcp_problem_raises_error(self) -> None:
         problem = cvxpy.Problem(
           cvxpy.Minimize(cvxpy.Variable(pos=True) * cvxpy.Variable(pos=True)),
         )
@@ -337,7 +337,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertEqual(problem.status, "unbounded")
         self.assertAlmostEqual(problem.value, 0.0)
 
-    def test_solving_non_dcp_problems_raises_detailed_error(self):
+    def test_solving_non_dcp_problems_raises_detailed_error(self) -> None:
         x = cvxpy.Variable(3)
         problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(x) - cvxpy.sum_squares(x)))
         with self.assertRaisesRegex(error.DCPError, r"The objective is not DCP"):
@@ -348,7 +348,7 @@ class TestDgp2Dcp(BaseTest):
         with self.assertRaisesRegex(error.DCPError, r"The following constraints are not DCP"):
             problem.solve(SOLVER)
 
-    def test_add_canon(self):
+    def test_add_canon(self) -> None:
         X = cvxpy.Constant(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
         Y = cvxpy.Constant(np.array([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]))
         Z = X + Y
@@ -368,7 +368,7 @@ class TestDgp2Dcp(BaseTest):
         expected = np.log(np.exp(X.value) + np.exp(y.value))
         np.testing.assert_almost_equal(expected, canon_matrix.value)
 
-    def test_matmul_canon(self):
+    def test_matmul_canon(self) -> None:
         X = cvxpy.Constant(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
         Y = cvxpy.Constant(np.array([[1.0], [2.0], [3.0]]))
         Z = cvxpy.matmul(X, Y)
@@ -381,7 +381,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(first_entry, canon_matrix[0, 0].value)
         self.assertAlmostEqual(second_entry, canon_matrix[1, 0].value)
 
-    def test_trace_canon(self):
+    def test_trace_canon(self) -> None:
         X = cvxpy.Constant(np.array([[1.0, 5.0], [9.0, 14.0]]))
         Y = cvxpy.trace(X)
         canon, constraints = dgp_atom_canon.trace_canon(Y, Y.args)
@@ -390,7 +390,7 @@ class TestDgp2Dcp(BaseTest):
         expected = np.log(np.exp(1.0) + np.exp(14.0))
         self.assertAlmostEqual(expected, canon.value)
 
-    def test_one_minus_pos(self):
+    def test_one_minus_pos(self) -> None:
         x = cvxpy.Variable(pos=True)
         obj = cvxpy.Maximize(x)
         constr = [cvxpy.one_minus_pos(x) >= 0.4]
@@ -399,7 +399,7 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(problem.value, 0.6)
         self.assertAlmostEqual(x.value, 0.6)
 
-    def test_qp_solver_not_allowed(self):
+    def test_qp_solver_not_allowed(self) -> None:
         x = cvxpy.Variable(pos=True)
         problem = cvxpy.Problem(cvxpy.Minimize(x))
         error_msg = ("When `gp=True`, `solver` must be a conic solver "
@@ -409,7 +409,7 @@ class TestDgp2Dcp(BaseTest):
             problem.solve(solver="OSQP", gp=True)
             self.assertEqual(error_msg, str(err))
 
-    def test_paper_example_sum_largest(self):
+    def test_paper_example_sum_largest(self) -> None:
         self.skipTest("Enable test once sum_largest is implemented.")
         x = cvxpy.Variable((4,), pos=True)
         x0, x1, x2, x3 = (x[0], x[1], x[2], x[3])
@@ -423,7 +423,7 @@ class TestDgp2Dcp(BaseTest):
         # smoke test.
         p.solve(SOLVER, gp=True)
 
-    def test_paper_example_one_minus_pos(self):
+    def test_paper_example_one_minus_pos(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         obj = cvxpy.Minimize(x * y)
@@ -432,7 +432,7 @@ class TestDgp2Dcp(BaseTest):
         # smoke test.
         problem.solve(SOLVER, gp=True)
 
-    def test_paper_example_eye_minus_inv(self):
+    def test_paper_example_eye_minus_inv(self) -> None:
         X = cvxpy.Variable((2, 2), pos=True)
         obj = cvxpy.Minimize(cvxpy.trace(cvxpy.eye_minus_inv(X)))
         constr = [cvxpy.geo_mean(cvxpy.diag(X)) == 0.1,
@@ -442,7 +442,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(X.value, 0.1*np.ones((2, 2)), decimal=3)
         self.assertAlmostEqual(problem.value, 2.25)
 
-    def test_simpler_eye_minus_inv(self):
+    def test_simpler_eye_minus_inv(self) -> None:
         X = cvxpy.Variable((2, 2), pos=True)
         obj = cvxpy.Minimize(cvxpy.trace(cvxpy.eye_minus_inv(X)))
         constr = [cvxpy.diag(X) == 0.1,
@@ -452,7 +452,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(X.value, 0.1*np.ones((2, 2)), decimal=3)
         self.assertAlmostEqual(problem.value, 2.25)
 
-    def test_paper_example_exp_log(self):
+    def test_paper_example_exp_log(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         obj = cvxpy.Minimize(x * y)
@@ -461,7 +461,7 @@ class TestDgp2Dcp(BaseTest):
         # smoke test.
         problem.solve(SOLVER, gp=True)
 
-    def test_pf_matrix_completion(self):
+    def test_pf_matrix_completion(self) -> None:
         X = cvxpy.Variable((3, 3), pos=True)
         obj = cvxpy.Minimize(cvxpy.pf_eigenvalue(X))
         known_indices = tuple(zip(*[[0, 0], [0, 2], [1, 1], [2, 0], [2, 1]]))
@@ -473,7 +473,7 @@ class TestDgp2Dcp(BaseTest):
         # smoke test.
         problem.solve(SOLVER, gp=True)
 
-    def test_rank_one_nmf(self):
+    def test_rank_one_nmf(self) -> None:
         X = cvxpy.Variable((3, 3), pos=True)
         x = cvxpy.Variable((3,), pos=True)
         y = cvxpy.Variable((3,), pos=True)
@@ -494,7 +494,7 @@ class TestDgp2Dcp(BaseTest):
         prob = cvxpy.Problem(cvxpy.Minimize(objective), constraints)
         prob.solve(SOLVER, gp=True)
 
-    def test_documentation_prob(self):
+    def test_documentation_prob(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         z = cvxpy.Variable(pos=True)
@@ -506,7 +506,7 @@ class TestDgp2Dcp(BaseTest):
         # Smoke test.
         problem.solve(SOLVER, gp=True)
 
-    def test_solver_error(self):
+    def test_solver_error(self) -> None:
         x = cvxpy.Variable(pos=True)
         y = cvxpy.Variable(pos=True)
         prod = x * y
@@ -517,7 +517,7 @@ class TestDgp2Dcp(BaseTest):
         dgp_soln = dgp2dcp.invert(soln, inverse_data)
         self.assertEqual(dgp_soln.status, SOLVER_ERROR)
 
-    def test_sum_scalar(self):
+    def test_sum_scalar(self) -> None:
         w = cvxpy.Variable(pos=True)
         h = cvxpy.Variable(pos=True)
         problem = cvxpy.Problem(cvxpy.Minimize(h),
@@ -527,7 +527,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(h.value, 2)
         np.testing.assert_almost_equal(w.value, 5)
 
-    def test_sum_vector(self):
+    def test_sum_vector(self) -> None:
         w = cvxpy.Variable(2, pos=True)
         h = cvxpy.Variable(2, pos=True)
         problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(h)),
@@ -538,7 +538,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(h.value, np.array([2, 2]))
         np.testing.assert_almost_equal(w.value, np.array([5, 5]))
 
-    def test_sum_squares_vector(self):
+    def test_sum_squares_vector(self) -> None:
         w = cvxpy.Variable(2, pos=True)
         h = cvxpy.Variable(2, pos=True)
         problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum_squares(h)),
@@ -549,7 +549,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(h.value, np.array([2, 2]))
         np.testing.assert_almost_equal(w.value, np.array([5, 5]))
 
-    def test_sum_matrix(self):
+    def test_sum_matrix(self) -> None:
         w = cvxpy.Variable((2, 2), pos=True)
         h = cvxpy.Variable((2, 2), pos=True)
         problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(h)),
@@ -560,7 +560,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(h.value, np.array([[2, 2], [2, 2]]))
         np.testing.assert_almost_equal(w.value, np.array([[5, 5], [5, 5]]))
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         w = cvxpy.Variable((1, 1), pos=True)
         h = cvxpy.Variable(pos=True)
         problem = cvxpy.Problem(cvxpy.Minimize(h),
@@ -570,7 +570,7 @@ class TestDgp2Dcp(BaseTest):
         np.testing.assert_almost_equal(h.value, 2)
         np.testing.assert_almost_equal(w.value, np.array([[5]]))
 
-    def test_parameter(self):
+    def test_parameter(self) -> None:
         param = cvxpy.Parameter(pos=True)
         param.value = 1.0
         dgp = cvxpy.Problem(cvxpy.Minimize(param), [])
@@ -587,7 +587,7 @@ class TestDgp2Dcp(BaseTest):
         problem.solve(SOLVER, gp=True)
         self.assertAlmostEqual(problem.value, 2.0)
 
-    def test_parameter_name(self):
+    def test_parameter_name(self) -> None:
         param = cvxpy.Parameter(pos=True, name='alpha')
         param.value = 1.0
         dgp = cvxpy.Problem(cvxpy.Minimize(param), [])
@@ -595,7 +595,7 @@ class TestDgp2Dcp(BaseTest):
         dcp = dgp2dcp.reduce()
         self.assertAlmostEqual(dcp.parameters()[0].name(), 'alpha')
 
-    def test_gmatmul(self):
+    def test_gmatmul(self) -> None:
         x = cvxpy.Variable(2, pos=True)
         A = np.array([[-5., 2.], [1., -3.]])
         b = np.array([3, 2])

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -25,7 +25,7 @@ from cvxpy.tests.base_test import BaseTest
 class TestDomain(BaseTest):
     """ Unit tests for the domain module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
 
         self.x = Variable(2, name='x')
@@ -36,7 +36,7 @@ class TestDomain(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-    def test_partial_problem(self):
+    def test_partial_problem(self) -> None:
         """Test domain for partial minimization/maximization problems.
         """
         for obj in [Minimize((self.a)**-1), Maximize(cp.log(self.a))]:
@@ -70,7 +70,7 @@ class TestDomain(BaseTest):
             self.assertAlmostEqual(self.a.value, -100)
             self.assertItemsAlmostEqual(self.x.value, [0, 0])
 
-    def test_geo_mean(self):
+    def test_geo_mean(self) -> None:
         """Test domain for geo_mean
         """
         dom = cp.geo_mean(self.x).domain
@@ -91,7 +91,7 @@ class TestDomain(BaseTest):
         prob.solve()
         self.assertItemsAlmostEqual(self.z.value, [-1, 0, 0])
 
-    def test_quad_over_lin(self):
+    def test_quad_over_lin(self) -> None:
         """Test domain for quad_over_lin
         """
         dom = cp.quad_over_lin(self.x, self.a).domain
@@ -107,7 +107,7 @@ class TestDomain(BaseTest):
     #     Problem(Minimize(norm2(self.A-A0)), dom).solve()
     #     self.assertItemsAlmostEqual(self.A.value, np.array([[1, 2.5], [2.5, 4]]))
 
-    def test_pnorm(self):
+    def test_pnorm(self) -> None:
         """ Test domain for pnorm.
         """
         dom = cp.pnorm(self.a, -0.5).domain
@@ -115,28 +115,28 @@ class TestDomain(BaseTest):
         prob.solve()
         self.assertAlmostEqual(prob.value, 0)
 
-    def test_log(self):
+    def test_log(self) -> None:
         """Test domain for log.
         """
         dom = cp.log(self.a).domain
         Problem(Minimize(self.a), dom).solve()
         self.assertAlmostEqual(self.a.value, 0)
 
-    def test_log1p(self):
+    def test_log1p(self) -> None:
         """Test domain for log1p.
         """
         dom = cp.log1p(self.a).domain
         Problem(Minimize(self.a), dom).solve()
         self.assertAlmostEqual(self.a.value, -1)
 
-    def test_entr(self):
+    def test_entr(self) -> None:
         """Test domain for entr.
         """
         dom = cp.entr(self.a).domain
         Problem(Minimize(self.a), dom).solve()
         self.assertAlmostEqual(self.a.value, 0)
 
-    def test_kl_div(self):
+    def test_kl_div(self) -> None:
         """Test domain for kl_div.
         """
         b = Variable()
@@ -145,7 +145,7 @@ class TestDomain(BaseTest):
         self.assertAlmostEqual(self.a.value, 0)
         self.assertAlmostEqual(b.value, 0)
 
-    def test_power(self):
+    def test_power(self) -> None:
         """Test domain for power.
         """
         dom = cp.sqrt(self.a).domain
@@ -164,7 +164,7 @@ class TestDomain(BaseTest):
         Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
         self.assertAlmostEqual(self.a.value, 0)
 
-    def test_log_det(self):
+    def test_log_det(self) -> None:
         """Test domain for log_det.
         """
         dom = cp.log_det(self.A + np.eye(2)).domain
@@ -172,7 +172,7 @@ class TestDomain(BaseTest):
         prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(prob.value, -2, places=3)
 
-    def test_matrix_frac(self):
+    def test_matrix_frac(self) -> None:
         """Test domain for matrix_frac.
         """
         dom = cp.matrix_frac(self.x, self.A + np.eye(2)).domain

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -11,53 +11,53 @@ SOLVER = cp.ECOS
 
 
 class TestDcp(BaseTest):
-    def test_multiply_scalar_params_not_dpp(self):
+    def test_multiply_scalar_params_not_dpp(self) -> None:
         x = cp.Parameter()
         product = x * x
         self.assertFalse(product.is_dpp())
         self.assertTrue(product.is_dcp())
 
-    def test_matmul_params_not_dpp(self):
+    def test_matmul_params_not_dpp(self) -> None:
         X = cp.Parameter((4, 4))
         product = X @ X
         self.assertTrue(product.is_dcp())
         self.assertFalse(product.is_dpp())
 
-    def test_multiply_param_and_variable_is_dpp(self):
+    def test_multiply_param_and_variable_is_dpp(self) -> None:
         x = cp.Parameter()
         y = cp.Variable()
         product = x * y
         self.assertTrue(product.is_dpp())
         self.assertTrue(product.is_dcp())
 
-    def test_multiply_variable_and_param_is_dpp(self):
+    def test_multiply_variable_and_param_is_dpp(self) -> None:
         x = cp.Parameter()
         y = cp.Variable()
         product = cp.multiply(y, x)
         self.assertTrue(product.is_dpp())
         self.assertTrue(product.is_dcp())
 
-    def test_multiply_nonlinear_param_and_variable_is_not_dpp(self):
+    def test_multiply_nonlinear_param_and_variable_is_not_dpp(self) -> None:
         x = cp.Parameter()
         y = cp.Variable()
         product = cp.exp(x) * y
         self.assertFalse(product.is_dpp())
 
-    def test_multiply_nonlinear_nonneg_param_and_nonneg_variable_is_not_dpp(self):
+    def test_multiply_nonlinear_nonneg_param_and_nonneg_variable_is_not_dpp(self) -> None:
         x = cp.Parameter(nonneg=True)
         y = cp.Variable(nonneg=True)
         product = cp.exp(x) * y
         self.assertFalse(product.is_dpp())
         self.assertTrue(product.is_dcp())
 
-    def test_multiply_affine_param_and_variable_is_dpp(self):
+    def test_multiply_affine_param_and_variable_is_dpp(self) -> None:
         x = cp.Parameter()
         y = cp.Variable()
         product = (x + x) * y
         self.assertTrue(product.is_dpp())
         self.assertTrue(product.is_dcp())
 
-    def test_multiply_param_plus_var_times_const(self):
+    def test_multiply_param_plus_var_times_const(self) -> None:
         x = cp.Parameter()
         y = cp.Variable()
         product = (x + y) * 5
@@ -65,7 +65,7 @@ class TestDcp(BaseTest):
         self.assertTrue(product.is_dcp())
         self.assertTrue(product.is_dpp())
 
-    def test_multiply_param_and_nonlinear_variable_is_dpp(self):
+    def test_multiply_param_and_nonlinear_variable_is_dpp(self) -> None:
         x = cp.Parameter(nonneg=True)
         y = cp.Variable()
         product = x * cp.exp(y)
@@ -73,7 +73,7 @@ class TestDcp(BaseTest):
         self.assertTrue(product.is_dcp())
         self.assertTrue(product.is_dpp())
 
-    def test_nonlinear_equality_not_dpp(self):
+    def test_nonlinear_equality_not_dpp(self) -> None:
         x = cp.Variable()
         a = cp.Parameter()
         constraint = [x == cp.norm(a)]
@@ -81,7 +81,7 @@ class TestDcp(BaseTest):
         problem = cp.Problem(cp.Minimize(0), constraint)
         self.assertFalse(problem.is_dcp(dpp=True))
 
-    def test_nonconvex_inequality_not_dpp(self):
+    def test_nonconvex_inequality_not_dpp(self) -> None:
         x = cp.Variable()
         a = cp.Parameter()
         constraint = [x <= cp.norm(a)]
@@ -89,7 +89,7 @@ class TestDcp(BaseTest):
         problem = cp.Problem(cp.Minimize(0), constraint)
         self.assertFalse(problem.is_dcp(dpp=True))
 
-    def test_solve_multiply_param_plus_var_times_const(self):
+    def test_solve_multiply_param_plus_var_times_const(self) -> None:
         x = cp.Parameter()
         y = cp.Variable()
         product = (x + y) * 5
@@ -99,7 +99,7 @@ class TestDcp(BaseTest):
         value = problem.solve(cp.SCS)
         self.assertAlmostEqual(value, 15)
 
-    def test_paper_example_is_dpp(self):
+    def test_paper_example_is_dpp(self) -> None:
         F = cp.Parameter((2, 2))
         x = cp.Variable((2, 1))
         g = cp.Parameter((2, 1))
@@ -111,12 +111,12 @@ class TestDcp(BaseTest):
         self.assertTrue(constraints[0].is_dpp())
         self.assertTrue(problem.is_dpp())
 
-    def test_non_dcp_expression_is_not_dpp(self):
+    def test_non_dcp_expression_is_not_dpp(self) -> None:
         x = cp.Parameter()
         expr = cp.exp(cp.log(x))
         self.assertFalse(expr.is_dpp())
 
-    def test_can_solve_non_dpp_problem(self):
+    def test_can_solve_non_dpp_problem(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
@@ -131,7 +131,7 @@ class TestDcp(BaseTest):
             warnings.simplefilter('ignore')
             self.assertEqual(problem.solve(cp.SCS), 9)
 
-    def test_solve_dpp_problem(self):
+    def test_solve_dpp_problem(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
@@ -142,7 +142,7 @@ class TestDcp(BaseTest):
         x.value = 3
         self.assertAlmostEqual(problem.solve(cp.SCS), 6)
 
-    def test_chain_data_for_non_dpp_problem_evals_params(self):
+    def test_chain_data_for_non_dpp_problem_evals_params(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
@@ -154,7 +154,7 @@ class TestDcp(BaseTest):
         self.assertTrue(cp.reductions.eval_params.EvalParams in
                         [type(r) for r in chain.reductions])
 
-    def test_chain_data_for_dpp_problem_does_not_eval_params(self):
+    def test_chain_data_for_dpp_problem_does_not_eval_params(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
@@ -163,7 +163,7 @@ class TestDcp(BaseTest):
         self.assertFalse(cp.reductions.eval_params.EvalParams
                          in [type(r) for r in chain.reductions])
 
-    def test_param_quad_form_not_dpp(self):
+    def test_param_quad_form_not_dpp(self) -> None:
         x = cp.Variable((2, 1))
         P = cp.Parameter((2, 2), PSD=True)
         P.value = np.eye(2)
@@ -171,14 +171,14 @@ class TestDcp(BaseTest):
         self.assertFalse(y.is_dpp())
         self.assertTrue(y.is_dcp())
 
-    def test_const_quad_form_is_dpp(self):
+    def test_const_quad_form_is_dpp(self) -> None:
         x = cp.Variable((2, 1))
         P = np.eye(2)
         y = cp.quad_form(x, P)
         self.assertTrue(y.is_dpp())
         self.assertTrue(y.is_dcp())
 
-    def test_paper_example_logreg_is_dpp(self):
+    def test_paper_example_logreg_is_dpp(self) -> None:
         N, n = 3, 2
         beta = cp.Variable((n, 1))
         b = cp.Variable((1, 1))
@@ -196,7 +196,7 @@ class TestDcp(BaseTest):
         self.assertTrue(problem.is_dcp())
         self.assertTrue(problem.is_dpp())
 
-    def test_paper_example_stoch_control(self):
+    def test_paper_example_stoch_control(self) -> None:
         n, m = 3, 3
         x = cp.Parameter((n, 1))
         P_sqrt = cp.Parameter((m, m))
@@ -210,7 +210,7 @@ class TestDcp(BaseTest):
         self.assertTrue(problem.is_dpp())
         self.assertTrue(problem.is_dcp())
 
-    def test_paper_example_relu(self):
+    def test_paper_example_relu(self) -> None:
         n = 2
         x = cp.Parameter(n)
         y = cp.Variable(n)
@@ -225,7 +225,7 @@ class TestDcp(BaseTest):
         problem.solve(cp.SCS, eps=1e-8)
         self.assertItemsAlmostEqual(y.value, np.zeros(2))
 
-    def test_paper_example_opt_net_qp(self):
+    def test_paper_example_opt_net_qp(self) -> None:
         m, n = 3, 2
         G = cp.Parameter((m, n))
         h = cp.Parameter((m, 1))
@@ -236,7 +236,7 @@ class TestDcp(BaseTest):
         problem = cp.Problem(objective, constraints)
         self.assertTrue(problem.is_dpp())
 
-    def test_paper_example_ellipsoidal_constraints(self):
+    def test_paper_example_ellipsoidal_constraints(self) -> None:
         n = 2
         A_sqrt = cp.Parameter((n, n))
         z = cp.Parameter(n)
@@ -249,7 +249,7 @@ class TestDcp(BaseTest):
         problem = cp.Problem(objective, constraints)
         self.assertTrue(problem.is_dpp())
 
-    def test_non_dpp_powers(self):
+    def test_non_dpp_powers(self) -> None:
         s = cp.Parameter(1, nonneg=True)
         x = cp.Variable(1)
         obj = cp.Maximize(x+s)
@@ -285,7 +285,7 @@ class TestDcp(BaseTest):
 
 
 class TestDgp(BaseTest):
-    def test_basic_equality_constraint(self):
+    def test_basic_equality_constraint(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         x = cp.Variable(pos=True)
         dgp = cp.Problem(cp.Minimize(x), [x == alpha])
@@ -305,28 +305,28 @@ class TestDgp(BaseTest):
         dgp.solve(gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 2.0)
 
-    def test_basic_inequality_constraint(self):
+    def test_basic_inequality_constraint(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         x = cp.Variable(pos=True)
         constraint = [x + alpha <= x]
         self.assertTrue(constraint[0].is_dgp(dpp=True))
         self.assertTrue(cp.Problem(cp.Minimize(1), constraint).is_dgp(dpp=True))
 
-    def test_nonlla_equality_constraint_not_dpp(self):
+    def test_nonlla_equality_constraint_not_dpp(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         x = cp.Variable(pos=True)
         constraint = [x == x + alpha]
         self.assertFalse(constraint[0].is_dgp(dpp=True))
         self.assertFalse(cp.Problem(cp.Minimize(1), constraint).is_dgp(dpp=True))
 
-    def test_nonllcvx_inequality_constraint_not_dpp(self):
+    def test_nonllcvx_inequality_constraint_not_dpp(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         x = cp.Variable(pos=True)
         constraint = [x <= x + alpha]
         self.assertFalse(constraint[0].is_dgp(dpp=True))
         self.assertFalse(cp.Problem(cp.Minimize(1), constraint).is_dgp(dpp=True))
 
-    def test_param_monomial_is_dpp(self):
+    def test_param_monomial_is_dpp(self) -> None:
         alpha = cp.Parameter(pos=True)
         beta = cp.Parameter(pos=True)
         kappa = cp.Parameter(pos=True)
@@ -334,7 +334,7 @@ class TestDgp(BaseTest):
         monomial = alpha**1.2 * beta**0.5 * kappa**3 * kappa**2
         self.assertTrue(monomial.is_dgp(dpp=True))
 
-    def test_param_posynomial_is_dpp(self):
+    def test_param_posynomial_is_dpp(self) -> None:
         alpha = cp.Parameter(pos=True)
         beta = cp.Parameter(pos=True)
         kappa = cp.Parameter(pos=True)
@@ -343,7 +343,7 @@ class TestDgp(BaseTest):
         posynomial = monomial + alpha**2 * beta**3
         self.assertTrue(posynomial.is_dgp(dpp=True))
 
-    def test_mixed_monomial_is_dpp(self):
+    def test_mixed_monomial_is_dpp(self) -> None:
         alpha = cp.Parameter(pos=True)
         beta = cp.Variable(pos=True)
         kappa = cp.Parameter(pos=True)
@@ -352,7 +352,7 @@ class TestDgp(BaseTest):
         monomial = alpha**1.2 * beta**0.5 * kappa**3 * kappa**2 * tau
         self.assertTrue(monomial.is_dgp(dpp=True))
 
-    def test_mixed_posynomial_is_dpp(self):
+    def test_mixed_posynomial_is_dpp(self) -> None:
         alpha = cp.Parameter(pos=True)
         beta = cp.Variable(pos=True)
         kappa = cp.Parameter(pos=True)
@@ -362,7 +362,7 @@ class TestDgp(BaseTest):
         posynomial = (monomial + monomial)**3
         self.assertTrue(posynomial.is_dgp(dpp=True))
 
-    def test_nested_power_not_dpp(self):
+    def test_nested_power_not_dpp(self) -> None:
         alpha = cp.Parameter(value=1.0)
         x = cp.Variable(pos=True)
 
@@ -372,7 +372,7 @@ class TestDgp(BaseTest):
         pow2 = pow1**alpha
         self.assertFalse(pow2.is_dgp(dpp=True))
 
-    def test_non_dpp_problem_raises_error(self):
+    def test_non_dpp_problem_raises_error(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         x = cp.Variable(pos=True)
         dgp = cp.Problem(cp.Minimize((alpha*x)**(alpha)), [x == alpha])
@@ -387,7 +387,7 @@ class TestDgp(BaseTest):
             dgp.solve(gp=True, enforce_dpp=False)
             self.assertAlmostEqual(x.value, 1.0)
 
-    def test_basic_monomial(self):
+    def test_basic_monomial(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         beta = cp.Parameter(pos=True, value=2.0)
         x = cp.Variable(pos=True)
@@ -408,7 +408,7 @@ class TestDgp(BaseTest):
         # 3 * 2 * 3 == 18
         self.assertAlmostEqual(problem.value, 18.0)
 
-    def test_basic_posynomial(self):
+    def test_basic_posynomial(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         beta = cp.Parameter(pos=True, value=2.0)
         kappa = cp.Parameter(pos=True, value=3.0)
@@ -439,7 +439,7 @@ class TestDgp(BaseTest):
         # 4*5*4 + 5*3*4*5 == 80 + 300 == 380
         self.assertAlmostEqual(problem.value, 380.0, places=3)
 
-    def test_basic_gp(self):
+    def test_basic_gp(self) -> None:
         x, y, z = cp.Variable((3,), pos=True)
         a = cp.Parameter(pos=True, value=2.0)
         b = cp.Parameter(pos=True, value=1.0)
@@ -449,7 +449,7 @@ class TestDgp(BaseTest):
         problem.solve(SOLVER, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(15.59, problem.value, places=2)
 
-    def test_maximum(self):
+    def test_maximum(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
 
@@ -481,7 +481,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(x.value, 2.0)
         self.assertAlmostEqual(y.value, 3.0)
 
-    def test_max(self):
+    def test_max(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
 
@@ -513,7 +513,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(x.value, 2.0)
         self.assertAlmostEqual(y.value, 3.0)
 
-    def test_param_in_exponent_and_elsewhere(self):
+    def test_param_in_exponent_and_elsewhere(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0, name='alpha')
         x = cp.Variable(pos=True)
         problem = cp.Problem(cp.Minimize(x**alpha), [x == alpha])
@@ -533,7 +533,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(problem.value, 27.0)
         self.assertAlmostEqual(x.value, 3.0)
 
-    def test_minimum(self):
+    def test_minimum(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
 
@@ -559,7 +559,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(x.value, 2.0)
         self.assertAlmostEqual(y.value, 4.0)
 
-    def test_min(self):
+    def test_min(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
 
@@ -585,7 +585,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(x.value, 2.0)
         self.assertAlmostEqual(y.value, 4.0)
 
-    def test_div(self):
+    def test_div(self) -> None:
         alpha = cp.Parameter(pos=True, value=3.0)
         beta = cp.Parameter(pos=True, value=1.0)
         x = cp.Variable(pos=True)
@@ -604,7 +604,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(x.value, 2.0 / 3.0)
         self.assertAlmostEqual(y.value, 2.0)
 
-    def test_one_minus_pos(self):
+    def test_one_minus_pos(self) -> None:
         x = cp.Variable(pos=True)
         obj = cp.Maximize(x)
         alpha = cp.Parameter(pos=True, value=0.1)
@@ -619,7 +619,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(problem.value, 0.2)
         self.assertAlmostEqual(x.value, 0.2)
 
-    def test_pf_matrix_completion(self):
+    def test_pf_matrix_completion(self) -> None:
         X = cp.Variable((3, 3), pos=True)
         obj = cp.Minimize(cp.pf_eigenvalue(X))
         known_indices = tuple(zip(*[[0, 0], [0, 2], [1, 1], [2, 0], [2, 1]]))
@@ -648,7 +648,7 @@ class TestDgp(BaseTest):
         problem.solve(SOLVER, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(problem.value, optimal_value)
 
-    def test_rank_one_nmf(self):
+    def test_rank_one_nmf(self) -> None:
         X = cp.Variable((3, 3), pos=True)
         x = cp.Variable((3,), pos=True)
         y = cp.Variable((3,), pos=True)
@@ -684,7 +684,7 @@ class TestDgp(BaseTest):
         prob.solve(SOLVER, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(prob.value, optimal_value)
 
-    def test_documentation_prob(self):
+    def test_documentation_prob(self) -> None:
         x = cp.Variable(pos=True)
         y = cp.Variable(pos=True)
         z = cp.Variable(pos=True)
@@ -700,7 +700,7 @@ class TestDgp(BaseTest):
         # Smoke test.
         problem.solve(SOLVER, gp=True, enforce_dpp=True)
 
-    def test_sum_scalar(self):
+    def test_sum_scalar(self) -> None:
         alpha = cp.Parameter(pos=True, value=1.0)
         w = cp.Variable(pos=True)
         h = cp.Variable(pos=True)
@@ -717,7 +717,7 @@ class TestDgp(BaseTest):
         self.assertAlmostEqual(h.value, 8)
         self.assertAlmostEqual(w.value, 1)
 
-    def test_sum_vector(self):
+    def test_sum_vector(self) -> None:
         alpha = cp.Parameter(shape=(2,), pos=True, value=[1.0, 1.0])
         w = cp.Variable(2, pos=True)
         h = cp.Variable(2, pos=True)
@@ -735,7 +735,7 @@ class TestDgp(BaseTest):
         np.testing.assert_almost_equal(h.value, np.array([20, 20]), decimal=3)
         np.testing.assert_almost_equal(w.value, np.array([1, 1]), decimal=3)
 
-    def test_sum_squares_vector(self):
+    def test_sum_squares_vector(self) -> None:
         alpha = cp.Parameter(shape=(2,), pos=True, value=[1.0, 1.0])
         w = cp.Variable(2, pos=True)
         h = cp.Variable(2, pos=True)
@@ -753,7 +753,7 @@ class TestDgp(BaseTest):
         np.testing.assert_almost_equal(h.value, np.array([20, 20]), decimal=3)
         np.testing.assert_almost_equal(problem.value, 24**2 + 24**2, decimal=3)
 
-    def test_sum_matrix(self):
+    def test_sum_matrix(self) -> None:
         w = cp.Variable((2, 2), pos=True)
         h = cp.Variable((2, 2), pos=True)
         alpha = cp.Parameter(pos=True, value=1.0)
@@ -785,7 +785,7 @@ class TestDgp(BaseTest):
         problem.solve(SOLVER, gp=True, enforce_dpp=True)
         np.testing.assert_almost_equal(problem.value, 12.0)
 
-    def test_exp(self):
+    def test_exp(self) -> None:
         x = cp.Variable(4, pos=True)
         c = cp.Parameter(4, pos=True)
         expr = cp.exp(cp.multiply(c, x))
@@ -794,7 +794,7 @@ class TestDgp(BaseTest):
         expr = cp.exp(c.T @ x)
         self.assertTrue(expr.is_dgp(dpp=True))
 
-    def test_log(self):
+    def test_log(self) -> None:
         x = cp.Variable(4, pos=True)
         c = cp.Parameter(4, pos=True)
         expr = cp.log(cp.multiply(c, x))
@@ -803,7 +803,7 @@ class TestDgp(BaseTest):
         expr = cp.log(c.T @ x)
         self.assertFalse(expr.is_dgp(dpp=True))
 
-    def test_gmatmul(self):
+    def test_gmatmul(self) -> None:
         x = cp.Variable(2, pos=True)
         A = cp.Parameter(shape=(2, 2))
         A.value = np.array([[-5, 2], [1, -3]])

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -25,7 +25,7 @@ SOLVER = cp.ECOS
 
 
 class TestDqcp(base_test.BaseTest):
-    def test_basic_with_interval(self):
+    def test_basic_with_interval(self) -> None:
         x = cp.Variable()
         expr = cp.ceil(x)
 
@@ -53,7 +53,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(soln.opt_val, problem.value)
         self.assertAlmostEqual(x.value, 12.0, places=3)
 
-    def test_basic_without_interval(self):
+    def test_basic_without_interval(self) -> None:
         x = cp.Variable()
         expr = cp.ceil(x)
 
@@ -81,7 +81,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(soln.opt_val, problem.value)
         self.assertAlmostEqual(x.value, 12.0, places=3)
 
-    def test_basic_solve(self):
+    def test_basic_solve(self) -> None:
         x = cp.Variable()
         expr = cp.ceil(x)
 
@@ -121,7 +121,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(problem.value, 12.0, places=3)
         self.assertAlmostEqual(x.value, 12.0, places=3)
 
-    def test_basic_maximization_with_interval(self):
+    def test_basic_maximization_with_interval(self) -> None:
         x = cp.Variable()
         expr = cp.ceil(x)
 
@@ -141,7 +141,7 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(SOLVER, qcp=True)
         self.assertAlmostEqual(x.value, 17.0, places=3)
 
-    def test_basic_maximum(self):
+    def test_basic_maximum(self) -> None:
         x, y = cp.Variable(2)
         expr = cp.maximum(cp.ceil(x), cp.ceil(y))
 
@@ -153,7 +153,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertGreater(x.value, 11.9)
         self.assertGreater(y.value, 17.3)
 
-    def test_basic_minimum(self):
+    def test_basic_minimum(self) -> None:
         x, y = cp.Variable(2)
         expr = cp.minimum(cp.ceil(x), cp.ceil(y))
 
@@ -165,7 +165,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertGreater(x.value, 14.9)
         self.assertGreater(y.value, 17.3)
 
-    def test_basic_composition(self):
+    def test_basic_composition(self) -> None:
         x, y = cp.Variable(2)
         expr = cp.maximum(cp.ceil(cp.ceil(x)), cp.ceil(cp.ceil(y)))
 
@@ -187,7 +187,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertGreater(x.value, 11.9)
         self.assertGreater(y.value, 17.3)
 
-    def test_basic_floor(self):
+    def test_basic_floor(self) -> None:
         x = cp.Variable()
         expr = cp.floor(x)
 
@@ -208,7 +208,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(problem.objective.value, 11.0)
         self.assertGreater(x.value, 11.7)
 
-    def test_basic_multiply_nonneg(self):
+    def test_basic_multiply_nonneg(self) -> None:
         x, y = cp.Variable(2, nonneg=True)
         expr = x * y
         self.assertTrue(expr.is_dqcp())
@@ -227,7 +227,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
 
-    def test_basic_multiply_nonpos(self):
+    def test_basic_multiply_nonpos(self) -> None:
         x, y = cp.Variable(2, nonpos=True)
         expr = x * y
         self.assertTrue(expr.is_dqcp())
@@ -246,7 +246,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, -12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
 
-    def test_basic_multiply_qcvx(self):
+    def test_basic_multiply_qcvx(self) -> None:
         x = cp.Variable(nonneg=True)
         y = cp.Variable(nonpos=True)
         expr = x * y
@@ -285,7 +285,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
 
-    def test_concave_multiply(self):
+    def test_concave_multiply(self) -> None:
         x, y = cp.Variable(2, nonneg=True)
         expr = cp.sqrt(x) * cp.sqrt(y)
         self.assertTrue(expr.is_dqcp())
@@ -311,7 +311,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 4, places=1)
         self.assertAlmostEqual(y.value, 9, places=1)
 
-    def test_basic_ratio(self):
+    def test_basic_ratio(self) -> None:
         x = cp.Variable()
         y = cp.Variable(nonneg=True)
         expr = x / y
@@ -342,7 +342,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
 
-    def test_lin_frac(self):
+    def test_lin_frac(self) -> None:
         x = cp.Variable((2,), nonneg=True)
         A = np.array([[1.0, 2.0], [3.0, 4.0]])
         b = np.arange(2)
@@ -359,7 +359,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(problem.objective.value, 0, places=1)
         np.testing.assert_almost_equal(x.value, 0, decimal=5)
 
-    def test_concave_frac(self):
+    def test_concave_frac(self) -> None:
         x = cp.Variable(nonneg=True)
         concave_frac = cp.sqrt(x) / cp.exp(x)
         self.assertTrue(concave_frac.is_dqcp())
@@ -372,7 +372,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(problem.objective.value, 0.428, places=1)
         self.assertAlmostEqual(x.value, 0.5, places=1)
 
-    def test_length(self):
+    def test_length(self) -> None:
         x = cp.Variable(5)
         expr = cp.length(x)
         self.assertTrue(expr.is_dqcp())
@@ -384,14 +384,14 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(problem.objective.value, 2)
         np.testing.assert_almost_equal(x.value, np.array([2, 1, 0, 0, 0]))
 
-    def test_infeasible(self):
+    def test_infeasible(self) -> None:
         x = cp.Variable(2)
         problem = cp.Problem(
             cp.Minimize(cp.length(x)), [x == -1, cp.ceil(x) >= 1])
         problem.solve(SOLVER, qcp=True)
         self.assertIn(problem.status, (s.INFEASIBLE, s.INFEASIBLE_INACCURATE))
 
-    def test_sign(self):
+    def test_sign(self) -> None:
         x = cp.Variable()
         problem = cp.Problem(cp.Minimize(cp.sign(x)), [-2 <= x, x <= -0.5])
         problem.solve(SOLVER, qcp=True)
@@ -414,7 +414,7 @@ class TestDqcp(base_test.BaseTest):
         cp.sign(variable).value
         self.assertItemsAlmostEqual(value, variable.value)
 
-    def test_dist_ratio(self):
+    def test_dist_ratio(self) -> None:
         x = cp.Variable(2)
         a = np.ones(2)
         b = np.zeros(2)
@@ -423,49 +423,49 @@ class TestDqcp(base_test.BaseTest):
         np.testing.assert_almost_equal(problem.objective.value, 0.25)
         np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]))
 
-    def test_infeasible_exp_constr(self):
+    def test_infeasible_exp_constr(self) -> None:
         x = cp.Variable()
         constr = [cp.exp(cp.ceil(x)) <= -5]
         problem = cp.Problem(cp.Minimize(0), constr)
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.INFEASIBLE)
 
-    def test_infeasible_inv_pos_constr(self):
+    def test_infeasible_inv_pos_constr(self) -> None:
         x = cp.Variable(nonneg=True)
         constr = [cp.inv_pos(cp.ceil(x)) <= -5]
         problem = cp.Problem(cp.Minimize(0), constr)
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.INFEASIBLE)
 
-    def test_infeasible_logistic_constr(self):
+    def test_infeasible_logistic_constr(self) -> None:
         x = cp.Variable(nonneg=True)
         constr = [cp.logistic(cp.ceil(x)) <= -5]
         problem = cp.Problem(cp.Minimize(0), constr)
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.INFEASIBLE)
 
-    def test_noop_exp_constr(self):
+    def test_noop_exp_constr(self) -> None:
         x = cp.Variable()
         constr = [cp.exp(cp.ceil(x)) >= -5]
         problem = cp.Problem(cp.Minimize(0), constr)
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.OPTIMAL)
 
-    def test_noop_inv_pos_constr(self):
+    def test_noop_inv_pos_constr(self) -> None:
         x = cp.Variable()
         constr = [cp.inv_pos(cp.ceil(x)) >= -5]
         problem = cp.Problem(cp.Minimize(0), constr)
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.OPTIMAL)
 
-    def test_noop_logistic_constr(self):
+    def test_noop_logistic_constr(self) -> None:
         x = cp.Variable(nonneg=True)
         constr = [cp.logistic(cp.ceil(x)) >= -5]
         problem = cp.Problem(cp.Minimize(0), constr)
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.OPTIMAL)
 
-    def test_gen_lambda_max_matrix_completion(self):
+    def test_gen_lambda_max_matrix_completion(self) -> None:
         A = cp.Variable((3, 3))
         B = cp.Variable((3, 3), PSD=True)
         gen_lambda_max = cp.gen_lambda_max(A, B)
@@ -479,7 +479,7 @@ class TestDqcp(base_test.BaseTest):
         # smoke test
         problem.solve(cp.SCS, qcp=True)
 
-    def test_card_ls(self):
+    def test_card_ls(self) -> None:
         n = 10
         np.random.seed(0)
         A = np.random.randn(n, n)
@@ -494,7 +494,7 @@ class TestDqcp(base_test.BaseTest):
         # smoke test
         problem.solve(SOLVER, qcp=True)
 
-    def test_multiply_const(self):
+    def test_multiply_const(self) -> None:
         x = cp.Variable()
         obj = cp.Minimize(0.5 * cp.ceil(x))
         problem = cp.Problem(obj, [x >= 10])
@@ -523,7 +523,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 10, places=1)
         self.assertAlmostEqual(problem.value, -5, places=1)
 
-    def test_div_const(self):
+    def test_div_const(self) -> None:
         x = cp.Variable()
         obj = cp.Minimize(cp.ceil(x) / 0.5)
         problem = cp.Problem(obj, [x >= 10])
@@ -538,7 +538,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 10, places=1)
         self.assertAlmostEqual(problem.value, -20, places=1)
 
-    def test_tutorial_example(self):
+    def test_tutorial_example(self) -> None:
         x = cp.Variable()
         y = cp.Variable(pos=True)
         objective_fn = -cp.sqrt(x) / y
@@ -546,7 +546,7 @@ class TestDqcp(base_test.BaseTest):
         # smoke test
         problem.solve(SOLVER, qcp=True)
 
-    def test_curvature(self):
+    def test_curvature(self) -> None:
         x = cp.Variable(3)
         expr = cp.length(x)
         self.assertEqual(expr.curvature, s.QUASICONVEX)
@@ -556,7 +556,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(expr.curvature, s.QUASILINEAR)
         self.assertTrue(expr.is_quasilinear())
 
-    def test_tutorial_dqcp(self):
+    def test_tutorial_dqcp(self) -> None:
         # The sign of variables affects curvature analysis.
         x = cp.Variable(nonneg=True)
         concave_frac = x * cp.sqrt(x)
@@ -572,7 +572,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(fn.is_dqcp())
         self.assertFalse(problem.is_dqcp())
 
-    def test_add_constant(self):
+    def test_add_constant(self) -> None:
         # The sign of variables affects curvature analysis.
         x = cp.Variable()
         problem = cp.Problem(cp.Minimize(cp.ceil(x) + 5), [x >= 2])
@@ -580,7 +580,7 @@ class TestDqcp(base_test.BaseTest):
         np.testing.assert_almost_equal(x.value, 2)
         np.testing.assert_almost_equal(problem.objective.value, 7)
 
-    def test_max(self):
+    def test_max(self) -> None:
         x = cp.Variable(2, pos=True)
         obj = cp.max((1 - 2*cp.sqrt(x) + x) / x)
         problem = cp.Problem(cp.Minimize(obj), [x[0] <= 0.5, x[1] <= 0.9])
@@ -588,7 +588,7 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(SOLVER, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.1715, places=3)
 
-    def test_min(self):
+    def test_min(self) -> None:
         x = cp.Variable(2)
         expr = cp.min(cp.ceil(x))
         problem = cp.Problem(cp.Maximize(expr),
@@ -600,7 +600,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertGreater(x[0].value, 14.9)
         self.assertGreater(x[1].value, 17.3)
 
-    def test_sum_of_qccv_not_dqcp(self):
+    def test_sum_of_qccv_not_dqcp(self) -> None:
         t = cp.Variable(5, pos=True)
         expr = cp.sum(cp.square(t) / t)
         self.assertFalse(expr.is_dqcp())

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -27,7 +27,7 @@ class TestExamples(BaseTest):
     """ Unit tests using example problems. """
 
     # Find the largest Euclidean ball in the polyhedron.
-    def test_chebyshev_center(self):
+    def test_chebyshev_center(self) -> None:
         # The goal is to find the largest Euclidean ball (i.e. its center and
         # radius) that lies in a polyhedron described by linear inequalities in this
         # fashion: P = {x : a_i'*x <= b_i, i=1,...,m} where x is in R^2
@@ -57,7 +57,7 @@ class TestExamples(BaseTest):
         self.assertItemsAlmostEqual(x_c.value, [0, 0])
 
     # Test issue with numpy scalars.
-    def test_numpy_scalars(self):
+    def test_numpy_scalars(self) -> None:
         n = 6
         eps = 1e-6
         np.random.seed(10)
@@ -115,7 +115,7 @@ class TestExamples(BaseTest):
         self.assertEqual(intf.shape(dual_result), (1, 1))
 
     # Tests examples from the README.
-    def test_readme_examples(self):
+    def test_readme_examples(self) -> None:
         import numpy
         numpy.random.seed(1)
         # cvx.Problem data.
@@ -269,7 +269,7 @@ class TestExamples(BaseTest):
         print(a.value)
         print(b.value)
 
-    def test_advanced1(self):
+    def test_advanced1(self) -> None:
         """Code from the advanced tutorial.
         """
         # Solving a problem with different solvers.
@@ -325,7 +325,7 @@ class TestExamples(BaseTest):
 
         print(cvx.installed_solvers())
 
-    def test_log_det(self):
+    def test_log_det(self) -> None:
         # Generate data
         x = np.array([[0.55, 0.0],
                       [0.25, 0.35],
@@ -346,7 +346,7 @@ class TestExamples(BaseTest):
         result = p.solve()
         self.assertAlmostEqual(result, 1.9746, places=2)
 
-    def test_portfolio_problem(self):
+    def test_portfolio_problem(self) -> None:
         """Test portfolio problem that caused dcp_attr errors.
         """
         import numpy as np
@@ -369,7 +369,7 @@ class TestExamples(BaseTest):
         # is scalar.
         cvx.square(cvx.norm(D @ x)) + cvx.square(Z @ y)
 
-    def test_intro(self):
+    def test_intro(self) -> None:
         """Test examples from cvxpy.org introduction.
         """
         import numpy
@@ -582,7 +582,7 @@ class TestExamples(BaseTest):
         except ValueError as e:
             print(e)
 
-    def test_inpainting(self):
+    def test_inpainting(self) -> None:
         """Test image in-painting.
         """
         import numpy as np
@@ -608,7 +608,7 @@ class TestExamples(BaseTest):
         prob = cvx.Problem(obj, constraints)
         prob.solve(solver=cvx.SCS)
 
-    def test_advanced2(self):
+    def test_advanced2(self) -> None:
         """Test code from the advanced section of the tutorial.
         """
         x = cvx.Variable()
@@ -633,7 +633,7 @@ class TestExamples(BaseTest):
         # Unpack raw solver output.
         prob.unpack_results(solution, chain, inverse)
 
-    def test_log_sum_exp(self):
+    def test_log_sum_exp(self) -> None:
         """Test log_sum_exp function that failed in Github issue.
         """
         import numpy as np

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -31,7 +31,7 @@ import warnings
 class TestExpressions(BaseTest):
     """ Unit tests for the expression/expression module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
 
         self.x = Variable(2, name='x')
@@ -44,7 +44,7 @@ class TestExpressions(BaseTest):
         self.intf = intf.DEFAULT_INTF
 
     # Test the Variable class.
-    def test_variable(self):
+    def test_variable(self) -> None:
         x = Variable(2)
         y = Variable(2)
         assert y.name() != x.name()
@@ -98,7 +98,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Variable name 1 must be a string.")
 
-    def test_assign_var_value(self):
+    def test_assign_var_value(self) -> None:
         """Test assigning a value to a variable.
         """
         # Scalar variable.
@@ -130,7 +130,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(str(cm.exception), "Variable value must be nonnegative.")
 
     # Test tranposing variables.
-    def test_transpose_variable(self):
+    def test_transpose_variable(self) -> None:
         var = self.a.T
         self.assertEqual(var.name(), "a")
         self.assertEqual(var.shape, tuple())
@@ -169,7 +169,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(var.shape, (2, 1))
 
     # Test the Constant class.
-    def test_constants(self):
+    def test_constants(self) -> None:
         c = Constant(2.0)
         self.assertEqual(c.name(), str(2.0))
 
@@ -214,7 +214,7 @@ class TestExpressions(BaseTest):
         # Test repr.
         self.assertEqual(repr(c), "Constant(CONSTANT, NONNEGATIVE, (2,))")
 
-    def test_1D_array(self):
+    def test_1D_array(self) -> None:
         """Test NumPy 1D arrays as constants.
         """
         c = np.array([1, 2])
@@ -224,7 +224,7 @@ class TestExpressions(BaseTest):
         self.assertEqual((c @ self.x).shape, tuple())
 
     # Test Parameter class on good inputs.
-    def test_parameters_successes(self):
+    def test_parameters_successes(self) -> None:
         # Parameter names and dimensions
         p = Parameter(name='p')
         self.assertEqual(p.name(), "p")
@@ -252,7 +252,7 @@ class TestExpressions(BaseTest):
         p.value = sp.csc_matrix(np.eye(2))
         self.assertItemsAlmostEqual(p.value.todense(), np.eye(2), places=10)
 
-    def test_psd_nsd_parameters(self):
+    def test_psd_nsd_parameters(self) -> None:
         # Test valid rank-deficeint PSD parameter.
         np.random.seed(42)
         a = np.random.normal(size=(100, 95))
@@ -300,7 +300,7 @@ class TestExpressions(BaseTest):
             self.assertEqual(str(cm.exception), "Parameter value must be negative semidefinite.")
 
     # Test the Parameter class on bad inputs.
-    def test_parameters_failures(self):
+    def test_parameters_failures(self) -> None:
         p = Parameter(name='p')
         self.assertEqual(p.name(), "p")
         self.assertEqual(p.shape, tuple())
@@ -356,7 +356,7 @@ class TestExpressions(BaseTest):
             p = Parameter((2, 2), symmetric=True, value=[[1, 1], [-1, -1]])
         self.assertEqual(str(cm.exception), "Parameter value must be symmetric.")
 
-    def test_symmetric(self):
+    def test_symmetric(self) -> None:
         """Test symmetric variables.
         """
         with self.assertRaises(Exception) as cm:
@@ -390,7 +390,7 @@ class TestExpressions(BaseTest):
         expr = cp.promote(Variable(), (2, 2))
         assert expr.is_symmetric()
 
-    def test_hermitian(self):
+    def test_hermitian(self) -> None:
         """Test Hermitian variables.
         """
         with self.assertRaises(Exception) as cm:
@@ -422,7 +422,7 @@ class TestExpressions(BaseTest):
         expr = cp.promote(Variable(), (2, 2))
         assert expr.is_hermitian()
 
-    def test_round_attr(self):
+    def test_round_attr(self) -> None:
         """Test rounding for attributes.
         """
         # Nonpos
@@ -483,7 +483,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(A.is_nsd(), True)
 
     # Test the AddExpresion class.
-    def test_add_expression(self):
+    def test_add_expression(self) -> None:
         # Vectors
         c = Constant([2, 2])
         exp = self.x + c
@@ -522,7 +522,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(repr(exp), "Expression(AFFINE, UNKNOWN, (2,))")
 
     # Test the SubExpresion class.
-    def test_sub_expression(self):
+    def test_sub_expression(self) -> None:
         # Vectors
         c = Constant([2, 2])
         exp = self.x - c
@@ -553,7 +553,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(repr(self.x - c), "Expression(AFFINE, UNKNOWN, (2,))")
 
     # Test the MulExpresion class.
-    def test_mul_expression(self):
+    def test_mul_expression(self) -> None:
         # Vectors
         c = Constant([[2], [2]])
         exp = c @ self.x
@@ -614,7 +614,7 @@ class TestExpressions(BaseTest):
             with self.assertRaises(UserWarning):
                 c * self.x
 
-    def test_matmul_expression(self):
+    def test_matmul_expression(self) -> None:
         """Test matmul function, corresponding to .__matmul__( operator.
         """
         # Vectors
@@ -684,7 +684,7 @@ class TestExpressions(BaseTest):
         assert v.shape == col_scalar.shape == col_scalar.T.shape
 
     # Test the DivExpresion class.
-    def test_div_expression(self):
+    def test_div_expression(self) -> None:
         # Vectors
         exp = self.x/2
         self.assertEqual(exp.curvature, s.AFFINE)
@@ -742,7 +742,7 @@ class TestExpressions(BaseTest):
                                  "Incompatible shapes for division.*")
 
     # Test the NegExpression class.
-    def test_neg_expression(self):
+    def test_neg_expression(self) -> None:
         # Vectors
         exp = -self.x
         self.assertEqual(exp.curvature, s.AFFINE)
@@ -761,7 +761,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(exp.shape, (3, 2))
 
     # Test promotion of scalar constants.
-    def test_scalar_const_promotion(self):
+    def test_scalar_const_promotion(self) -> None:
         # Vectors
         exp = self.x + 2
         self.assertEqual(exp.curvature, s.AFFINE)
@@ -787,7 +787,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(exp.shape, (2, 2))
 
     # Test indexing expression.
-    def test_index_expression(self):
+    def test_index_expression(self) -> None:
         # Tuple of integers as key.
         exp = self.x[1]
         # self.assertEqual(exp.name(), "x[1,0]")
@@ -887,7 +887,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(exp.curvature, s.AFFINE)
         self.assertEqual(exp.shape, (1,))
 
-    def test_none_idx(self):
+    def test_none_idx(self) -> None:
         """Test None as index.
         """
         expr = self.a[None, None]
@@ -903,7 +903,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(expr.shape, (1, 2))
         self.assertItemsAlmostEqual(expr.value, [1, 2])
 
-    def test_out_of_bounds(self):
+    def test_out_of_bounds(self) -> None:
         """Test out of bounds indices.
         """
         with self.assertRaises(Exception) as cm:
@@ -927,7 +927,7 @@ class TestExpressions(BaseTest):
         exp = self.C[:, -199:-3]
         self.assertEqual(exp.shape, (3, 0))
 
-    def test_neg_indices(self):
+    def test_neg_indices(self) -> None:
         """Test negative indices.
         """
         c = Constant([[1, 2], [3, 4]])
@@ -968,7 +968,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(expr.shape, (2,))
         self.assertItemsAlmostEqual(expr.value, [3, 1])
 
-    def test_logical_indices(self):
+    def test_logical_indices(self) -> None:
         """Test indexing with boolean arrays.
         """
         A = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
@@ -1020,7 +1020,7 @@ class TestExpressions(BaseTest):
         self.assertItemsAlmostEqual(A[np.array([True, True, True]),
                                       np.array([True, False, True, True])], expr.value)
 
-    def test_selector_list_indices(self):
+    def test_selector_list_indices(self) -> None:
         """Test indexing with lists/ndarrays of indices.
         """
         A = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
@@ -1074,7 +1074,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(expr.sign, s.NONNEG)
         self.assertItemsAlmostEqual(A[np.array([0, 1]), np.array([1, 3])], expr.value)
 
-    def test_powers(self):
+    def test_powers(self) -> None:
         exp = self.x**2
         self.assertEqual(exp.curvature, s.CONVEX)
         exp = self.x**0.5
@@ -1082,7 +1082,7 @@ class TestExpressions(BaseTest):
         exp = self.x**-1
         self.assertEqual(exp.curvature, s.CONVEX)
 
-    def test_sum(self):
+    def test_sum(self) -> None:
         """Test cvxpy sum function.
         """
         self.a.value = 1
@@ -1093,7 +1093,7 @@ class TestExpressions(BaseTest):
         expr = cp.sum(self.x)
         self.assertEqual(expr.value, 3)
 
-    def test_var_copy(self):
+    def test_var_copy(self) -> None:
         """Test the copy function for variable types.
         """
         x = Variable((3, 4), name="x")
@@ -1105,7 +1105,7 @@ class TestExpressions(BaseTest):
         y = x.copy()
         self.assertEqual(y.shape, (5, 5))
 
-    def test_param_copy(self):
+    def test_param_copy(self) -> None:
         """Test the copy function for Parameters.
         """
         x = Parameter((3, 4), name="x", nonneg=True)
@@ -1114,7 +1114,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(y.name(), "x")
         self.assertEqual(y.sign, "NONNEGATIVE")
 
-    def test_constant_copy(self):
+    def test_constant_copy(self) -> None:
         """Test the copy function for Constants.
         """
         x = Constant(2)
@@ -1122,7 +1122,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(y.shape, tuple())
         self.assertEqual(y.value, 2)
 
-    def test_is_pwl(self):
+    def test_is_pwl(self) -> None:
         """Test is_pwl()
         """
         A = np.ones((2, 3))
@@ -1143,7 +1143,7 @@ class TestExpressions(BaseTest):
         expr = cp.pnorm(3 * self.y ** 2, 1)
         self.assertEqual(expr.is_pwl(), False)
 
-    def test_broadcast_mul(self):
+    def test_broadcast_mul(self) -> None:
         """Test multiply broadcasting.
         """
         y = Parameter((3, 1))
@@ -1175,7 +1175,7 @@ class TestExpressions(BaseTest):
         R = cp.multiply(A, row_scale)
         self.assertEqual(R.shape, (m, n))
 
-    def test_broadcast_add(self):
+    def test_broadcast_add(self) -> None:
         """Test addition broadcasting.
         """
         y = Parameter((3, 1))

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -27,7 +27,7 @@ from cvxpy.tests.base_test import BaseTest
 class TestGrad(BaseTest):
     """ Unit tests for the grad module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
 
         self.x = Variable(2, name='x')
@@ -37,7 +37,7 @@ class TestGrad(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-    def test_affine_prod(self):
+    def test_affine_prod(self) -> None:
         """Test gradient for affine_prod
         """
         expr = self.C @ self.A
@@ -51,7 +51,7 @@ class TestGrad(BaseTest):
                                     np.array([[1, 3, -1, 0, 0, 0], [-2, 4, -3, 0, 0, 0],
                                               [0, 0, 0, 1, 3, -1], [0, 0, 0, -2, 4, -3]]))
 
-    def test_pnorm(self):
+    def test_pnorm(self) -> None:
         """Test gradient for pnorm
         """
         expr = cp.pnorm(self.x, 1)
@@ -100,7 +100,7 @@ class TestGrad(BaseTest):
         self.A.value = np.array([[3, -4], [4, 3]])
         self.assertAlmostEqual(expr.grad[self.A], None)
 
-    def test_log_sum_exp(self):
+    def test_log_sum_exp(self) -> None:
         expr = cp.log_sum_exp(self.x)
         self.x.value = [0, 1]
         e = np.exp(1)
@@ -118,7 +118,7 @@ class TestGrad(BaseTest):
                                     np.transpose(np.array([[1.0/(1+1.0/e), 1.0/e/(1+1.0/e), 0, 0],
                                                            [0, 0, e/(1+e), 1.0/(1+e)]])))
 
-    def test_geo_mean(self):
+    def test_geo_mean(self) -> None:
         """Test gradient for geo_mean
         """
         expr = cp.geo_mean(self.x)
@@ -136,7 +136,7 @@ class TestGrad(BaseTest):
         self.x.value = [-1, 2]
         self.assertAlmostEqual(expr.grad[self.x], None)
 
-    def test_lambda_max(self):
+    def test_lambda_max(self) -> None:
         """Test gradient for lambda_max
         """
         expr = cp.lambda_max(self.A)
@@ -149,7 +149,7 @@ class TestGrad(BaseTest):
         self.A.value = [[1, 0], [0, 1]]
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 0, 0, 1])
 
-    def test_matrix_frac(self):
+    def test_matrix_frac(self) -> None:
         """Test gradient for matrix_frac
         """
         expr = cp.matrix_frac(self.A, self.B)
@@ -174,14 +174,14 @@ class TestGrad(BaseTest):
         self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), [4, 6])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [-4, -6, -6, -9])
 
-    def test_norm_nuc(self):
+    def test_norm_nuc(self) -> None:
         """Test gradient for norm_nuc
         """
         expr = cp.normNuc(self.A)
         self.A.value = [[10, 4], [4, 30]]
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 0, 1])
 
-    def test_log_det(self):
+    def test_log_det(self) -> None:
         """Test gradient for log_det
         """
         expr = cp.log_det(self.A)
@@ -206,7 +206,7 @@ class TestGrad(BaseTest):
         val[[1, 2], [1, 2]] = 1
         self.assertItemsAlmostEqual(expr.grad[K].toarray(), val)
 
-    def test_quad_over_lin(self):
+    def test_quad_over_lin(self) -> None:
         """Test gradient for quad_over_lin
         """
         expr = cp.quad_over_lin(self.x, self.a)
@@ -234,7 +234,7 @@ class TestGrad(BaseTest):
         self.assertItemsAlmostEqual(expr.grad[self.y].toarray(), [1, 2])
         self.assertAlmostEqual(expr.grad[self.a], [-2.5])
 
-    def test_quad_form(self):
+    def test_quad_form(self) -> None:
         """Test gradient for quad_form.
         """
         # Issue 1260
@@ -255,7 +255,7 @@ class TestGrad(BaseTest):
         # access quad_form.expr.grad without error
         prob.constraints[1].expr.grad
 
-    def test_max(self):
+    def test_max(self) -> None:
         """Test gradient for max
         """
         expr = cp.max(self.x)
@@ -276,7 +276,7 @@ class TestGrad(BaseTest):
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(),
                                     np.array([[0, 0], [0, 1], [1, 0], [0, 0]]))
 
-    def test_sigma_max(self):
+    def test_sigma_max(self) -> None:
         """Test sigma_max.
         """
         expr = cp.sigma_max(self.A)
@@ -286,7 +286,7 @@ class TestGrad(BaseTest):
         self.A.value = [[1, 0], [0, 1]]
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [1, 0, 0, 0])
 
-    def test_sum_largest(self):
+    def test_sum_largest(self) -> None:
         """Test sum_largest.
         """
         expr = cp.sum_largest(self.A, 2)
@@ -297,7 +297,7 @@ class TestGrad(BaseTest):
         self.A.value = [[1, 2], [3, 0.5]]
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), [0, 1, 1, 0])
 
-    def test_abs(self):
+    def test_abs(self) -> None:
         """Test abs.
         """
         expr = cp.abs(self.A)
@@ -305,7 +305,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag([1, 1, -1, 0])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_linearize(self):
+    def test_linearize(self) -> None:
         """Test linearize method.
         """
         # Affine.
@@ -346,7 +346,7 @@ class TestGrad(BaseTest):
         assert (lin_expr.value >= expr.value).all()
         self.assertItemsAlmostEqual(lin_expr.value, manual.value)
 
-    def test_log(self):
+    def test_log(self) -> None:
         """Test gradient for log.
         """
         expr = cp.log(self.a)
@@ -373,7 +373,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag([1, 1/2, 1/3, 1/4])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_log1p(self):
+    def test_log1p(self) -> None:
         """Test domain for log1p.
         """
         expr = cp.log1p(self.a)
@@ -400,7 +400,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag([1/2, 1/3, 1/4, 1/5])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_entr(self):
+    def test_entr(self) -> None:
         """Test domain for entr.
         """
         expr = cp.entr(self.a)
@@ -427,7 +427,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag(-(np.log([1, 2, 3, 4]) + 1))
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_exp(self):
+    def test_exp(self) -> None:
         """Test domain for exp.
         """
         expr = cp.exp(self.a)
@@ -455,7 +455,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag(np.exp([1, 2, 3, 4]))
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_logistic(self):
+    def test_logistic(self) -> None:
         """Test domain for logistic.
         """
         expr = cp.logistic(self.a)
@@ -483,7 +483,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag(np.exp([1, 2, 3, 4])/(1+np.exp([1, 2, 3, 4])))
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_huber(self):
+    def test_huber(self) -> None:
         """Test domain for huber.
         """
         expr = cp.huber(self.a)
@@ -512,7 +512,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag([2, 4, 6, 6])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(), val)
 
-    def test_kl_div(self):
+    def test_kl_div(self) -> None:
         """Test domain for kl_div.
         """
         b = Variable()
@@ -556,7 +556,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag(1 - div)
         self.assertItemsAlmostEqual(expr.grad[self.B].toarray(), val)
 
-    def test_maximum(self):
+    def test_maximum(self) -> None:
         """Test domain for maximum.
         """
         b = Variable()
@@ -613,7 +613,7 @@ class TestGrad(BaseTest):
         val = np.eye(2)
         self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
 
-    def test_minimum(self):
+    def test_minimum(self) -> None:
         """Test domain for minimum.
         """
         b = Variable()
@@ -658,7 +658,7 @@ class TestGrad(BaseTest):
         val = np.zeros((4, 4)) + np.diag([0, 1, 0, 1])
         self.assertItemsAlmostEqual(expr.grad[self.B].toarray(), val)
 
-    def test_power(self):
+    def test_power(self) -> None:
         """Test grad for power.
         """
         expr = cp.sqrt(self.a)
@@ -692,7 +692,7 @@ class TestGrad(BaseTest):
         expr = (self.x)**0
         self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), np.zeros((2, 2)))
 
-    def test_partial_problem(self):
+    def test_partial_problem(self) -> None:
         """Test grad for partial minimization/maximization problems.
         """
         for obj in [Minimize((self.a)**-1), Maximize(cp.entr(self.a))]:
@@ -737,7 +737,7 @@ class TestGrad(BaseTest):
             grad = expr.grad
             self.assertAlmostEqual(grad, {})
 
-    def test_affine(self):
+    def test_affine(self) -> None:
         """Test grad for affine atoms.
         """
         expr = -self.a

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -23,10 +23,10 @@ from cvxpy.tests.base_test import BaseTest
 class TestInterfaces(BaseTest):
     """ Unit tests for matrix interfaces. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         pass
 
-    def sign_for_intf(self, interface):
+    def sign_for_intf(self, interface) -> None:
         """Test sign for a given interface.
         """
         mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
@@ -37,7 +37,7 @@ class TestInterfaces(BaseTest):
         self.assertEqual(intf.sign(mat), (False, False))  # Unknown.
 
     # Test numpy ndarray interface.
-    def test_ndarray(self):
+    def test_ndarray(self) -> None:
         interface = intf.get_matrix_interface(np.ndarray)
         # const_to_matrix
         mat = interface.const_to_matrix([1, 2, 3])
@@ -71,7 +71,7 @@ class TestInterfaces(BaseTest):
         self.assertEqual(interface.shape(np.array([1, 2, 3])), (3,))
 
     # Test numpy matrix interface.
-    def test_numpy_matrix(self):
+    def test_numpy_matrix(self) -> None:
         interface = intf.get_matrix_interface(np.matrix)
         # const_to_matrix
         mat = interface.const_to_matrix([1, 2, 3])
@@ -95,7 +95,7 @@ class TestInterfaces(BaseTest):
         # Sign
         self.sign_for_intf(interface)
 
-    def test_scipy_sparse(self):
+    def test_scipy_sparse(self) -> None:
         """Test cvxopt sparse interface.
         """
         interface = intf.get_matrix_interface(sp.csc_matrix)
@@ -143,7 +143,7 @@ class TestInterfaces(BaseTest):
         self.assertEqual(mat[0, 1], 1j)
         self.assertEqual(mat[1, 0], -1j)
 
-    def test_conversion_between_intf(self):
+    def test_conversion_between_intf(self) -> None:
         """Test conversion between every pair of interfaces.
         """
         interfaces = [intf.get_matrix_interface(np.ndarray),

--- a/cvxpy/tests/test_lin_ops.py
+++ b/cvxpy/tests/test_lin_ops.py
@@ -27,7 +27,7 @@ from cvxpy.tests.base_test import BaseTest
 class test_lin_ops(BaseTest):
     """ Unit tests for the lin_ops module. """
 
-    def test_variables(self):
+    def test_variables(self) -> None:
         """Test creating a variable.
         """
         var = create_var((5, 4), var_id=1)
@@ -36,7 +36,7 @@ class test_lin_ops(BaseTest):
         self.assertEqual(len(var.args), 0)
         self.assertEqual(var.type, VARIABLE)
 
-    def test_param(self):
+    def test_param(self) -> None:
         """Test creating a parameter.
         """
         var = create_param((5, 4))
@@ -44,7 +44,7 @@ class test_lin_ops(BaseTest):
         self.assertEqual(len(var.args), 0)
         self.assertEqual(var.type, PARAM)
 
-    def test_constant(self):
+    def test_constant(self) -> None:
         """Test creating a constant.
         """
         # Scalar constant.
@@ -71,7 +71,7 @@ class test_lin_ops(BaseTest):
         self.assertEqual(mat.type, SPARSE_CONST)
         assert (mat.data.todense() == sp.eye(5).todense()).all()
 
-    def test_add_expr(self):
+    def test_add_expr(self) -> None:
         """Test adding lin expr.
         """
         shape = (5, 4)
@@ -82,7 +82,7 @@ class test_lin_ops(BaseTest):
         self.assertEqual(add_expr.shape, shape)
         assert len(add_expr.args) == 2
 
-    def test_get_vars(self):
+    def test_get_vars(self) -> None:
         """Test getting vars from an expression.
         """
         shape = (5, 4)
@@ -95,7 +95,7 @@ class test_lin_ops(BaseTest):
         ref = [(x.data, shape), (y.data, shape)]
         self.assertCountEqual(vars_, ref)
 
-    def test_neg_expr(self):
+    def test_neg_expr(self) -> None:
         """Test negating an expression.
         """
         shape = (5, 4)
@@ -105,7 +105,7 @@ class test_lin_ops(BaseTest):
         self.assertEqual(expr.shape, shape)
         self.assertEqual(expr.type, NEG)
 
-    def test_eq_constr(self):
+    def test_eq_constr(self) -> None:
         """Test creating an equality constraint.
         """
         shape = (5, 5)
@@ -120,7 +120,7 @@ class test_lin_ops(BaseTest):
         ref = [(x.data, shape), (y.data, shape)]
         self.assertCountEqual(vars_, ref)
 
-    def test_leq_constr(self):
+    def test_leq_constr(self) -> None:
         """Test creating a less than or equal constraint.
         """
         shape = (5, 5)
@@ -135,7 +135,7 @@ class test_lin_ops(BaseTest):
         ref = [(x.data, shape), (y.data, shape)]
         self.assertCountEqual(vars_, ref)
 
-    def test_sum(self):
+    def test_sum(self) -> None:
         """Test sum entries op.
         """
         shape = (5, 5)

--- a/cvxpy/tests/test_linear_cone.py
+++ b/cvxpy/tests/test_linear_cone.py
@@ -39,7 +39,7 @@ def solve_wrapper(solver, param_cone_prog):
 class TestLinearCone(BaseTest):
     """ Unit tests for the domain module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
         self.b = Variable(name='b')
         self.c = Variable(name='c')
@@ -54,7 +54,7 @@ class TestLinearCone(BaseTest):
 
         self.solvers = [ECOS()]
 
-    def test_scalar_lp(self):
+    def test_scalar_lp(self) -> None:
         """Test scalar LP problems.
         """
         for solver in self.solvers:
@@ -132,7 +132,7 @@ class TestLinearCone(BaseTest):
             self.assertAlmostEqual(inv_flipped_sltn.opt_val, result)
 
     # Test vector LP problems.
-    def test_vector_lp(self):
+    def test_vector_lp(self) -> None:
         for solver in self.solvers:
             c = Constant(np.array([1, 2]))
             p = Problem(Minimize(c.T @ self.x), [self.x >= c])
@@ -174,7 +174,7 @@ class TestLinearCone(BaseTest):
                                             var.value, places=1)
 
     # Test matrix LP problems.
-    def test_matrix_lp(self):
+    def test_matrix_lp(self) -> None:
         for solver in self.solvers:
             T = Constant(np.ones((2, 2))).value
             p = Problem(Minimize(self.a), [self.A == T + self.a, self.a >= 0])
@@ -203,7 +203,7 @@ class TestLinearCone(BaseTest):
                 self.assertItemsAlmostEqual(inv_sltn.primal_vars[var.id],
                                             var.value)
 
-    def test_socp(self):
+    def test_socp(self) -> None:
         """Test SOCP problems.
         """
         for solver in self.solvers:
@@ -239,7 +239,7 @@ class TestLinearCone(BaseTest):
                 self.assertItemsAlmostEqual(inv_sltn.primal_vars[var.id],
                                             var.value, places=2)
 
-    def exp_cone(self):
+    def exp_cone(self) -> None:
         """Test exponential cone problems.
         """
         for solver in self.solvers:
@@ -276,7 +276,7 @@ class TestLinearCone(BaseTest):
                                             var.value, places=0)
 
     # Test positive definite constraints.
-    def test_psd_constraints(self):
+    def test_psd_constraints(self) -> None:
         """ Test positive semi-definite constraints
         """
         C = Variable((3, 3))
@@ -305,7 +305,7 @@ class TestLinearCone(BaseTest):
         prob, _ = CvxAttr2Constr().apply(Problem(obj, constraints))
         self.assertTrue(ConeMatrixStuffing().accepts(prob))
 
-    def test_nonneg_constraints_backend(self):
+    def test_nonneg_constraints_backend(self) -> None:
         x = Variable(shape=(2,), name='x')
         objective = Maximize(-4 * x[0] - 5 * x[1])
         constr_expr = hstack([3 - (2 * x[0] + x[1]),
@@ -319,7 +319,7 @@ class TestLinearCone(BaseTest):
         p_min = FlipObjective().apply(prob)
         self.assertTrue(ConeMatrixStuffing().accepts(p_min[0]))
 
-    def test_nonneg_constraints_end_user(self):
+    def test_nonneg_constraints_end_user(self) -> None:
         x = Variable(shape=(2,), name='x')
         objective = Minimize(-4 * x[0] - 5 * x[1])
         constr_expr = hstack([3 - (2 * x[0] + x[1]),

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -28,13 +28,13 @@ PY35 = sys.version_info >= (3, 5)
 class TestMatrices(unittest.TestCase):
     """ Unit tests for testing different forms of matrices as constants. """
 
-    def assertExpression(self, expr, shape):
+    def assertExpression(self, expr, shape) -> None:
         """Asserts that expr is an Expression with dimension shape.
         """
         assert isinstance(expr, Expression) or isinstance(expr, Constraint)
         self.assertEqual(expr.shape, shape)
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
         self.b = Variable(name='b')
         self.c = Variable(name='c')
@@ -48,7 +48,7 @@ class TestMatrices(unittest.TestCase):
         self.C = Variable((3, 2), name='C')
 
     # Test numpy arrays
-    def test_numpy_arrays(self):
+    def test_numpy_arrays(self) -> None:
         # Vector
         v = numpy.arange(2)
         self.assertExpression(self.x + v, (2,))
@@ -68,7 +68,7 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(A >> self.A, (2, 2))
 
     # Test numpy matrices
-    def test_numpy_matrices(self):
+    def test_numpy_matrices(self) -> None:
         # Vector
         v = numpy.arange(2)
         self.assertExpression(self.x + v, (2,))
@@ -88,7 +88,7 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(A << self.A, (2, 2))
         self.assertExpression(A >> self.A, (2, 2))
 
-    def test_numpy_scalars(self):
+    def test_numpy_scalars(self) -> None:
         """Test numpy scalars."""
         v = numpy.float64(2.0)
         self.assertExpression(self.x + v, (2,))
@@ -104,7 +104,7 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(v << self.A, (2, 2))
         self.assertExpression(v >> self.A, (2, 2))
 
-    def test_scipy_sparse(self):
+    def test_scipy_sparse(self) -> None:
         """Test scipy sparse matrices."""
         # Constants.
         A = numpy.arange(8).reshape((4, 2))

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -25,7 +25,7 @@ from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS as MIP_SOLVERS
 class TestMIPVariable(BaseTest):
     """ Unit tests for the expressions/shape module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.x_bool = cp.Variable(boolean=True)
         self.y_int = cp.Variable(integer=True)
         self.A_bool = cp.Variable((3, 2), boolean=True)
@@ -33,7 +33,7 @@ class TestMIPVariable(BaseTest):
         # Check for all installed QP solvers
         self.solvers = MIP_SOLVERS
 
-    def test_all_solvers(self):
+    def test_all_solvers(self) -> None:
         for solver in self.solvers:
             self.bool_prob(solver)
             self.int_prob(solver)
@@ -41,7 +41,7 @@ class TestMIPVariable(BaseTest):
                 self.bool_socp(solver)
                 self.int_socp(solver)
 
-    def bool_prob(self, solver):
+    def bool_prob(self, solver) -> None:
         # Bool in objective.
         obj = cp.Minimize(cp.abs(self.x_bool - 0.2))
         p = cp.Problem(obj, [])
@@ -77,7 +77,7 @@ class TestMIPVariable(BaseTest):
 
         self.assertItemsAlmostEqual(self.A_bool.value, C, places=4)
 
-    def int_prob(self, solver):
+    def int_prob(self, solver) -> None:
         # Int in objective.
         obj = cp.Minimize(cp.abs(self.y_int - 0.2))
         p = cp.Problem(obj, [])
@@ -93,7 +93,7 @@ class TestMIPVariable(BaseTest):
         result = p.solve(solver=solver)
         self.assertEqual(p.status in s.INF_OR_UNB, True)
 
-    def int_socp(self, solver):
+    def int_socp(self, solver) -> None:
         # Int in objective.
         t = cp.Variable()
         obj = cp.Minimize(t)
@@ -103,7 +103,7 @@ class TestMIPVariable(BaseTest):
 
         self.assertAlmostEqual(self.y_int.value, 0)
 
-    def bool_socp(self, solver):
+    def bool_socp(self, solver) -> None:
         # Int in objective.
         t = cp.Variable()
         obj = cp.Minimize(t)

--- a/cvxpy/tests/test_monotonicity.py
+++ b/cvxpy/tests/test_monotonicity.py
@@ -23,7 +23,7 @@ class TestMonotonicity(BaseTest):
     """ Unit tests for the utilities/monotonicity class. """
     # Test application of DCP composition rules to determine curvature.
 
-    def test_dcp_curvature(self):
+    def test_dcp_curvature(self) -> None:
         expr = 1 + cvx.exp(cvx.Variable())
         self.assertEqual(expr.curvature, s.CONVEX)
 
@@ -56,7 +56,7 @@ class TestMonotonicity(BaseTest):
         self.assertEqual(expr.curvature, s.CONSTANT)
 
     # Test DCP composition rules with signed monotonicity.
-    def test_signed_curvature(self):
+    def test_signed_curvature(self) -> None:
         # Convex argument.
         expr = cvx.abs(1 + cvx.exp(cvx.Variable()))
         self.assertEqual(expr.curvature, s.CONVEX)

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -23,7 +23,7 @@ import numpy as np
 class TestNonlinearAtoms(BaseTest):
     """ Unit tests for the nonlinear atoms module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.x = cvx.Variable(2, name='x')
         self.y = cvx.Variable(2, name='y')
 
@@ -31,7 +31,7 @@ class TestNonlinearAtoms(BaseTest):
         self.B = cvx.Variable((2, 2), name='B')
         self.C = cvx.Variable((3, 2), name='C')
 
-    def test_log_problem(self):
+    def test_log_problem(self) -> None:
         # Log in objective.
         obj = cvx.Maximize(cvx.sum(cvx.log(self.x)))
         constr = [self.x <= [1, math.e]]
@@ -62,13 +62,13 @@ class TestNonlinearAtoms(BaseTest):
         result = p.solve()
         self.assertAlmostEqual(result, 1)
 
-    def test_entr(self):
+    def test_entr(self) -> None:
         """Test the entr atom.
         """
         self.assertEqual(cvx.entr(0).value, 0)
         assert np.isneginf(cvx.entr(-1).value)
 
-    def test_kl_div(self):
+    def test_kl_div(self) -> None:
         """Test a problem with kl_div.
         """
         import numpy as np
@@ -97,7 +97,7 @@ class TestNonlinearAtoms(BaseTest):
         klprob.solve(solver=cvx.ECOS, verbose=True)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
-    def test_entr_prob(self):
+    def test_entr_prob(self) -> None:
         """Test a problem with entr.
         """
         for n in [5, 10, 25]:
@@ -110,7 +110,7 @@ class TestNonlinearAtoms(BaseTest):
             p.solve(solver=cvx.SCS, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
 
-    def test_exp(self):
+    def test_exp(self) -> None:
         """Test a problem with exp.
         """
         for n in [5, 10, 25]:
@@ -123,7 +123,7 @@ class TestNonlinearAtoms(BaseTest):
             p.solve(solver=cvx.ECOS, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
 
-    def test_log(self):
+    def test_log(self) -> None:
         """Test a problem with log.
         """
         for n in [5, 10, 25]:

--- a/cvxpy/tests/test_objectives.py
+++ b/cvxpy/tests/test_objectives.py
@@ -23,12 +23,12 @@ import unittest
 class TestObjectives(unittest.TestCase):
     """ Unit tests for the expression/expression module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.x = Variable(name='x')
         self.y = Variable(3, name='y')
         self.z = Variable(name='z')
 
-    def test_str(self):
+    def test_str(self) -> None:
         """Test string representations.
         """
         obj = cp.Minimize(self.x)
@@ -42,7 +42,7 @@ class TestObjectives(unittest.TestCase):
         self.assertEqual(repr(obj), "Maximize(%s)" % repr(2*self.x))
 
     # Test the Minimize class.
-    def test_minimize(self):
+    def test_minimize(self) -> None:
         exp = self.x + self.z
         obj = cp.Minimize(exp)
         self.assertEqual(str(obj), "minimize %s" % exp.name())
@@ -69,7 +69,7 @@ class TestObjectives(unittest.TestCase):
         self.assertTrue(copy.args[0].args[0] is self.z)
 
     # Test the Maximize class.
-    def test_maximize(self):
+    def test_maximize(self) -> None:
         exp = self.x + self.z
         obj = cp.Maximize(exp)
         self.assertEqual(str(obj), "maximize %s" % exp.name())
@@ -96,14 +96,14 @@ class TestObjectives(unittest.TestCase):
         self.assertTrue(copy.args[0].args[0].args[0] is self.x)
 
     # Test is_dcp for Minimize and Maximize
-    def test_is_dcp(self):
+    def test_is_dcp(self) -> None:
         self.assertEqual(cp.Minimize(cp.norm_inf(self.x)).is_dcp(), True)
         self.assertEqual(cp.Minimize(-cp.norm_inf(self.x)).is_dcp(), False)
 
         self.assertEqual(cp.Maximize(cp.norm_inf(self.x)).is_dcp(), False)
         self.assertEqual(cp.Maximize(-cp.norm_inf(self.x)).is_dcp(), True)
 
-    def test_add_problems(self):
+    def test_add_problems(self) -> None:
         """Test adding objectives.
         """
         expr1 = self.x**2

--- a/cvxpy/tests/test_param_cone_prog.py
+++ b/cvxpy/tests/test_param_cone_prog.py
@@ -24,14 +24,14 @@ import numpy as np
 
 class TestParamConeProg(BaseTest):
     # Overridden method to assume lower accuracy.
-    def assertItemsAlmostEqual(self, a, b, places=2):
+    def assertItemsAlmostEqual(self, a, b, places: int=2) -> None:
         super(TestParamConeProg, self).assertItemsAlmostEqual(a, b, places=places)
 
     # Overridden method to assume lower accuracy.
-    def assertAlmostEqual(self, a, b, places=2):
+    def assertAlmostEqual(self, a, b, places: int=2) -> None:
         super(TestParamConeProg, self).assertAlmostEqual(a, b, places=places)
 
-    def test_log_problem(self):
+    def test_log_problem(self) -> None:
         # Log in objective.
         x = cp.Variable(2)
         var_dict = {x.id: x}
@@ -74,7 +74,7 @@ class TestParamConeProg(BaseTest):
         problem.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(x.value, sltn_dict[x.id])
 
-    def test_psd_var(self):
+    def test_psd_var(self) -> None:
         """Test PSD variable.
         """
         s = cp.Variable((2, 2), PSD=True)

--- a/cvxpy/tests/test_param_quad_prog.py
+++ b/cvxpy/tests/test_param_quad_prog.py
@@ -22,18 +22,18 @@ import numpy as np
 
 class TestParamQuadProg(BaseTest):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.solvers = [x for x in QP_SOLVERS if x in INSTALLED_SOLVERS]
 
     # Overridden method to assume lower accuracy.
-    def assertItemsAlmostEqual(self, a, b, places=2):
+    def assertItemsAlmostEqual(self, a, b, places: int=2) -> None:
         super(TestParamQuadProg, self).assertItemsAlmostEqual(a, b, places=places)
 
     # Overridden method to assume lower accuracy.
-    def assertAlmostEqual(self, a, b, places=2):
+    def assertAlmostEqual(self, a, b, places: int=2) -> None:
         super(TestParamQuadProg, self).assertAlmostEqual(a, b, places=places)
 
-    def test_param_data(self):
+    def test_param_data(self) -> None:
         for solver in self.solvers:
             np.random.seed(0)
             m = 30
@@ -73,7 +73,7 @@ class TestParamQuadProg(BaseTest):
             # Check if solutions match
             np.testing.assert_allclose(x_gamma_new, x_scratch, rtol=1e-02, atol=1e-02)
 
-    def test_qp_problem(self):
+    def test_qp_problem(self) -> None:
         for solver in self.solvers:
             m = 30
             n = 20

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -45,7 +45,7 @@ class TestProblem(BaseTest):
     """Unit tests for the expression/expression module.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
         self.b = Variable(name='b')
         self.c = Variable(name='c')
@@ -58,7 +58,7 @@ class TestProblem(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-    def test_to_str(self):
+    def test_to_str(self) -> None:
         """Test string representations.
         """
         obj = cp.Minimize(self.a)
@@ -77,7 +77,7 @@ class TestProblem(BaseTest):
         prob = Problem(cp.Minimize(self.a), [Zero(self.a), NonPos(self.a)])
         self.assertEqual(str(prob), result)
 
-    def test_variables(self):
+    def test_variables(self) -> None:
         """Test the variables method.
         """
         p = Problem(cp.Minimize(self.a), [self.a <= self.x, self.b <= self.A + 2])
@@ -85,11 +85,11 @@ class TestProblem(BaseTest):
         ref = [self.a, self.x, self.b, self.A]
         self.assertCountEqual(vars_, ref)
 
-    def test_var_dict(self):
+    def test_var_dict(self) -> None:
         p = Problem(cp.Minimize(self.a), [self.a <= self.x, self.b <= self.A + 2])
         assert p.var_dict == {"a": self.a, "x": self.x, "b": self.b, "A": self.A}
 
-    def test_parameters(self):
+    def test_parameters(self) -> None:
         """Test the parameters method.
         """
         p1 = Parameter()
@@ -100,21 +100,21 @@ class TestProblem(BaseTest):
         ref = [p1, p2, p3]
         self.assertCountEqual(params, ref)
 
-    def test_param_dict(self):
+    def test_param_dict(self) -> None:
         p1 = Parameter(name="p1")
         p2 = Parameter(3, nonpos=True, name="p2")
         p3 = Parameter((4, 4), nonneg=True, name="p3")
         p = Problem(cp.Minimize(p1), [self.a + p1 <= p2, self.b <= p3 + p3 + 2])
         assert p.param_dict == {"p1": p1, "p2": p2, "p3": p3}
 
-    def test_solving_a_problem_with_unspecified_parameters(self):
+    def test_solving_a_problem_with_unspecified_parameters(self) -> None:
         param = cp.Parameter(name="lambda")
         problem = cp.Problem(cp.Minimize(param), [])
         with self.assertRaises(
               ParameterError, msg="A Parameter (whose name is 'lambda').*"):
             problem.solve()
 
-    def test_constants(self):
+    def test_constants(self) -> None:
         """Test the constants method.
         """
         c1 = numpy.random.randn(1, 2)
@@ -140,7 +140,7 @@ class TestProblem(BaseTest):
             # Allows comparison between numpy matrices and numpy arrays
             # Necessary because of the way cvxpy handles numpy arrays and constants
 
-    def test_size_metrics(self):
+    def test_size_metrics(self) -> None:
         """Test the size_metrics method.
         """
         p1 = Parameter()
@@ -180,7 +180,7 @@ class TestProblem(BaseTest):
         ref = max(p3.shape)
         self.assertEqual(max_data_dim, ref)
 
-    def test_solver_stats(self):
+    def test_solver_stats(self) -> None:
         """Test the solver_stats method.
         """
         prob = Problem(cp.Minimize(cp.norm(self.x)), [self.x == 0])
@@ -208,7 +208,7 @@ class TestProblem(BaseTest):
         self.assertGreater(stats.num_iters, 0)
         self.assertTrue(hasattr(stats.extra_stats, 'info'))
 
-    def test_get_problem_data(self):
+    def test_get_problem_data(self) -> None:
         """Test get_problem_data method.
         """
         data, _, _ = Problem(cp.Minimize(cp.exp(self.a) + 2)).get_problem_data(s.SCS)
@@ -233,7 +233,7 @@ class TestProblem(BaseTest):
             # offsets were correctly parsed until we update the CVXOPT
             # interface.
 
-    def test_unpack_results(self):
+    def test_unpack_results(self) -> None:
         """Test unpack results method.
         """
         prob = Problem(cp.Minimize(cp.exp(self.a)), [self.a == 0])
@@ -258,7 +258,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(prob.value, 0)
         self.assertAlmostEqual(prob.status, s.OPTIMAL)
 
-    def test_verbose(self):
+    def test_verbose(self) -> None:
         """Test silencing and enabling solver messages.
         """
         # From http://stackoverflow.com/questions/5136611/capture-stdout-from-a-script-in-python
@@ -306,7 +306,7 @@ class TestProblem(BaseTest):
             assert len(output) == 0
 
     # Test registering other solve methods.
-    def test_register_solve(self):
+    def test_register_solve(self) -> None:
         Problem.register_solve("test", lambda self: 1)
         p = Problem(cp.Minimize(1))
         result = p.solve(method="test")
@@ -394,7 +394,7 @@ class TestProblem(BaseTest):
     #     self.assertEqual(result, (0, 3))
 
     # Test the is_dcp method.
-    def test_is_dcp(self):
+    def test_is_dcp(self) -> None:
         p = Problem(cp.Minimize(cp.norm_inf(self.a)))
         self.assertEqual(p.is_dcp(), True)
 
@@ -404,7 +404,7 @@ class TestProblem(BaseTest):
             p.solve()
 
     # Test the is_qp method.
-    def test_is_qp(self):
+    def test_is_qp(self) -> None:
         A = numpy.random.randn(4, 3)
         b = numpy.random.randn(4)
         Aeq = numpy.random.randn(2, 3)
@@ -453,7 +453,7 @@ class TestProblem(BaseTest):
         self.assertEqual(p.is_qp(), False)
 
     # Test problems involving variables with the same name.
-    def test_variable_name_conflict(self):
+    def test_variable_name_conflict(self) -> None:
         var = Variable(name='a')
         p = Problem(cp.Maximize(self.a + var), [var == 2 + self.a, var <= 3])
         result = p.solve()
@@ -462,7 +462,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(var.value, 3)
 
     # Test adding problems
-    def test_add_problems(self):
+    def test_add_problems(self) -> None:
         prob1 = Problem(cp.Minimize(self.a), [self.a >= self.b])
         prob2 = Problem(cp.Minimize(2*self.b), [self.a >= 1, self.b >= 2])
         prob_minimize = prob1 + prob2
@@ -488,7 +488,7 @@ class TestProblem(BaseTest):
         self.assertEqual(str(cm.exception), "Problem does not follow DCP rules.")
 
     # Test problem multiplication by scalar
-    def test_mul_problems(self):
+    def test_mul_problems(self) -> None:
         prob1 = Problem(cp.Minimize(pow(self.a, 2)), [self.a >= 2])
         answer = prob1.solve()
         factors = [0, 1, 2.3, -4.321]
@@ -497,7 +497,7 @@ class TestProblem(BaseTest):
             self.assertAlmostEqual((prob1 * f).solve(), f * answer)
 
     # Test problem linear combinations
-    def test_lin_combination_problems(self):
+    def test_lin_combination_problems(self) -> None:
         prob1 = Problem(cp.Minimize(self.a), [self.a >= self.b])
         prob2 = Problem(cp.Minimize(2*self.b), [self.a >= 1, self.b >= 2])
         prob3 = Problem(cp.Maximize(-pow(self.b + self.a, 2)), [self.b >= 3])
@@ -521,7 +521,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(combo3.solve(), combo3_ref.solve())
 
     # Test scalar LP problems.
-    def test_scalar_lp(self):
+    def test_scalar_lp(self) -> None:
         p = Problem(cp.Minimize(3*self.a), [self.a >= 2])
         result = p.solve()
         self.assertAlmostEqual(result, 6)
@@ -592,7 +592,7 @@ class TestProblem(BaseTest):
         assert p.value > 0
 
     # Test vector LP problems.
-    def test_vector_lp(self):
+    def test_vector_lp(self) -> None:
         c = Constant(numpy.array([[1, 2]]).T).value
         p = Problem(cp.Minimize(c.T @ self.x), [self.x[:, None] >= c])
         result = p.solve()
@@ -613,7 +613,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.x.value, [8, 8], places=3)
         self.assertItemsAlmostEqual(self.z.value, [2, 2], places=3)
 
-    def test_ecos_noineq(self):
+    def test_ecos_noineq(self) -> None:
         """Test ECOS with no inequality constraints.
         """
         T = Constant(numpy.ones((2, 2))).value
@@ -623,7 +623,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.A.value, T)
 
     # Test matrix LP problems.
-    def test_matrix_lp(self):
+    def test_matrix_lp(self) -> None:
         T = Constant(numpy.ones((2, 2))).value
         p = Problem(cp.Minimize(1), [self.A == T])
         result = p.solve()
@@ -643,7 +643,7 @@ class TestProblem(BaseTest):
         self.assertEqual(type(self.A.value), intf.DEFAULT_INTF.TARGET_MATRIX)
 
     # Test variable promotion.
-    def test_variable_promotion(self):
+    def test_variable_promotion(self) -> None:
         p = Problem(cp.Minimize(self.a), [self.x <= self.a, self.x == [1, 2]])
         result = p.solve()
         self.assertAlmostEqual(result, 2)
@@ -664,13 +664,13 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 5)
 
     # Test parameter promotion.
-    def test_parameter_promotion(self):
+    def test_parameter_promotion(self) -> None:
         a = Parameter()
         exp = [[1, 2], [3, 4]] * a
         a.value = 2
         assert not (exp.value - 2*numpy.array([[1, 2], [3, 4]]).T).any()
 
-    def test_parameter_problems(self):
+    def test_parameter_problems(self) -> None:
         """Test problems with parameters.
         """
         p1 = Parameter()
@@ -688,7 +688,7 @@ class TestProblem(BaseTest):
             p.solve()
 
     # Test problems with norm_inf
-    def test_norm_inf(self):
+    def test_norm_inf(self) -> None:
         # Constant argument.
         p = Problem(cp.Minimize(cp.norm_inf(-2)))
         result = p.solve()
@@ -721,7 +721,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(float(list(self.x.value)[1] - list(self.z.value)[1]), 7)
 
     # Test problems with norm1
-    def test_norm1(self):
+    def test_norm1(self) -> None:
         # Constant argument.
         p = Problem(cp.Minimize(cp.norm1(-2)))
         result = p.solve()
@@ -747,7 +747,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(float(list(self.x.value)[1] - list(self.z.value)[1]), 7)
 
     # Test problems with norm2
-    def test_norm2(self):
+    def test_norm2(self) -> None:
         # Constant argument.
         p = Problem(cp.Minimize(cp.pnorm(-2, p=2)))
         result = p.solve()
@@ -782,14 +782,14 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.z.value, [-1, -4])
 
     # Test problems with abs
-    def test_abs(self):
+    def test_abs(self) -> None:
         p = Problem(cp.Minimize(cp.sum(cp.abs(self.A))), [-2 >= self.A])
         result = p.solve()
         self.assertAlmostEqual(result, 8)
         self.assertItemsAlmostEqual(self.A.value, [-2, -2, -2, -2])
 
     # Test problems with quad_form.
-    def test_quad_form(self):
+    def test_quad_form(self) -> None:
         with self.assertRaises(Exception) as cm:
             Problem(cp.Minimize(cp.quad_form(self.x, self.A))).solve()
         self.assertEqual(
@@ -825,7 +825,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 40)
 
     # Test combining atoms
-    def test_mixed_atoms(self):
+    def test_mixed_atoms(self) -> None:
         p = Problem(cp.Minimize(cp.pnorm(5 + cp.norm1(self.z)
                                          + cp.norm1(self.x) +
                                          cp.norm_inf(self.x - self.z), p=2)),
@@ -836,13 +836,13 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.z.value, [-1, -4])
 
     # Test multiplying by constant atoms.
-    def test_mult_constant_atoms(self):
+    def test_mult_constant_atoms(self) -> None:
         p = Problem(cp.Minimize(cp.pnorm([3, 4], p=2)*self.a), [self.a >= 2])
         result = p.solve()
         self.assertAlmostEqual(result, 10)
         self.assertAlmostEqual(self.a.value, 2)
 
-    def test_dual_variables(self):
+    def test_dual_variables(self) -> None:
         """Test recovery of dual variables.
         """
         for solver in [s.ECOS, s.SCS, s.CVXOPT]:
@@ -876,7 +876,7 @@ class TestProblem(BaseTest):
                 self.assertItemsAlmostEqual(p.constraints[2].dual_value, 6*[0], places=acc)
 
     # Test problems with indexing.
-    def test_indexing(self):
+    def test_indexing(self) -> None:
         # Vector variables
         p = Problem(cp.Maximize(self.x[0]), [self.x[0] <= 2, self.x[1] == 3])
         result = p.solve()
@@ -906,7 +906,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 12)
         self.assertItemsAlmostEqual(self.x.value, self.z.value)
 
-    def test_non_python_int_index(self):
+    def test_non_python_int_index(self) -> None:
         """Test problems that have special types as indices.
         """
         import sys
@@ -936,7 +936,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
     # Test problems with slicing.
-    def test_slicing(self):
+    def test_slicing(self) -> None:
         p = Problem(cp.Maximize(cp.sum(self.C)), [self.C[1:3, :] <= 2, self.C[0, :] == 1])
         result = p.solve()
         self.assertAlmostEqual(result, 10)
@@ -982,7 +982,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(self.C.value, 2*[1, 2, 2])
 
     # Test the vstack atom.
-    def test_vstack(self):
+    def test_vstack(self) -> None:
         a = Variable((1, 1), name='a')
         b = Variable((1, 1), name='b')
 
@@ -1026,7 +1026,7 @@ class TestProblem(BaseTest):
                         in str(cm.exception))
 
     # Test the hstack atom.
-    def test_hstack(self):
+    def test_hstack(self) -> None:
         a = Variable((1, 1), name='a')
         b = Variable((1, 1), name='b')
 
@@ -1070,7 +1070,7 @@ class TestProblem(BaseTest):
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
 
-    def test_bad_objective(self):
+    def test_bad_objective(self) -> None:
         """Test using a cvxpy expression as an objective.
         """
         with self.assertRaises(Exception) as cm:
@@ -1078,7 +1078,7 @@ class TestProblem(BaseTest):
         self.assertEqual(str(cm.exception), "Problem objective must be Minimize or Maximize.")
 
     # Test variable transpose.
-    def test_transpose(self):
+    def test_transpose(self) -> None:
         p = Problem(cp.Minimize(cp.sum(self.x)),
                     [self.x[None, :] >= numpy.array([[1, 2]])])
         result = p.solve()
@@ -1126,7 +1126,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(self.C.value, 2*[1, 2, 2])
 
-    def test_multiplication_on_left(self):
+    def test_multiplication_on_left(self) -> None:
         """Test multiplication on the left by a non-constant.
         """
         c = numpy.array([[1, 2]]).T
@@ -1155,7 +1155,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 0)
 
     # Test redundant constraints in cpopt.
-    def test_redundant_constraints(self):
+    def test_redundant_constraints(self) -> None:
         obj = cp.Minimize(cp.sum(self.x))
         constraints = [self.x == 2, self.x == 2, self.x.T == 2, self.x[0] == 2]
         p = Problem(obj, constraints)
@@ -1180,7 +1180,7 @@ class TestProblem(BaseTest):
             "might have redundant constraints.")
 
     # Test that symmetry is enforced.
-    def test_sdp_symmetry(self):
+    def test_sdp_symmetry(self) -> None:
         p = Problem(cp.Minimize(cp.lambda_max(self.A)), [self.A >= 2])
         p.solve()
         self.assertItemsAlmostEqual(self.A.value, self.A.value.T, places=3)
@@ -1190,7 +1190,7 @@ class TestProblem(BaseTest):
         self.assertEqual(p.status, s.INFEASIBLE)
 
     # Test PSD
-    def test_sdp(self):
+    def test_sdp(self) -> None:
         # Ensure sdp constraints enforce transpose.
         obj = cp.Maximize(self.A[1, 0] - self.A[0, 1])
         p = Problem(obj, [cp.lambda_max(self.A) <= 100,
@@ -1201,7 +1201,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 0, places=3)
 
     # Test getting values for expressions.
-    def test_expression_values(self):
+    def test_expression_values(self) -> None:
         diff_exp = self.x - self.z
         inf_exp = cp.norm_inf(diff_exp)
         sum_exp = 5 + cp.norm1(self.z) + cp.norm1(self.x) + inf_exp
@@ -1224,7 +1224,7 @@ class TestProblem(BaseTest):
                                LA.norm(self.x.value + self.z.value, 2))
         self.assertAlmostEqual(obj.value, result)
 
-    def test_mult_by_zero(self):
+    def test_mult_by_zero(self) -> None:
         """Test multiplication by zero.
         """
         self.a.value = 1
@@ -1236,7 +1236,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 0)
         assert self.a.value is not None
 
-    def test_div(self):
+    def test_div(self) -> None:
         """Tests a problem with division.
         """
         obj = cp.Minimize(cp.norm_inf(self.A/5))
@@ -1274,7 +1274,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
-    def test_multiply(self):
+    def test_multiply(self) -> None:
         """Tests problems with multiply.
         """
         c = [[1, -1], [2, -2]]
@@ -1305,7 +1305,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
-    def test_invalid_solvers(self):
+    def test_invalid_solvers(self) -> None:
         """Tests that errors occur when you use an invalid solver.
         """
         with self.assertRaises(SolverError):
@@ -1317,7 +1317,7 @@ class TestProblem(BaseTest):
         with self.assertRaises(SolverError):
             Problem(cp.Minimize(self.a)).solve(solver=s.SCS)
 
-    def test_solver_error_raised_on_failure(self):
+    def test_solver_error_raised_on_failure(self) -> None:
         """Tests that a SolverError is raised when a solver fails.
         """
         A = numpy.random.randn(40, 40)
@@ -1328,7 +1328,7 @@ class TestProblem(BaseTest):
                 cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
                 solver=s.OSQP, max_iter=1)
 
-    def test_reshape(self):
+    def test_reshape(self) -> None:
         """Tests problems with reshape.
         """
         # Test on scalars.
@@ -1383,7 +1383,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(expr.value, 2*c)
 
-    def test_cumsum(self):
+    def test_cumsum(self) -> None:
         """Test problems with cumsum.
         """
         tt = cp.Variable(5)
@@ -1392,7 +1392,7 @@ class TestProblem(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, -0.0001)
 
-    def test_cummax(self):
+    def test_cummax(self) -> None:
         """Test problems with cummax.
         """
         tt = cp.Variable(5)
@@ -1401,7 +1401,7 @@ class TestProblem(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 15)
 
-    def test_vec(self):
+    def test_vec(self) -> None:
         """Tests problems with vec.
         """
         c = [1, 2, 3, 4]
@@ -1413,7 +1413,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 20)
         self.assertItemsAlmostEqual(expr.value, [-1, -2, 3, 4])
 
-    def test_diag_prob(self):
+    def test_diag_prob(self) -> None:
         """Test a problem with diag.
         """
         C = Variable((3, 3))
@@ -1426,7 +1426,7 @@ class TestProblem(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 0.583151, places=2)
 
-    def test_presolve_parameters(self):
+    def test_presolve_parameters(self) -> None:
         """Test presolve with parameters.
         """
         # Test with parameters.
@@ -1442,7 +1442,7 @@ class TestProblem(BaseTest):
         prob.solve(solver=s.SCS)
         self.assertEqual(prob.status, s.OPTIMAL)
 
-    def test_parameter_expressions(self):
+    def test_parameter_expressions(self) -> None:
         """Test that expressions with parameters are updated properly.
         """
         x = Variable()
@@ -1481,7 +1481,7 @@ class TestProblem(BaseTest):
             prob.solve()
         self.assertAlmostEqual(prob.value, 1, places=2)
 
-    def test_psd_constraints(self):
+    def test_psd_constraints(self) -> None:
         """Test positive definite constraints.
         """
         C = Variable((3, 3))
@@ -1509,7 +1509,7 @@ class TestProblem(BaseTest):
         result = prob.solve()
         self.assertEqual(prob.status, s.UNBOUNDED)
 
-    def test_psd_duals(self):
+    def test_psd_duals(self) -> None:
         """Test the duals of PSD constraints.
         """
         if s.CVXOPT in INSTALLED_SOLVERS:
@@ -1565,7 +1565,7 @@ class TestProblem(BaseTest):
         self.assertItemsAlmostEqual(constraints[0].dual_value, psd_constr_dual,
                                     places=3)
 
-    def test_geo_mean(self):
+    def test_geo_mean(self) -> None:
         import numpy as np
 
         x = Variable(2)
@@ -1640,7 +1640,7 @@ class TestProblem(BaseTest):
         xval = np.array(x.value).flatten()
         self.assertTrue(np.allclose(xval, x_true, 1e-3))
 
-    def test_pnorm(self):
+    def test_pnorm(self) -> None:
         import numpy as np
 
         x = Variable(3, name='x')
@@ -1667,7 +1667,7 @@ class TestProblem(BaseTest):
             self.assertTrue(np.allclose(prob.value, np.linalg.norm(x_alg, p)))
             self.assertTrue(np.allclose(np.linalg.norm(x_alg, p), cp.pnorm(x_alg, p).value))
 
-    def test_pnorm_concave(self):
+    def test_pnorm_concave(self) -> None:
         import numpy as np
 
         x = Variable(3, name='x')
@@ -1687,14 +1687,14 @@ class TestProblem(BaseTest):
 
             self.assertAlmostEqual(prob.value, 0, places=6)
 
-    def test_power(self):
+    def test_power(self) -> None:
         x = Variable()
         prob = Problem(cp.Minimize(cp.power(x, 1.7) + cp.power(x, -2.3) - cp.power(x, .45)))
         prob.solve()
         x = x.value
         self.assertTrue(builtins.abs(1.7*x**.7 - 2.3*x**-3.3 - .45*x**-.55) <= 1e-3)
 
-    def test_multiply_by_scalar(self):
+    def test_multiply_by_scalar(self) -> None:
         """Test a problem with multiply by a scalar.
         """
         import numpy as np
@@ -1720,7 +1720,7 @@ class TestProblem(BaseTest):
         result = prob.solve()
         self.assertAlmostEqual(result, 8)
 
-    def test_int64(self):
+    def test_int64(self) -> None:
         """Test bug with 64 bit integers.
         """
         q = cp.Variable(numpy.int64(2))
@@ -1729,7 +1729,7 @@ class TestProblem(BaseTest):
         problem.solve()
         print(q.value)
 
-    def test_neg_slice(self):
+    def test_neg_slice(self) -> None:
         """Test bug with negative slice.
         """
         x = cp.Variable(2)
@@ -1739,7 +1739,7 @@ class TestProblem(BaseTest):
         problem.solve()
         self.assertItemsAlmostEqual(x.value, [1, 1])
 
-    def test_pnorm_axis(self):
+    def test_pnorm_axis(self) -> None:
         """Test pnorm with axis != 0.
         """
         b = numpy.arange(2)
@@ -1760,7 +1760,7 @@ class TestProblem(BaseTest):
         prob.solve(solver='ECOS')
         self.assertItemsAlmostEqual(expr.value, numpy.zeros(10))
 
-    def test_bool_constr(self):
+    def test_bool_constr(self) -> None:
         """Test constraints that evaluate to booleans.
         """
         x = cp.Variable(pos=True)
@@ -1802,7 +1802,7 @@ class TestProblem(BaseTest):
         prob.solve()
         self.assertEqual(prob.status, s.INFEASIBLE)
 
-    def test_pos(self):
+    def test_pos(self) -> None:
         """Test the pos and neg attributes.
         """
         x = cp.Variable(pos=True)
@@ -1815,7 +1815,7 @@ class TestProblem(BaseTest):
         prob.solve()
         self.assertAlmostEqual(x.value, 0)
 
-    def test_pickle(self):
+    def test_pickle(self) -> None:
         """Test pickling and unpickling problems.
         """
         prob = cp.Problem(cp.Minimize(2*self.a + 3),
@@ -1826,7 +1826,7 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 5.0)
         self.assertAlmostEqual(new_prob.variables()[0].value, 1.0)
 
-    def test_spare_int8_matrix(self):
+    def test_spare_int8_matrix(self) -> None:
         """Test problem with sparse int8 matrix.
            issue #809.
         """
@@ -1865,7 +1865,7 @@ class TestProblem(BaseTest):
         coef_sparse = a.value.T @ D_sparse
         np.testing.assert_almost_equal(expected_coef, coef_sparse)
 
-    def test_special_index(self):
+    def test_special_index(self) -> None:
         """Test QP code path with special indexing.
         """
         x = cp.Variable((1, 3))
@@ -1881,7 +1881,7 @@ class TestProblem(BaseTest):
         result2 = prob.solve()
         self.assertAlmostEqual(result1, result2)
 
-    def test_indicator(self):
+    def test_indicator(self) -> None:
         """Test a problem with indicators.
         """
         n = 5
@@ -1901,7 +1901,7 @@ class TestProblem(BaseTest):
         solution2 = problem.solve()
         self.assertAlmostEqual(solution1, solution2)
 
-    def test_rmul_scalar_mats(self):
+    def test_rmul_scalar_mats(self) -> None:
         """Test that rmul works with 1x1 matrices.
         """
         x = [[4144.30127531]]
@@ -1922,7 +1922,7 @@ class TestProblem(BaseTest):
         prob.solve('OSQP', verbose=True)
         self.assertAlmostEqual(prob.value, result1)
 
-    def test_min_with_axis(self):
+    def test_min_with_axis(self) -> None:
         """Test reshape of a min with axis=0.
         """
         x = cp.Variable((5, 2))

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -33,7 +33,7 @@ from cvxpy.tests.base_test import BaseTest
 class TestQp(BaseTest):
     """ Unit tests for the domain module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.a = Variable(name='a')
         self.b = Variable(name='b')
         self.c = Variable(name='c')
@@ -68,7 +68,7 @@ class TestQp(BaseTest):
     def solve_QP(self, problem, solver_name):
         return problem.solve(solver=solver_name, verbose=False)
 
-    def test_all_solvers(self):
+    def test_all_solvers(self) -> None:
         for solver in self.solvers:
             self.quad_over_lin(solver)
             self.power(solver)
@@ -99,7 +99,7 @@ class TestQp(BaseTest):
             self.equivalent_forms_2(solver)
             self.equivalent_forms_3(solver)
 
-    def quad_over_lin(self, solver):
+    def quad_over_lin(self, solver) -> None:
         p = Problem(Minimize(0.5 * quad_over_lin(abs(self.x-1), 1)),
                     [self.x <= -1])
         self.solve_QP(p, solver)
@@ -110,7 +110,7 @@ class TestQp(BaseTest):
             self.assertItemsAlmostEqual(np.array([2., 2.]),
                                         con.dual_value, places=4)
 
-    def abs(self, solver):
+    def abs(self, solver) -> None:
         u = Variable(2)
         constr = []
         constr += [abs(u[1] - u[0]) <= 100]
@@ -120,20 +120,20 @@ class TestQp(BaseTest):
         result = prob.solve(solver=solver)
         self.assertAlmostEqual(result, 0)
 
-    def power(self, solver):
+    def power(self, solver) -> None:
         p = Problem(Minimize(sum(power(self.x, 2))), [])
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual([0., 0.], var.value, places=4)
 
-    def power_matrix(self, solver):
+    def power_matrix(self, solver) -> None:
         p = Problem(Minimize(sum(power(self.A - 3., 2))), [])
         self.solve_QP(p, solver)
         for var in p.variables():
             self.assertItemsAlmostEqual([3., 3., 3., 3.],
                                         var.value, places=4)
 
-    def square_affine(self, solver):
+    def square_affine(self, solver) -> None:
         A = np.random.randn(10, 2)
         b = np.random.randn(10)
         p = Problem(Minimize(sum_squares(A @ self.x - b)))
@@ -143,7 +143,7 @@ class TestQp(BaseTest):
                                         var.value,
                                         places=1)
 
-    def quad_form(self, solver):
+    def quad_form(self, solver) -> None:
         np.random.seed(0)
         A = np.random.randn(5, 5)
         z = np.random.randn(5)
@@ -154,7 +154,7 @@ class TestQp(BaseTest):
         for var in p.variables():
             self.assertItemsAlmostEqual(z, var.value, places=4)
 
-    def rep_quad_form(self, solver):
+    def rep_quad_form(self, solver) -> None:
         """A problem where the quad_form term is used multiple times.
         """
         np.random.seed(0)
@@ -168,7 +168,7 @@ class TestQp(BaseTest):
         for var in p.variables():
             self.assertItemsAlmostEqual(z, var.value, places=4)
 
-    def affine_problem(self, solver):
+    def affine_problem(self, solver) -> None:
         A = np.random.randn(5, 2)
         A = np.maximum(A, 0)
         b = np.random.randn(5)
@@ -178,7 +178,7 @@ class TestQp(BaseTest):
         for var in p.variables():
             self.assertItemsAlmostEqual([0., 0.], var.value, places=3)
 
-    def maximize_problem(self, solver):
+    def maximize_problem(self, solver) -> None:
         A = np.random.randn(5, 2)
         A = np.maximum(A, 0)
         b = np.random.randn(5)
@@ -188,7 +188,7 @@ class TestQp(BaseTest):
         for var in p.variables():
             self.assertItemsAlmostEqual([0., 0.], var.value, places=3)
 
-    def norm_2(self, solver):
+    def norm_2(self, solver) -> None:
         A = np.random.randn(10, 5)
         b = np.random.randn(10)
         p = Problem(Minimize(norm(A @ self.w - b, 2)))
@@ -197,7 +197,7 @@ class TestQp(BaseTest):
             self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(), var.value,
                                         places=1)
 
-    def mat_norm_2(self, solver):
+    def mat_norm_2(self, solver) -> None:
         A = np.random.randn(5, 3)
         B = np.random.randn(5, 2)
         p = Problem(Minimize(norm(A @ self.C - B, 2)))
@@ -206,7 +206,7 @@ class TestQp(BaseTest):
             self.assertItemsAlmostEqual(lstsq(A, B)[0],
                                         s.primal_vars[var.id], places=1)
 
-    def quad_form_coeff(self, solver):
+    def quad_form_coeff(self, solver) -> None:
         np.random.seed(0)
         A = np.random.randn(5, 5)
         z = np.random.randn(5)
@@ -217,7 +217,7 @@ class TestQp(BaseTest):
         for var in p.variables():
             self.assertItemsAlmostEqual(z, var.value, places=4)
 
-    def quad_form_bound(self, solver):
+    def quad_form_bound(self, solver) -> None:
         P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
         q = np.array([[-22], [-14.5], [13]])
         r = 1
@@ -228,7 +228,7 @@ class TestQp(BaseTest):
         for var in p.variables():
             self.assertItemsAlmostEqual(y_star, var.value, places=4)
 
-    def regression_1(self, solver):
+    def regression_1(self, solver) -> None:
         np.random.seed(1)
         # Number of examples to use
         n = 100
@@ -250,7 +250,7 @@ class TestQp(BaseTest):
         self.solve_QP(p, solver)
         self.assertAlmostEqual(1171.60037715, p.value, places=4)
 
-    def regression_2(self, solver):
+    def regression_2(self, solver) -> None:
         np.random.seed(1)
         # Number of examples to use
         n = 100
@@ -272,7 +272,7 @@ class TestQp(BaseTest):
 
         self.assertAlmostEqual(139.225660756, p.value, places=4)
 
-    def control(self, solver):
+    def control(self, solver) -> None:
         # Some constraints on our motion
         # The object should start from the origin, and end at rest
         initial_velocity = np.array([-20, 100])
@@ -304,7 +304,7 @@ class TestQp(BaseTest):
         self.solve_QP(p, solver)
         self.assertAlmostEqual(178.500, p.value, places=1)
 
-    def sparse_system(self, solver):
+    def sparse_system(self, solver) -> None:
         m = 100
         n = 80
         np.random.seed(1)
@@ -316,7 +316,7 @@ class TestQp(BaseTest):
         self.solve_QP(p, solver)
         self.assertAlmostEqual(b.T.dot(b), p.value, places=4)
 
-    def smooth_ridge(self, solver):
+    def smooth_ridge(self, solver) -> None:
         np.random.seed(1)
         n = 200
         k = 50
@@ -330,7 +330,7 @@ class TestQp(BaseTest):
         self.solve_QP(p, solver)
         self.assertAlmostEqual(0, p.value, places=4)
 
-    def huber_small(self, solver):
+    def huber_small(self, solver) -> None:
         # Solve the Huber regression problem
         x = Variable(3)
         objective = sum(huber(x))
@@ -341,7 +341,7 @@ class TestQp(BaseTest):
         self.assertAlmostEqual(3, x.value[2], places=4)
         self.assertAlmostEqual(5, objective.value, places=4)
 
-    def huber(self, solver):
+    def huber(self, solver) -> None:
         # Generate problem data
         np.random.seed(2)
         n = 3
@@ -364,7 +364,7 @@ class TestQp(BaseTest):
                                     [-1.03751745, 0.86657204, -0.9649172],
                                     places=3)
 
-    def equivalent_forms_1(self, solver):
+    def equivalent_forms_1(self, solver) -> None:
         m = 100
         n = 80
         r = 70
@@ -381,7 +381,7 @@ class TestQp(BaseTest):
         self.solve_QP(p1, solver)
         self.assertAlmostEqual(p1.value, 68.1119420108, places=4)
 
-    def equivalent_forms_2(self, solver):
+    def equivalent_forms_2(self, solver) -> None:
         m = 100
         n = 80
         r = 70
@@ -403,7 +403,7 @@ class TestQp(BaseTest):
         self.solve_QP(p2, solver)
         self.assertAlmostEqual(p2.value, 68.1119420108, places=4)
 
-    def equivalent_forms_3(self, solver):
+    def equivalent_forms_3(self, solver) -> None:
         m = 100
         n = 80
         r = 70
@@ -426,7 +426,7 @@ class TestQp(BaseTest):
         self.solve_QP(p3, solver)
         self.assertAlmostEqual(p3.value, 68.1119420108, places=4)
 
-    def test_warm_start(self):
+    def test_warm_start(self) -> None:
         """Test warm start.
         """
         m = 200
@@ -449,7 +449,7 @@ class TestQp(BaseTest):
         self.assertAlmostEqual(result, result2)
         pass
 
-    def test_parametric(self):
+    def test_parametric(self) -> None:
         """Test solve parametric problem vs full problem"""
         x = Variable()
         a = 10
@@ -489,7 +489,7 @@ class TestQp(BaseTest):
                 self.assertItemsAlmostEqual(x_full[i], x_param[i], places=3)
                 self.assertAlmostEqual(obj_full[i], obj_param[i])
 
-    def test_square_param(self):
+    def test_square_param(self) -> None:
         """Test issue arising with square plus parameter.
         """
         a = Parameter(value=1)
@@ -500,7 +500,7 @@ class TestQp(BaseTest):
         prob.solve()
         self.assertAlmostEqual(obj.value, 1.0)
 
-    def test_gurobi_time_limit_no_solution(self):
+    def test_gurobi_time_limit_no_solution(self) -> None:
         """Make sure that if Gurobi terminates due to a time limit before finding a solution:
             1) no error is raised,
             2) solver stats are returned.

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -27,7 +27,7 @@ from cvxpy.tests.base_test import BaseTest
 
 
 class TestNonOptimal(BaseTest):
-    def test_singular_quad_form(self):
+    def test_singular_quad_form(self) -> None:
         """Test quad form with a singular matrix.
         """
         # Solve a quadratic program.
@@ -72,7 +72,7 @@ class TestNonOptimal(BaseTest):
                     assert_allclose(yopt, 0, atol=1e-3)
                     assert_allclose(xopt, v, atol=1e-3)
 
-    def test_sparse_quad_form(self):
+    def test_sparse_quad_form(self) -> None:
         """Test quad form with a sparse matrix.
         """
         Q = sp.eye(2)
@@ -96,7 +96,7 @@ class TestNonOptimal(BaseTest):
         problem.solve()
         self.assertEqual(len(function.value), 1)
 
-    def test_param_quad_form(self):
+    def test_param_quad_form(self) -> None:
         """Test quad form with a parameter.
         """
         P = cvxpy.Parameter((2, 2), PSD=True)
@@ -109,7 +109,7 @@ class TestNonOptimal(BaseTest):
             warnings.simplefilter('ignore')
             self.assertAlmostEqual(prob.solve(), 5)
 
-    def test_non_symmetric(self):
+    def test_non_symmetric(self) -> None:
         """Test when P is constant and not symmetric.
         """
         P = np.array([[2, 2], [3, 4]])
@@ -119,7 +119,7 @@ class TestNonOptimal(BaseTest):
         self.assertTrue("P must be symmetric/Hermitian."
                         in str(cm.exception))
 
-    def test_non_psd(self):
+    def test_non_psd(self) -> None:
         """Test error when P is symmetric but not definite.
         """
         P = np.array([[1, 0], [0, -1]])
@@ -134,7 +134,7 @@ class TestNonOptimal(BaseTest):
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
 
-    def test_psd_exactly_tolerance(self):
+    def test_psd_exactly_tolerance(self) -> None:
         """Test that PSD check when eigenvalue is exactly -EIGVAL_TOL
         """
         P = np.array([[-EIGVAL_TOL, 0], [0, 10]])
@@ -146,7 +146,7 @@ class TestNonOptimal(BaseTest):
             prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
             prob.solve()
 
-    def test_nsd_exactly_tolerance(self):
+    def test_nsd_exactly_tolerance(self) -> None:
         """Test that NSD check when eigenvalue is exactly EIGVAL_TOL
         """
         P = np.array([[EIGVAL_TOL, 0], [0, -10]])
@@ -158,7 +158,7 @@ class TestNonOptimal(BaseTest):
             prob = cvxpy.Problem(cvxpy.Maximize(cost), [x == [1, 2]])
             prob.solve()
 
-    def test_obj_eval(self):
+    def test_obj_eval(self) -> None:
         """Test case where objective evaluation differs from result.
         """
         x = cvxpy.Variable((2, 1))
@@ -170,7 +170,7 @@ class TestNonOptimal(BaseTest):
         prob.solve()
         self.assertAlmostEqual(prob.value, prob.objective.value)
 
-    def test_zero_term(self):
+    def test_zero_term(self) -> None:
         """Test a quad form multiplied by zero.
         """
         data_norm = np.random.random(5)
@@ -187,7 +187,7 @@ class TestNonOptimal(BaseTest):
         prob = cvxpy.Problem(objective, constraints)
         prob.solve()
 
-    def test_zero_matrix(self):
+    def test_zero_matrix(self) -> None:
         """Test quad_form with P = 0.
         """
         x = cvxpy.Variable(3)

--- a/cvxpy/tests/test_quadratic.py
+++ b/cvxpy/tests/test_quadratic.py
@@ -26,11 +26,11 @@ import warnings
 class TestExpressions(BaseTest):
     """ Unit tests for the expression/expression module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         pass
 
     # Test elementwise power
-    def test_power(self):
+    def test_power(self) -> None:
         x = Variable(3)
         y = Variable(3)
         self.assertFalse(x.is_constant())
@@ -61,7 +61,7 @@ class TestExpressions(BaseTest):
         self.assertTrue(w.is_quadratic())
         self.assertTrue(w.is_dcp())
 
-    def test_matrix_multiplication(self):
+    def test_matrix_multiplication(self) -> None:
         x = Variable((3, 5))
         y = Variable((3, 5))
         self.assertFalse(x.is_constant())
@@ -76,7 +76,7 @@ class TestExpressions(BaseTest):
         self.assertTrue(s.is_quadratic())
         self.assertFalse(s.is_dcp())
 
-    def test_quad_over_lin(self):
+    def test_quad_over_lin(self) -> None:
         x = Variable((3, 5))
         y = Variable((3, 5))
         z = Variable()
@@ -92,7 +92,7 @@ class TestExpressions(BaseTest):
         self.assertTrue(t.is_quadratic())
         self.assertTrue(t.is_dcp())
 
-    def test_matrix_frac(self):
+    def test_matrix_frac(self) -> None:
         x = Variable(5)
         M = np.eye(5)
         P = M.T @ M
@@ -102,7 +102,7 @@ class TestExpressions(BaseTest):
         self.assertTrue(s.is_quadratic())
         self.assertTrue(s.is_dcp())
 
-    def test_quadratic_form(self):
+    def test_quadratic_form(self) -> None:
         x = Variable(5)
         P = np.eye(5) - 2*np.ones((5, 5))
         q = np.ones((5, 1))
@@ -114,7 +114,7 @@ class TestExpressions(BaseTest):
         self.assertTrue(s.is_quadratic())
         self.assertFalse(s.is_dcp())
 
-    def test_sum_squares(self):
+    def test_sum_squares(self) -> None:
         X = Variable((5, 4))
         P = np.ones((3, 5))
         Q = np.ones((4, 7))
@@ -140,7 +140,7 @@ class TestExpressions(BaseTest):
         self.assertFalse(t.is_quadratic())
         self.assertTrue(t.is_dcp())
 
-    def test_indefinite_quadratic(self):
+    def test_indefinite_quadratic(self) -> None:
         x = Variable()
         y = Variable()
         z = Variable()
@@ -154,7 +154,7 @@ class TestExpressions(BaseTest):
             self.assertTrue(t.is_quadratic())
             self.assertFalse(t.is_dcp())
 
-    def test_non_quadratic(self):
+    def test_non_quadratic(self) -> None:
         x = Variable()
         y = Variable()
         z = Variable()
@@ -165,7 +165,7 @@ class TestExpressions(BaseTest):
         t = cp.max(vstack([x**2, power(y, 2), z]))
         self.assertFalse(t.is_quadratic())
 
-    def test_affine_prod(self):
+    def test_affine_prod(self) -> None:
         x = Variable((3, 5))
         y = Variable((5, 4))
 

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -23,12 +23,12 @@ from cvxpy.tests.base_test import BaseTest
 class TestSemidefiniteVariable(BaseTest):
     """ Unit tests for the expressions/shape module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.X = Variable((2, 2), PSD=True)
         self.Y = Variable((2, 2))
         self.F = np.array([[1, 0], [0, -1]])
 
-    def test_symm(self):
+    def test_symm(self) -> None:
         """Test that results are symmetric.
         """
         M = Variable((3, 3), PSD=True)
@@ -43,7 +43,7 @@ class TestSemidefiniteVariable(BaseTest):
         prob.solve()
         assert (M.value == M.T.value).all()
 
-    def test_sdp_problem(self):
+    def test_sdp_problem(self) -> None:
         # PSD in objective.
         obj = cvx.Minimize(cvx.sum(cvx.square(self.X - self.F)))
         p = cvx.Problem(obj, [])

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -23,17 +23,17 @@ import unittest
 class TestShape(unittest.TestCase):
     """ Unit tests for the expressions/shape module. """
 
-    def setUp(self):
+    def setUp(self) -> None:
         pass
 
     # Test adding two shapes.
-    def test_add_matching(self):
+    def test_add_matching(self) -> None:
         """Test addition of matching shapes.
         """
         self.assertEqual(shape.sum_shapes([(3, 4), (3, 4)]), (3, 4))
         self.assertEqual(shape.sum_shapes([(3, 4)] * 5), (3, 4))
 
-    def test_add_broadcasting(self):
+    def test_add_broadcasting(self) -> None:
         """Test broadcasting of shapes during addition.
         """
         # Broadcasting with scalars is permitted.
@@ -65,13 +65,13 @@ class TestShape(unittest.TestCase):
         with self.assertRaises(ValueError):
             shape.sum_shapes([(4, 1), (4, 2)])
 
-    def test_add_incompatible(self):
+    def test_add_incompatible(self) -> None:
         """Test addition of incompatible shapes raises a ValueError.
         """
         with self.assertRaises(ValueError):
             shape.sum_shapes([(4, 2), (4,)])
 
-    def test_mul_scalars(self):
+    def test_mul_scalars(self) -> None:
         """Test multiplication by scalars raises a ValueError.
         """
         with self.assertRaises(ValueError):
@@ -81,7 +81,7 @@ class TestShape(unittest.TestCase):
         with self.assertRaises(ValueError):
             shape.mul_shapes(tuple(), tuple())
 
-    def test_mul_2d(self):
+    def test_mul_2d(self) -> None:
         """Test multiplication where at least one of the shapes is >= 2D.
         """
         self.assertEqual(shape.mul_shapes((5, 9), (9, 2)), (5, 2))
@@ -97,7 +97,7 @@ class TestShape(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Incompatible dimensions (3, 5, 9) (4, 9, 2)")
 
-    def test_reshape_with_lists(self):
+    def test_reshape_with_lists(self) -> None:
         n = 2
         a = Variable([n, n])
         b = Variable(n**2)

--- a/cvxpy/tests/test_sign.py
+++ b/cvxpy/tests/test_sign.py
@@ -21,24 +21,24 @@ from cvxpy.tests.base_test import BaseTest
 class TestSign(BaseTest):
     """ Unit tests for the expression/sign class. """
     @classmethod
-    def setUpClass(self):
+    def setUpClass(self) -> None:
         self.pos = Constant(1)
         self.neg = Constant(-1)
         self.zero = Constant(0)
         self.unknown = Variable()
 
-    def test_add(self):
+    def test_add(self) -> None:
         self.assertEqual((self.pos + self.neg).sign, self.unknown.sign)
         self.assertEqual((self.neg + self.zero).sign, self.neg.sign)
         self.assertEqual((self.pos + self.pos).sign, self.pos.sign)
         self.assertEqual((self.unknown + self.zero).sign, self.unknown.sign)
 
-    def test_sub(self):
+    def test_sub(self) -> None:
         self.assertEqual((self.pos - self.neg).sign, self.pos.sign)
         self.assertEqual((self.neg - self.zero).sign, self.neg.sign)
         self.assertEqual((self.pos - self.pos).sign, self.unknown.sign)
 
-    def test_mult(self):
+    def test_mult(self) -> None:
         self.assertEqual((self.zero * self.pos).sign, self.zero.sign)
         self.assertEqual((self.unknown * self.pos).sign, self.unknown.sign)
         self.assertEqual((self.pos * self.neg).sign, self.neg.sign)
@@ -47,12 +47,12 @@ class TestSign(BaseTest):
         self.assertEqual((self.neg * self.neg).sign, self.pos.sign)
         self.assertEqual((self.zero * self.unknown).sign, self.zero.sign)
 
-    def test_neg(self):
+    def test_neg(self) -> None:
         self.assertEqual((-self.zero).sign, self.zero.sign)
         self.assertEqual((-self.pos).sign, self.neg.sign)
 
     # Tests the is_nonneg and is_nonpos methods.
-    def test_is_sign(self):
+    def test_is_sign(self) -> None:
         assert self.pos.is_nonneg()
         assert not self.neg.is_nonneg()
         assert not self.unknown.is_nonneg()

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -30,7 +30,7 @@ class TestSupportFunctions(BaseTest):
         cvxpy.reductions.dcp2cone.atom_canonicalizers.suppfunc_canon
     """
 
-    def test_Rn(self):
+    def test_Rn(self) -> None:
         np.random.seed(0)
         n = 5
         x = cp.Variable(shape=(n,))
@@ -50,7 +50,7 @@ class TestSupportFunctions(BaseTest):
         viol = cons[0].violation()
         self.assertLessEqual(viol, 1e-8)
 
-    def test_vector1norm(self):
+    def test_vector1norm(self) -> None:
         n = 3
         np.random.seed(1)
         a = np.random.randn(n,)
@@ -65,7 +65,7 @@ class TestSupportFunctions(BaseTest):
         self.assertLessEqual(abs(actual - expected), 1e-6)
         self.assertLessEqual(abs(prob.objective.expr.value - prob.value), 1e-6)
 
-    def test_vector2norm(self):
+    def test_vector2norm(self) -> None:
         n = 3
         np.random.seed(1)
         a = np.random.randn(n,)
@@ -80,7 +80,7 @@ class TestSupportFunctions(BaseTest):
         self.assertLessEqual(abs(actual - expected), 1e-6)
         self.assertLessEqual(abs(prob.objective.expr.value - prob.value), 1e-6)
 
-    def test_rectangular_variable(self):
+    def test_rectangular_variable(self) -> None:
         np.random.seed(2)
         rows, cols = 4, 2
         a = np.random.randn(rows, cols)
@@ -97,7 +97,7 @@ class TestSupportFunctions(BaseTest):
         viol = cons[0].violation()
         self.assertLessEqual(viol, 1e-6)
 
-    def test_psd_dualcone(self):
+    def test_psd_dualcone(self) -> None:
         np.random.seed(5)
         n = 3
         X = cp.Variable(shape=(n, n))
@@ -113,7 +113,7 @@ class TestSupportFunctions(BaseTest):
         eigs = np.linalg.eigh(Y.value)[0]
         self.assertLessEqual(np.max(eigs), 1e-6)
 
-    def test_largest_singvalue(self):
+    def test_largest_singvalue(self) -> None:
         np.random.seed(3)
         rows, cols = 3, 4
         A = np.random.randn(rows, cols)
@@ -128,7 +128,7 @@ class TestSupportFunctions(BaseTest):
         expect = np.sum(A_sv)
         self.assertLessEqual(abs(actual - expect), 1e-6)
 
-    def test_expcone_1(self):
+    def test_expcone_1(self) -> None:
         x = cp.Variable(shape=(1,))
         tempcons = [cp.exp(x[0]) <= np.exp(1), cp.exp(-x[0]) <= np.exp(1)]
         sigma = cp.suppfunc(x, tempcons)
@@ -142,7 +142,7 @@ class TestSupportFunctions(BaseTest):
         self.assertLessEqual(viol, 1e-6)
         self.assertLessEqual(abs(y.value - (-1)), 1e-6)
 
-    def test_expcone_2(self):
+    def test_expcone_2(self) -> None:
         x = cp.Variable(shape=(3,))
         tempcons = [cp.sum(x) <= 1.0, cp.sum(x) >= 0.1, x >= 0.01,
                     cp.kl_div(x[1], x[0]) + x[1] - x[0] + x[2] <= 0]
@@ -161,7 +161,7 @@ class TestSupportFunctions(BaseTest):
         self.assertLessEqual(abs(epi_actual - expect), 1e-6)
         self.assertLessEqual(abs(direct_actual - expect), 1e-6)
 
-    def test_basic_lmi(self):
+    def test_basic_lmi(self) -> None:
         np.random.seed(4)
         n = 3
         A = np.random.randn(n, n)
@@ -179,7 +179,7 @@ class TestSupportFunctions(BaseTest):
         expect = np.trace(A)
         self.assertLessEqual(abs(actual1 - expect), 1e-4)
 
-    def test_invalid_solver(self):
+    def test_invalid_solver(self) -> None:
         n = 3
         x = cp.Variable(shape=(n,))
         sigma = cp.suppfunc(x, [cp.norm(x - np.random.randn(n,), 2) <= 1])
@@ -189,12 +189,12 @@ class TestSupportFunctions(BaseTest):
                 SolverError, ".*could not be reduced to a QP.*"):
             prob.solve(solver='OSQP')
 
-    def test_invalid_variable(self):
+    def test_invalid_variable(self) -> None:
         x = cp.Variable(shape=(2, 2), symmetric=True)
         with self.assertRaises(ValueError):
             cp.suppfunc(x, [])
 
-    def test_invalid_constraint(self):
+    def test_invalid_constraint(self) -> None:
         x = cp.Variable(shape=(3,))
         a = cp.Parameter(shape=(3,))
         cons = [a @ x == 1]

--- a/cvxpy/transforms/indicator.py
+++ b/cvxpy/transforms/indicator.py
@@ -37,44 +37,44 @@ class indicator(Expression):
         super(indicator, self).__init__()
 
     @perf.compute_once
-    def is_constant(self):
+    def is_constant(self) -> bool:
         """The Indicator is constant if all constraints have constant args.
         """
         all_args = sum([c.args for c in self.args], [])
         return all([arg.is_constant() for arg in all_args])
 
-    def is_convex(self):
+    def is_convex(self) -> bool:
         """Is the expression convex?
         """
         return True
 
-    def is_concave(self):
+    def is_concave(self) -> bool:
         """Is the expression concave?
         """
         return False
 
-    def is_log_log_convex(self):
+    def is_log_log_convex(self) -> bool:
         return False
 
-    def is_log_log_concave(self):
+    def is_log_log_concave(self) -> bool:
         return False
 
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression positive?
         """
         return True
 
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         """Is the expression negative?
         """
         return False
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the Leaf complex valued?
         """
         return False

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -23,7 +23,7 @@ from cvxpy.expressions.expression import Expression
 from cvxpy.atoms import trace, sum
 
 
-def partial_optimize(prob, opt_vars=None, dont_opt_vars=None, solver=None):
+def partial_optimize(prob, opt_vars=None, dont_opt_vars=None, solver=None) -> "PartialProblem":
     """Partially optimizes the given problem over the specified variables.
 
     Either opt_vars or dont_opt_vars must be given.
@@ -101,7 +101,7 @@ class PartialProblem(Expression):
         The variables to not optimize over.
     """
 
-    def __init__(self, prob, opt_vars, dont_opt_vars, solver):
+    def __init__(self, prob, opt_vars, dont_opt_vars, solver) -> None:
         self.opt_vars = opt_vars
         self.dont_opt_vars = dont_opt_vars
         self.solver = solver
@@ -113,22 +113,22 @@ class PartialProblem(Expression):
         """
         return [self.opt_vars, self.dont_opt_vars, self.solver]
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         return len(self.args[0].variables()) == 0
 
-    def is_convex(self):
+    def is_convex(self) -> bool:
         """Is the expression convex?
         """
         return self.args[0].is_dcp() and \
             type(self.args[0].objective) == Minimize
 
-    def is_concave(self):
+    def is_concave(self) -> bool:
         """Is the expression concave?
         """
         return self.args[0].is_dcp() and \
             type(self.args[0].objective) == Maximize
 
-    def is_dpp(self, context='dcp'):
+    def is_dpp(self, context='dcp') -> bool:
         """The expression is a disciplined parameterized expression.
         """
         if context.lower() in ['dcp', 'dgp']:
@@ -136,34 +136,34 @@ class PartialProblem(Expression):
         else:
             raise ValueError("Unsupported context", context)
 
-    def is_log_log_convex(self):
+    def is_log_log_convex(self) -> bool:
         """Is the expression convex?
         """
         return self.args[0].is_dgp() and \
             type(self.args[0].objective) == Minimize
 
-    def is_log_log_concave(self):
+    def is_log_log_concave(self) -> bool:
         """Is the expression convex?
         """
         return self.args[0].is_dgp() and \
             type(self.args[0].objective) == Maximize
 
-    def is_nonneg(self):
+    def is_nonneg(self) -> bool:
         """Is the expression nonnegative?
         """
         return self.args[0].objective.args[0].is_nonneg()
 
-    def is_nonpos(self):
+    def is_nonpos(self) -> bool:
         """Is the expression nonpositive?
         """
         return self.args[0].objective.args[0].is_nonpos()
 
-    def is_imag(self):
+    def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
         return False
 
-    def is_complex(self):
+    def is_complex(self) -> bool:
         """Is the Leaf complex valued?
         """
         return False
@@ -174,7 +174,7 @@ class PartialProblem(Expression):
         """
         return tuple()
 
-    def name(self):
+    def name(self) -> str:
         """Returns the string representation of the expression.
         """
         return "PartialProblem(%s)" % str(self.args[0])

--- a/cvxpy/transforms/scalarize.py
+++ b/cvxpy/transforms/scalarize.py
@@ -13,14 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from typing import List
 
-from cvxpy import Constant
 import cvxpy.atoms as atoms
-from cvxpy.problems.objective import Minimize, Maximize
+from cvxpy import Constant
+from cvxpy.expressions.expression import Expression
+from cvxpy.problems.objective import Minimize, Maximize, Objective
 from cvxpy.transforms import indicator
 
 
-def weighted_sum(objectives, weights):
+def weighted_sum(objectives: List[Objective], weights) -> Expression:
     """Combines objectives as a weighted sum.
 
     Args:

--- a/cvxpy/transforms/suppfunc.py
+++ b/cvxpy/transforms/suppfunc.py
@@ -95,7 +95,7 @@ def scs_cone_selectors(K):
 
 class SuppFunc(object):
 
-    def __init__(self, x, constraints):
+    def __init__(self, x, constraints) -> None:
         """
         A callable python object, representing the support function of the convex set:
 
@@ -140,7 +140,7 @@ class SuppFunc(object):
         sigma_at_y = SuppFuncAtom(y, self)
         return sigma_at_y
 
-    def _compute_conic_repr_of_set(self):
+    def _compute_conic_repr_of_set(self) -> None:
         if len(self.constraints) == 0:
             dummy = Variable()
             constrs = [dummy == 1]

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -96,7 +96,7 @@ class Canonical(object):
         else:
             return type(self)(*args)
 
-    def get_data(self):
+    def get_data(self) -> None:
         """Returns info needed to reconstruct the object besides the args.
 
         Returns

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -32,7 +32,7 @@ from cvxpy.lin_ops.lin_op import LinOp, NO_OP
 # TODO find best format for sparse matrices: csr, csc, dok, lil, ...
 class CoeffExtractor(object):
 
-    def __init__(self, inverse_data):
+    def __init__(self, inverse_data) -> None:
         self.id_map = inverse_data.var_offsets
         self.x_length = inverse_data.x_length
         self.var_shapes = inverse_data.var_shapes

--- a/cvxpy/utilities/debug_tools.py
+++ b/cvxpy/utilities/debug_tools.py
@@ -17,7 +17,7 @@ DCP = 'DCP'
 DGP = 'DGP'
 
 
-def build_non_disciplined_error_msg(problem, discipline_type):
+def build_non_disciplined_error_msg(problem, discipline_type) -> str:
     prop_name = None
     prefix_conv = ""
     if discipline_type == DCP:

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -17,6 +17,8 @@ limitations under the License.
 # Utility functions to handle indexing/slicing into an expression.
 
 from __future__ import division
+from typing import Optional
+
 import numpy as np
 import numbers
 
@@ -60,7 +62,7 @@ def to_tuple(key):
         return (key,)
 
 
-def format_slice(key_val, dim, axis):
+def format_slice(key_val, dim, axis) -> Optional[slice]:
     """Converts part of a key into a slice with a start and step.
 
     Uses the same syntax as numpy.
@@ -119,7 +121,7 @@ def wrap_neg_index(index, dim, neg_step=False):
     return index
 
 
-def index_to_slice(idx):
+def index_to_slice(idx) -> slice:
     """Converts an index to a slice.
 
     Args:
@@ -154,7 +156,7 @@ def none_to_empty(val):
         return val
 
 
-def is_single_index(slc):
+def is_single_index(slc) -> bool:
     """Is the slice equivalent to a single index?
     """
     if slc.step is None:
@@ -194,7 +196,7 @@ def to_str(key):
     return tuple(slice_to_str(elem) for elem in key)
 
 
-def is_special_slice(key):
+def is_special_slice(key) -> bool:
     """Does the key contain a list, ndarray, or logical ndarray?
     """
     # Slices and int-like numbers are fine.

--- a/cvxpy/utilities/power_tools.py
+++ b/cvxpy/utilities/power_tools.py
@@ -122,7 +122,7 @@ def pow_neg(p, max_denom=1024):
     return p/(p-1), (p, 1-p)
 
 
-def is_power2(num):
+def is_power2(num) -> bool:
     """ Test if num is a positive integer power of 2.
 
     .. note::
@@ -148,7 +148,7 @@ def is_power2(num):
     return isinstance(num, numbers.Integral) and num > 0 and not (num & (num - 1))
 
 
-def is_dyad(frac):
+def is_dyad(frac) -> bool:
     """ Test if frac is a nonnegative dyadic fraction or integer.
 
     Examples
@@ -175,7 +175,7 @@ def is_dyad(frac):
         return False
 
 
-def is_dyad_weight(w):
+def is_dyad_weight(w) -> bool:
     """ Test if a vector is a valid dyadic weight vector.
 
         w must be nonnegative, sum to 1, and have integer or dyadic fractional elements.
@@ -192,7 +192,7 @@ def is_dyad_weight(w):
     return is_weight(w) and all(is_dyad(f) for f in w)
 
 
-def is_weight(w):
+def is_weight(w) -> bool:
     """ Test if w is a valid weight vector.
         w must have nonnegative integer or fractional elements, and sum to 1.
 

--- a/cvxpy/utilities/replace_quad_forms.py
+++ b/cvxpy/utilities/replace_quad_forms.py
@@ -36,7 +36,7 @@ def replace_quad_form(expr, idx, quad_forms):
     return quad_forms
 
 
-def restore_quad_forms(expr, quad_forms):
+def restore_quad_forms(expr, quad_forms) -> None:
     for idx, arg in enumerate(expr.args):
         if isinstance(arg, Variable) and arg.id in quad_forms:
             expr.args[idx] = quad_forms[arg.id][2]

--- a/cvxpy/utilities/scopes.py
+++ b/cvxpy/utilities/scopes.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 """
 Copyright, the CVXPY authors
 
@@ -20,7 +22,7 @@ _dpp_scope_active = False
 
 
 @contextlib.contextmanager
-def dpp_scope():
+def dpp_scope() -> Generator[None, None, None]:
     """Context manager for DPP curvature analysis
 
     When this scope is active, parameters are affine, not constant. The
@@ -44,6 +46,6 @@ def dpp_scope():
     _dpp_scope_active = prev_state
 
 
-def dpp_scope_active():
+def dpp_scope_active() -> bool:
     """Returns True if a `dpp_scope` is active. """
     return _dpp_scope_active

--- a/cvxpy/utilities/sign.py
+++ b/cvxpy/utilities/sign.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 """
 Copyright 2013 Steven Diamond
 
@@ -15,7 +17,7 @@ limitations under the License.
 """
 
 
-def sum_signs(exprs):
+def sum_signs(exprs) -> Tuple[bool, bool]:
     """Give the sign resulting from summing a list of expressions.
 
     Args:
@@ -29,7 +31,7 @@ def sum_signs(exprs):
     return (is_pos, is_neg)
 
 
-def mul_sign(lh_expr, rh_expr):
+def mul_sign(lh_expr, rh_expr) -> Tuple[bool, bool]:
     """Give the sign resulting from multiplying two expressions.
 
     Args:

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -80,12 +80,12 @@ class Reader(object):
 
     def read_to_next_empty_line(self):
         self.seek_next_non_empty_line()
-        def is_empty(line):
+        def is_empty(line) -> bool:
             return not line.strip()
         return self.read_to_condition(is_empty)
 
     def read_to_next_unindented_line(self):
-        def is_unindented(line):
+        def is_unindented(line) -> bool:
             return (line.strip() and (len(line.lstrip()) == len(line)))
         return self.read_to_condition(is_unindented)
 
@@ -95,7 +95,7 @@ class Reader(object):
         else:
             return ''
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return not ''.join(self._str).strip()
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools.command.build_ext import build_ext
 
 # inject numpy headers
 class build_ext_cvxpy(build_ext):
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
         # `__builtins__` can be a dict
@@ -24,7 +24,7 @@ class build_ext_cvxpy(build_ext):
         self.include_dirs.append(numpy.get_include())
 
 
-def is_platform_mac():
+def is_platform_mac() -> bool:
     return sys.platform == 'darwin'
 
 


### PR DESCRIPTION
This begins to add Python type annotations to the codebase. These are mostly the low-hanging fruit as I didn't want to invest too much time without knowing your plan for this.

Type annotations are useful because tools like mypy and Pyre can use them to quickly detect, in almost real-time, whether a function or variable has been used improperly. They are available as of Python 3.5 (see [here](https://docs.python.org/3/library/typing.html)).