### PR TITLE
Populate solver_stats for ECOS_BB, ECOS & SCS

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
@@ -101,9 +101,9 @@ class ECOS_BB(ECOS):
                     inverse_data[self.EQ_CONSTR]
                 )
                 dual_vars.update(eq_duals)
-            return Solution(status, opt_val, primal_vars, dual_vars, {})
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status)
+            return failure_solution(status, attr)
 
     def solve_via_data(self, data, warm_start, verbose, solver_opts, solver_cache=None):
         import ecos

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -173,4 +173,4 @@ class ECOS(ConicSolver):
             dual_vars.update(eq_duals)
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status)
+            return failure_solution(status, attr)

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -275,7 +275,7 @@ class SCS(ConicSolver):
             dual_vars.update(ineq_dual_vars)
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status)
+            return failure_solution(status, attr)
 
     def solve_via_data(self, data, warm_start, verbose, solver_opts, solver_cache=None):
         """Returns the result of the call to the solver.


### PR DESCRIPTION
Fixes #1322.

I have taken this opportunity to pass solver stats for ECOS and SCS as well when there is no solution (similar to [gurobi_conif.py](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py)).