### PR TITLE
Use lazy interpolation for logging

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -597,15 +597,15 @@ class Problem(u.Canonical):
             if verbose:
                 s.LOGGER.info(
                         'Finished problem compilation '
-                        '(took %.3e seconds).' % self._compilation_time)
+                        '(took %.3e seconds).', self._compilation_time)
         else:
             if verbose:
                 solver_name = solving_chain.reductions[-1].name()
                 reduction_chain_str = ' -> '.join(
                         type(r).__name__ for r in solving_chain.reductions)
                 s.LOGGER.info(
-                         'Compiling problem (target solver=%s).' % solver_name)
-                s.LOGGER.info('Reduction chain: ' + reduction_chain_str)
+                         'Compiling problem (target solver=%s).', solver_name)
+                s.LOGGER.info('Reduction chain: %s', reduction_chain_str)
             data, inverse_data = solving_chain.apply(self, verbose)
             safe_to_cache = (
                 isinstance(data, dict)
@@ -617,7 +617,7 @@ class Problem(u.Canonical):
             if verbose:
                 s.LOGGER.info(
                         'Finished problem compilation '
-                        '(took %.3e seconds).' % self._compilation_time)
+                        '(took %.3e seconds).', self._compilation_time)
             if safe_to_cache:
                 if verbose and self.parameters():
                     s.LOGGER.info(
@@ -874,8 +874,8 @@ class Problem(u.Canonical):
             n_parameters = sum(np.prod(p.shape) for p in self.parameters())
             s.LOGGER.info(
                     'Your problem has %d variables, '
-                    '%d constraints, and ' '%d parameters.' % (
-                        n_variables, len(self.constraints), n_parameters))
+                    '%d constraints, and ' '%d parameters.',
+                        n_variables, len(self.constraints), n_parameters)
             curvatures = []
             if self.is_dcp():
                 curvatures.append('DCP')
@@ -884,7 +884,7 @@ class Problem(u.Canonical):
             if self.is_dqcp():
                 curvatures.append('DQCP')
             s.LOGGER.info(
-                    'It is compliant with the following grammars: ' +
+                    'It is compliant with the following grammars: %s',
                     ', '.join(curvatures))
             if n_parameters == 0:
                 s.LOGGER.info(
@@ -939,8 +939,8 @@ class Problem(u.Canonical):
         if verbose:
             print(_NUM_SOLVER_STR)
             s.LOGGER.info(
-                    'Invoking solver %s  to obtain a solution.' % (
-                        solving_chain.reductions[-1].name()))
+                    'Invoking solver %s  to obtain a solution.',
+                        solving_chain.reductions[-1].name())
         start = time.time()
         solution = solving_chain.solve_via_data(
             self, data, warm_start, verbose, kwargs)
@@ -949,12 +949,12 @@ class Problem(u.Canonical):
         self.unpack_results(solution, solving_chain, inverse_data)
         if verbose:
             print(_FOOTER)
-            s.LOGGER.info('Problem status: ' + self.status)
-            s.LOGGER.info('Optimal value: %.3e' % self.value)
-            s.LOGGER.info('Compilation took %.3e seconds' % self._compilation_time)
+            s.LOGGER.info('Problem status: %s', self.status)
+            s.LOGGER.info('Optimal value: %.3e', self.value)
+            s.LOGGER.info('Compilation took %.3e seconds', self._compilation_time)
             s.LOGGER.info(
                     'Solver (including time spent in interface) took '
-                    '%.3e seconds' % self._solve_time)
+                    '%.3e seconds', self._solve_time)
         return self.value
 
     def backward(self):

--- a/cvxpy/reductions/chain.py
+++ b/cvxpy/reductions/chain.py
@@ -72,7 +72,7 @@ class Chain(Reduction):
         inverse_data = []
         for r in self.reductions:
             if verbose:
-                s.LOGGER.info('Applying reduction %s' % (type(r).__name__))
+                s.LOGGER.info('Applying reduction %s', type(r).__name__)
             problem, inv = r.apply(problem)
             inverse_data.append(inv)
         return problem, inverse_data


### PR DESCRIPTION
For performance reasons it's usually best to avoid performing string interpolation for loggers. If the logger is not emitting messages, then the interpolation is not performed and time is saved. If the logger is emitting, the logger functions handle the interpolation.