### PR TITLE
Ensure variables are initialized appropriately

### DIFF
--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -50,6 +50,7 @@ class Constant(Leaf):
         self._herm = None
         self._top_eig = None
         self._bottom_eig = None
+        self._cached_is_pos = None
         super(Constant, self).__init__(intf.shape(self.value))
 
     def name(self):
@@ -74,7 +75,7 @@ class Constant(Leaf):
     def is_pos(self):
         """Returns whether the constant is elementwise positive.
         """
-        if not hasattr(self, '._cached_is_pos'):
+        if self._cached_is_pos is None:
             self._cached_is_pos = np.all(self._value > 0)
         return self._cached_is_pos
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -143,6 +143,8 @@ class Problem(u.Canonical):
         self._size_metrics = None
         # Benchmarks reported by the solver:
         self._solver_stats = None
+        self._compilation_time = None
+        self._solve_time = None
         self.args = [self._objective, self._constraints]
 
     @property

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -178,10 +178,10 @@ class ParamConeProg(ParamProb):
                     canonInterface.reduce_problem_data_tensor(
                         self.A, self.x.size))
                 self.reduced_A = reduced_A
-                self.problem_data_index = (indices, indptr, shape)
+                problem_data_index = (indices, indptr, shape)
             else:
                 self.reduced_A = self.A
-                self.problem_data_index = None
+                problem_data_index = None
 
         def param_value(idx):
             return (np.array(self.id_to_param[idx].value) if id_to_param_value
@@ -202,7 +202,7 @@ class ParamConeProg(ParamProb):
         A, b = canonInterface.get_matrix_from_tensor(
             self.reduced_A, param_vec, self.x.size,
             nonzero_rows=self._A_mapping_nonzero, with_offset=True,
-            problem_data_index=self.problem_data_index)
+            problem_data_index=problem_data_index)
         return c, d, A, np.atleast_1d(b)
 
     def apply_param_jac(self, delc, delA, delb, active_params=None):


### PR DESCRIPTION
Trying to reduce situations where attributes are defined outside of `__init__` resulting in unstable class interfaces