### PR TITLE
Set prob.value to prob.objective.value

### DIFF
--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import cvxpy.settings as s
 from cvxpy.atoms.elementwise.elementwise import Elementwise
 import numpy as np
 import scipy.sparse as sp
@@ -26,7 +27,8 @@ class ceil(Elementwise):
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
-        return np.ceil(np.around(values[0], decimals=4))
+        decimals = np.int(np.abs(np.log10(s.ATOM_EVAL_TOL)))
+        return np.ceil(np.around(values[0], decimals=decimals))
 
     def sign_from_args(self):
         """Returns sign (is positive, is negative) of the expression.

--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -26,7 +26,7 @@ class ceil(Elementwise):
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
-        return np.ceil(values[0])
+        return np.ceil(np.around(values[0], decimals=4))
 
     def sign_from_args(self):
         """Returns sign (is positive, is negative) of the expression.

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -44,7 +44,7 @@ class lambda_sum_largest(lambda_max):
         Requires that A be symmetric.
         """
         eigs = LA.eigvals(values[0])
-        return sum_largest(eigs, self.k).value
+        return sum_largest(np.real(eigs), self.k).value
 
     def get_data(self):
         """Returns the parameter k.

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -43,8 +43,8 @@ class lambda_sum_largest(lambda_max):
 
         Requires that A be symmetric.
         """
-        eigs = LA.eigvals(values[0])
-        return sum_largest(np.real(eigs), self.k).value
+        eigs = LA.eigvalsh(values[0])
+        return sum_largest(eigs, self.k).value
 
     def get_data(self):
         """Returns the parameter k.

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -35,8 +35,10 @@ class log_det(Atom):
         For PSD matrix A, this is the sum of logs of eigenvalues of A
         and is equivalent to the nuclear norm of the matrix logarithm of A.
         """
-        sign, logdet = LA.slogdet(values[0])
-        if np.abs(sign) == 1:
+        # take symmetric part of the input.
+        symm = (values[0] + values[0].T)/2
+        sign, logdet = LA.slogdet(symm)
+        if sign == 1:
             return logdet
         else:
             return -np.inf

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -104,7 +104,10 @@ class log_det(Atom):
 
     @property
     def value(self):
-        if not np.allclose(self.args[0].value, self.args[0].value.T.conj()):
+        if not np.allclose(self.args[0].value,
+                           self.args[0].value.T.conj(),
+                           rtol=1e-3,
+                           atol=1e-3):
             raise ValueError("Input matrix was not Hermitian/symmetric.")
         if any([p.value is None for p in self.parameters()]):
             return None

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -35,7 +35,7 @@ class log_det(Atom):
         and is equivalent to the nuclear norm of the matrix logarithm of A.
         """
         sign, logdet = LA.slogdet(values[0])
-        if sign == 1:
+        if np.abs(sign) == 1:
             return logdet
         else:
             return -np.inf

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import cvxpy.settings as s
 from cvxpy.atoms.atom import Atom
 import numpy as np
 from numpy import linalg as LA
