### PR TITLE
Classes do not need to inherit from object in Python3

### DIFF
--- a/cvxpy/cvxcore/python/cvxcore.py
+++ b/cvxpy/cvxcore/python/cvxcore.py
@@ -61,7 +61,7 @@ class _SwigNonDynamicMeta(type):
     __setattr__ = _swig_setattr_nondynamic_class_variable(type.__setattr__)
 
 
-class SwigPyIterator(object):
+class SwigPyIterator:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
 
     def __init__(self, *args, **kwargs):
@@ -147,7 +147,7 @@ DENSE_CONST = _cvxcore.DENSE_CONST
 SPARSE_CONST = _cvxcore.SPARSE_CONST
 NO_OP = _cvxcore.NO_OP
 KRON = _cvxcore.KRON
-class LinOp(object):
+class LinOp:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -221,7 +221,7 @@ def acc_tensor(lh_ten, rh_ten):
 
 def diagonalize(mat):
     return _cvxcore.diagonalize(mat)
-class ProblemData(object):
+class ProblemData:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
     TensorV = property(_cvxcore.ProblemData_TensorV_get, _cvxcore.ProblemData_TensorV_set)
@@ -254,7 +254,7 @@ _cvxcore.ProblemData_swigregister(ProblemData)
 cvar = _cvxcore.cvar
 CONSTANT_ID = cvar.CONSTANT_ID
 
-class IntVector(object):
+class IntVector:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -360,7 +360,7 @@ class IntVector(object):
 # Register IntVector in _cvxcore:
 _cvxcore.IntVector_swigregister(IntVector)
 
-class DoubleVector(object):
+class DoubleVector:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -466,7 +466,7 @@ class DoubleVector(object):
 # Register DoubleVector in _cvxcore:
 _cvxcore.DoubleVector_swigregister(DoubleVector)
 
-class IntVector2D(object):
+class IntVector2D:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -572,7 +572,7 @@ class IntVector2D(object):
 # Register IntVector2D in _cvxcore:
 _cvxcore.IntVector2D_swigregister(IntVector2D)
 
-class DoubleVector2D(object):
+class DoubleVector2D:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -678,7 +678,7 @@ class DoubleVector2D(object):
 # Register DoubleVector2D in _cvxcore:
 _cvxcore.DoubleVector2D_swigregister(DoubleVector2D)
 
-class IntIntMap(object):
+class IntIntMap:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -786,7 +786,7 @@ class IntIntMap(object):
 # Register IntIntMap in _cvxcore:
 _cvxcore.IntIntMap_swigregister(IntIntMap)
 
-class LinOpVector(object):
+class LinOpVector:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -892,7 +892,7 @@ class LinOpVector(object):
 # Register LinOpVector in _cvxcore:
 _cvxcore.LinOpVector_swigregister(LinOpVector)
 
-class ConstLinOpVector(object):
+class ConstLinOpVector:
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
@@ -1001,5 +1001,3 @@ _cvxcore.ConstLinOpVector_swigregister(ConstLinOpVector)
 
 def build_matrix(*args):
     return _cvxcore.build_matrix(*args)
-
-

--- a/cvxpy/interface/base_matrix_interface.py
+++ b/cvxpy/interface/base_matrix_interface.py
@@ -19,7 +19,7 @@ import abc
 import numpy as np
 
 
-class BaseMatrixInterface(object):
+class BaseMatrixInterface:
     """
     An interface between constants' internal values
     and the target matrix used internally.

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -20,7 +20,7 @@ DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 
 # A linear operator applied to a variable
 # or a constant or function of parameters.
-class LinOp(object):
+class LinOp:
     def __init__(self, type, shape, args, data):
         self.type = type
         self.shape = shape

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -24,7 +24,7 @@ import numpy as np
 # Utility functions for dealing with LinOp.
 
 
-class Counter(object):
+class Counter:
     """A counter for ids.
 
     Attributes

--- a/cvxpy/problems/param_prob.py
+++ b/cvxpy/problems/param_prob.py
@@ -16,7 +16,7 @@ limitations under the License.
 import abc
 
 
-class ParamProb(object):
+class ParamProb:
     """An abstract base class for parameterized problems.
 
     Parameterized problems are produced during the first canonicalization

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -81,7 +81,7 @@ _FOOTER = (
 )
 
 
-class Cache(object):
+class Cache:
     def __init__(self):
         self.key = None
         self.solving_chain = None
@@ -1337,7 +1337,7 @@ class Problem(u.Canonical):
     __truediv__ = __div__
 
 
-class SolverStats(object):
+class SolverStats:
     """Reports some of the miscellaneous information that is returned
     by the solver after solving but that is not captured directly by
     the Problem instance.
@@ -1374,7 +1374,7 @@ class SolverStats(object):
             self.extra_stats = results_dict[s.EXTRA_STATS]
 
 
-class SizeMetrics(object):
+class SizeMetrics:
     """Reports various metrics regarding the problem.
 
     Attributes

--- a/cvxpy/reductions/cone2cone/affine2direct.py
+++ b/cvxpy/reductions/cone2cone/affine2direct.py
@@ -36,7 +36,7 @@ POW3D = 'pp3'
 DUAL_POW3D = 'dp3'
 
 
-class Dualize(object):
+class Dualize:
     """
     CVXPY represents cone programs as
 
