### PR TITLE
Switch to using safe default arguments

### DIFF
--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -81,7 +81,7 @@ class AddExpression(AffAtom):
 
     # As __init__ takes in the arg_groups instead of args, we need a special
     # copy() function.
-    def copy(self, args=None, id_objects={}):
+    def copy(self, args=None, id_objects=None):
         """Returns a shallow copy of the AddExpression atom.
 
         Parameters

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -368,7 +368,7 @@ class power(Elementwise):
     def get_data(self):
         return [self._p_orig, self.max_denom]
 
-    def copy(self, args=None, id_objects={}) -> "power":
+    def copy(self, args=None, id_objects=None) -> "power":
         """Returns a shallow copy of the power atom.
 
         Parameters

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -316,7 +316,7 @@ class geo_mean(Atom):
     def get_data(self):
         return [self.w, self.w_dyad, self.tree]
 
-    def copy(self, args=None, id_objects={}):
+    def copy(self, args=None, id_objects=None):
         """Returns a shallow copy of the geo_mean atom.
 
         Parameters

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -148,7 +148,7 @@ class Leaf(expression.Expression):
                 attr_str += ", %s=%s" % (attr, val)
         return attr_str
 
-    def copy(self, args=None, id_objects={}):
+    def copy(self, args=None, id_objects=None):
         """Returns a shallow copy of the object.
 
         Used to reconstruct an object tree.
@@ -163,7 +163,7 @@ class Leaf(expression.Expression):
         -------
         Expression
         """
-        if id(self) in id_objects:
+        if id_objects is not None and id(self) in id_objects:
             return id_objects[id(self)]
         return self  # Leaves are not deep copied.
 

--- a/cvxpy/reductions/chain.py
+++ b/cvxpy/reductions/chain.py
@@ -11,9 +11,9 @@ class Chain(Reduction):
         A list of reductions.
     """
 
-    def __init__(self, problem=None, reductions=[]) -> None:
+    def __init__(self, problem=None, reductions=None) -> None:
         super(Chain, self).__init__(problem=problem)
-        self.reductions = reductions
+        self.reductions = [] if reductions is None else reductions
 
     def __str__(self):
         return str(self.reductions)

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -260,7 +260,7 @@ class SolvingChain(Chain):
         The solver, i.e., reductions[-1].
     """
 
-    def __init__(self, problem=None, reductions=[]) -> None:
+    def __init__(self, problem=None, reductions=None) -> None:
         super(SolvingChain, self).__init__(problem=problem,
                                            reductions=reductions)
         if not isinstance(self.reductions[-1], Solver):

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -61,7 +61,7 @@ class Canonical(object):
         return unique_list(
             [const for arg in self.args for const in arg.constants()])
 
-    def tree_copy(self, id_objects={}):
+    def tree_copy(self, id_objects=None):
         new_args = []
         for arg in self.args:
             if isinstance(arg, list):
@@ -71,7 +71,7 @@ class Canonical(object):
                 new_args.append(arg.tree_copy(id_objects))
         return self.copy(args=new_args, id_objects=id_objects)
 
-    def copy(self, args=None, id_objects={}):
+    def copy(self, args=None, id_objects=None):
         """Returns a shallow copy of the object.
 
         Used to reconstruct an object tree.
@@ -86,7 +86,7 @@ class Canonical(object):
         -------
         Expression
         """
-        if id(self) in id_objects:
+        if id_objects is not None and id(self) in id_objects:
             return id_objects[id(self)]
         if args is None:
             args = self.args


### PR DESCRIPTION
When `[]` or `{}` or any other mutable type is used as a default argument, this can have unexpected results as discussed [here](https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html) and [here](https://stackoverflow.com/questions/26320899/why-is-the-empty-dictionary-a-dangerous-default-value-in-python) for reasons explained [here](https://web.archive.org/web/20200221224620/http://effbot.org/zone/default-values.htm).

Rather than relying on programmer discipline not to abuse these default arguments, it is generally considered best practice to default value the arguments to `None` and check this within the function body.

This PR fixes all the instances I found, excluding the `doc/` subdir, which I assume consists largely of upstream code.