@@ -88,7 +89,7 @@ class log_det(Atom):
             A list of SciPy CSC sparse matrices or None.
         """
         X = values[0]
-        eigen_val = LA.eigvals(X)
+        eigen_val = LA.eigvalsh(X)
         if np.min(eigen_val) > 0:
             # Grad: X^{-1}.T
             D = np.linalg.inv(X).T
@@ -106,8 +107,8 @@ class log_det(Atom):
     def value(self):
         if not np.allclose(self.args[0].value,
                            self.args[0].value.T.conj(),
-                           rtol=1e-3,
-                           atol=1e-3):
+                           rtol=s.ATOM_EVAL_TOL,
+                           atol=s.ATOM_EVAL_TOL):
             raise ValueError("Input matrix was not Hermitian/symmetric.")
         if any([p.value is None for p in self.parameters()]):
             return None

--- a/cvxpy/atoms/norm_inf.py
+++ b/cvxpy/atoms/norm_inf.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from cvxpy.atoms.axis_atom import AxisAtom
 import numpy as np
+import scipy.sparse as sp
 
 
 class norm_inf(AxisAtom):
@@ -25,7 +26,10 @@ class norm_inf(AxisAtom):
         """Returns the inf norm of x.
         """
         if self.axis is None:
-            values = np.array(values[0]).flatten()
+            if sp.issparse(values[0]):
+                values = values[0].todense().A.flatten()
+            else:
+                values = np.array(values[0]).flatten()
         else:
             values = np.array(values[0])
         return np.linalg.norm(values, np.inf, axis=self.axis, keepdims=self.keepdims)

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -54,7 +54,7 @@ _HEADER = (
     '\n' +
     ('CVXPY').center(_COL_WIDTH) +
     '\n' +
-    (f'v{cvxtypes.version()}').center(_COL_WIDTH) +
+    ('v%s' % cvxtypes.version()).center(_COL_WIDTH) +
     '\n' +
     '='*_COL_WIDTH
 )
@@ -1226,16 +1226,18 @@ class Problem(u.Canonical):
             for c in self.constraints:
                 if c.id in solution.dual_vars:
                     c.save_dual_value(solution.dual_vars[c.id])
+            # Eliminate confusion of problem.value versus objective.value.
+            self._value = self.objective.value
         elif solution.status in s.INF_OR_UNB:
             for v in self.variables():
                 v.save_value(None)
             for constr in self.constraints:
                 for dv in constr.dual_variables:
                     dv.save_value(None)
+            self._value = solution.opt_val
         else:
             raise ValueError("Cannot unpack invalid solution: %s" % solution)
 
-        self._value = solution.opt_val
         self._status = solution.status
         self._solution = solution
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -54,7 +54,7 @@ _HEADER = (
     '\n' +
     ('CVXPY').center(_COL_WIDTH) +
     '\n' +
-    ('v%s' % cvxtypes.version()).center(_COL_WIDTH) +
+    (f'v{cvxtypes.version()}').center(_COL_WIDTH) +
     '\n' +
     '='*_COL_WIDTH
 )

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -168,6 +168,7 @@ EIGVAL_TOL = 1e-10
 PSD_NSD_PROJECTION_TOL = 1e-8
 GENERAL_PROJECTION_TOL = 1e-10
 SPARSE_PROJECTION_TOL = 1e-10
+ATOM_EVAL_TOL = 1e-4
 
 # threads to use during compilation
 # -1 defaults to system default (configurable via the OMP_NUM_THREADS

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1016,7 +1016,8 @@ class TestAtoms(BaseTest):
         """Minimize the 1-norm in the usual way
         """
         dims = 3
-        x, t = Variable(dims), Variable(dims)
+        x = Variable(dims, name='x')
+        t = Variable(dims, name='t')
         p1 = Problem(Minimize(cp.sum(t)), [-t <= x, x <= t])
 
         # Minimize the 1-norm via partial_optimize

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -197,7 +197,7 @@ class TestComplex(BaseTest):
         self.assertAlmostEqual(x.value, 1j)
 
         x = Variable(2)
-        expr = x/1j
+        expr = x*1j
         prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) >= 1])
         result = prob.solve()
         self.assertAlmostEqual(result, -np.inf)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -928,13 +928,6 @@ class TestProblem(BaseTest):
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
-        # Test with float.
-        cost = self.x[numpy.float32(0)]
-        p = Problem(cp.Minimize(cost), [self.x == 1])
-        result = p.solve()
-        self.assertAlmostEqual(result, 1)
-        self.assertItemsAlmostEqual(self.x.value, [1, 1])
-
     # Test problems with slicing.
     def test_slicing(self):
         p = Problem(cp.Maximize(cp.sum(self.C)), [self.C[1:3, :] <= 2, self.C[0, :] == 1])

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -272,11 +272,13 @@ class PartialProblem(Expression):
             else:
                 fix_vars += [var == var.value]
         prob = Problem(self.args[0].objective, fix_vars + self.args[0].constraints)
-        result = prob.solve(solver=self.solver)
+        prob.solve(solver=self.solver)
         # Restore the original values to the variables.
         for var in self.variables():
             var.value = old_vals[var.id]
-        return result
+        # Need to get value returned by solver
+        # in case of stacked partial_optimizes.
+        return prob._solution.opt_val
 
     def canonicalize(self):
         """Returns the graph implementation of the object.


### PR DESCRIPTION
This PR sets prob.value to prob.objective.value when a solution is present. I had to fix a number of .value functions for individual atoms. The solutions I chose were not always the most elegant, so I'm open to improvements.