@@ -220,7 +220,7 @@ class Dualize(object):
         return sol
 
 
-class Slacks(object):
+class Slacks:
     """
     CVXPY represents mixed-integer cone programs as
 

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -34,7 +34,7 @@ import numpy as np
 import scipy.sparse as sp
 
 
-class ConeDims(object):
+class ConeDims:
     """Summary of cone dimensions present in constraints.
 
     Constraints must be formatted as dictionary that maps from

--- a/cvxpy/reductions/inverse_data.py
+++ b/cvxpy/reductions/inverse_data.py
@@ -17,7 +17,7 @@ limitations under the License.
 import cvxpy.lin_ops.lin_op as lo
 
 
-class InverseData(object):
+class InverseData:
     """Stores data useful for solution retrieval."""
 
     def __init__(self, problem):

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -32,7 +32,7 @@ from cvxpy.utilities.coeff_extractor import CoeffExtractor
 import numpy as np
 
 
-class ConeDims(object):
+class ConeDims:
     """Summary of cone dimensions present in constraints.
 
     Constraints must be formatted as dictionary that maps from

--- a/cvxpy/reductions/reduction.py
+++ b/cvxpy/reductions/reduction.py
@@ -17,7 +17,7 @@ limitations under the License.
 import abc
 
 
-class Reduction(object):
+class Reduction:
     """Abstract base class for reductions.
 
     A reduction is an actor that transforms a problem into an

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -42,7 +42,7 @@ def failure_solution(status, attr=None):
     return Solution(status, opt_val, {}, {}, attr)
 
 
-class Solution(object):
+class Solution:
     """A solution to an optimization problem.
 
     Attributes

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -30,7 +30,7 @@ import scipy.sparse as sp
 # make sure to run cvxpy/tests/test_benchmarks.py to ensure that you have
 # not introduced a regression.
 
-class LinearOperator(object):
+class LinearOperator:
     """A wrapper for linear operators."""
     def __init__(self, linear_op, shape):
         if sp.issparse(linear_op):

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -19,7 +19,7 @@ import cvxpy as cp
 from cvxpy.tests.base_test import BaseTest
 
 
-class SolverTestHelper(object):
+class SolverTestHelper:
 
     def __init__(self, obj_pair, var_pairs, con_pairs):
         self.objective = obj_pair[0]
@@ -698,7 +698,7 @@ def mi_pcp_0():
     return sth
 
 
-class StandardTestLPs(object):
+class StandardTestLPs:
 
     @staticmethod
     def test_lp_0(solver, places=4, duals=True, **kwargs):
@@ -778,7 +778,7 @@ class StandardTestLPs(object):
         sth.verify_primal_values(places)
 
 
-class StandardTestSOCPs(object):
+class StandardTestSOCPs:
 
     @staticmethod
     def test_socp_0(solver, places=4, duals=True, **kwargs):
@@ -844,7 +844,7 @@ class StandardTestSOCPs(object):
         sth.verify_primal_values(places)
 
 
-class StandardTestSDPs(object):
+class StandardTestSDPs:
 
     @staticmethod
     def test_sdp_1min(solver, places=4, duals=True, **kwargs):
@@ -879,7 +879,7 @@ class StandardTestSDPs(object):
             sth.check_dual_domains(places)
 
 
-class StandardTestECPs(object):
+class StandardTestECPs:
 
     @staticmethod
     def test_expcone_1(solver, places=4, duals=True, **kwargs):
@@ -892,7 +892,7 @@ class StandardTestECPs(object):
             sth.verify_dual_values(places)
 
 
-class StandardTestMixedCPs(object):
+class StandardTestMixedCPs:
 
     @staticmethod
     def test_exp_soc_1(solver, places=3, duals=True, **kwargs):
@@ -905,7 +905,7 @@ class StandardTestMixedCPs(object):
             sth.verify_dual_values(places)
 
 
-class StandardTestPCPs(object):
+class StandardTestPCPs:
 
     @staticmethod
     def test_pcp_1(solver, places=3, duals=True, **kwargs):

--- a/cvxpy/transforms/suppfunc.py
+++ b/cvxpy/transforms/suppfunc.py
@@ -93,7 +93,7 @@ def scs_cone_selectors(K):
     return selectors
 
 
-class SuppFunc(object):
+class SuppFunc:
 
     def __init__(self, x, constraints):
         """

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -19,7 +19,7 @@ from cvxpy.utilities import performance_utils as pu
 from cvxpy.utilities.deterministic import unique_list
 
 
-class Canonical(object):
+class Canonical:
     """
     An interface for objects that can be canonicalized.
     """

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -30,7 +30,7 @@ from cvxpy.lin_ops.lin_op import LinOp, NO_OP
 
 
 # TODO find best format for sparse matrices: csr, csc, dok, lil, ...
-class CoeffExtractor(object):
+class CoeffExtractor:
 
     def __init__(self, inverse_data):
         self.id_map = inverse_data.var_offsets

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,7 +48,7 @@ numpydoc_show_class_members = False
 # whenever it tries to import a CVXPY module to document it.
 # The following code replaces the relevant cvxopt modules with
 # a dummy namespace, allowing autodoc to work.
-class Mocked(object):
+class Mocked:
     def __setattr__(self, name, value):
         self.__dict__[name] = value
 
@@ -296,4 +296,3 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
-

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -25,7 +25,7 @@ import pydoc
 from StringIO import StringIO
 from warnings import warn
 
-class Reader(object):
+class Reader:
     """A line-based string reader.
 
     """
@@ -99,7 +99,7 @@ class Reader(object):
         return not ''.join(self._str).strip()
 
 
-class NumpyDocString(object):
+class NumpyDocString:
     def __init__(self, docstring, config={}):
         docstring = textwrap.dedent(docstring).split('\n')
 

--- a/doc/sphinxext/numpydoc.py
+++ b/doc/sphinxext/numpydoc.py
@@ -128,7 +128,7 @@ from docutils.statemachine import ViewList
 from sphinx.domains.c import CDomain
 from sphinx.domains.python import PythonDomain
 
-class ManglingDomainBase(object):
+class ManglingDomainBase:
     directive_mangling_map = {}
 
     def __init__(self, *a, **kw):
@@ -182,4 +182,3 @@ def wrap_mangling_directive(base_directive, objtype):
             return base_directive.run(self)
 
     return directive
-

--- a/examples/advanced/circuits.py
+++ b/examples/advanced/circuits.py
@@ -18,7 +18,7 @@ limitations under the License.
 import cvxpy as cp
 import abc
 
-class Node(object):
+class Node:
     """ A node connecting devices. """
     def __init__(self):
         self.voltage = cp.Variable()
@@ -33,7 +33,7 @@ class Ground(Node):
     def constraints(self):
         return [self.voltage == 0] + super(Ground, self).constraints()
 
-class Device(object):
+class Device:
     __metaclass__ = abc.ABCMeta
     """ A device on a circuit. """
     def __init__(self, pos_node, neg_node):

--- a/examples/advanced/numpy_test.py
+++ b/examples/advanced/numpy_test.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import numpy
 import abc
-class Meta(object):
+class Meta:
     def __subclasscheck__(self, subclass):
         print("hello")
 
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     print(issubclass(Meta, numpy.ndarray))
     print(issubclass(Test, numpy.ndarray))
     print(issubclass(numpy.ndarray, Test))
-    
+
     a = numpy.arange(2)
     t = Test(1)
     a + t

--- a/examples/advanced/optimal_control.py
+++ b/examples/advanced/optimal_control.py
@@ -25,7 +25,7 @@ x_init = cvxopt.normal(n)
 x_final = cvxopt.normal(n)
 
 # Object oriented optimal control problem.
-class Stage(object):
+class Stage:
     def __init__(self, A, B, x_prev):
         self.x = Variable(n)
         self.u = Variable(p)

--- a/examples/advanced/test.py
+++ b/examples/advanced/test.py
@@ -59,7 +59,7 @@ class MyMeta(type):
         return 0
 
 
-class Exp(object):
+class Exp:
     def __add__(self, other):
         return 0
 
@@ -75,7 +75,7 @@ import numpy as np
 a = np.random.random((2,2))
 
 
-class Bar1(object):
+class Bar1:
     __metaclass__ = MyMeta
     def __add__(self, rhs): return 0
     def __radd__(self, rhs): return 1

--- a/examples/floor_packing.py
+++ b/examples/floor_packing.py
@@ -19,7 +19,7 @@ import pylab
 import math
 
 # Based on http://cvxopt.org/examples/book/floorplan.html
-class Box(object):
+class Box:
     """ A box in a floor packing problem. """
     ASPECT_RATIO = 5.0
     def __init__(self, min_area):
@@ -53,7 +53,7 @@ class Box(object):
     def top(self):
         return self.y + self.height
 
-class FloorPlan(object):
+class FloorPlan:
     """ A minimum perimeter floor plan. """
     MARGIN = 1.0
     ASPECT_RATIO = 5.0

--- a/examples/flows/max_flow.py
+++ b/examples/flows/max_flow.py
@@ -19,7 +19,7 @@ from .create_graph import FILE, NODE_COUNT_KEY, EDGES_KEY
 import pickle
 
 # An object oriented max-flow problem.
-class Edge(object):
+class Edge:
     """ An undirected, capacity limited edge. """
     def __init__(self, capacity):
         self.capacity = capacity
@@ -34,7 +34,7 @@ class Edge(object):
     def constraints(self):
         return [abs(self.flow) <= self.capacity]
 
-class Node(object):
+class Node:
     """ A node with accumulation. """
     def __init__(self, accumulation=0):
         self.accumulation = accumulation


### PR DESCRIPTION
There are a number of instances where the code says:
```
class foo(object):
```
this PR switches them all to
```
class foo:
```
As explained [here](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object), the first form was necessary for Python 2, but is not needed in Python 3. Since CVXPY requires Python >=3.5, this pattern is no longer necessary.