### PR TITLE
Fix loop variable data type

### DIFF
--- a/cvxpy/cvxcore/src/cvxcore.cpp
+++ b/cvxpy/cvxcore/src/cvxcore.cpp
@@ -180,7 +180,7 @@ ProblemData build_matrix(std::vector<const LinOp *> constraints, int var_length,
   }
   #pragma omp parallel for
   #endif
-  for (int i = 0; i < constraints_and_offsets.size(); ++i) {
+  for (size_t i = 0; i < constraints_and_offsets.size(); ++i) {
     const std::pair<const LinOp*, int>& pair = constraints_and_offsets.at(i);
     const LinOp* constraint = pair.first;
     int vert_offset = pair.second;


### PR DESCRIPTION
Fixes
```
cvxpy/cvxcore/src/cvxcore.cpp: In function ‘ProblemData build_matrix(std::vector<const LinOp*>, int, std::map<int, int>, std::map<int, int>, int)’:
cvxpy/cvxcore/src/cvxcore.cpp:183:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::pair<const LinOp*, int> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  183 |   for (int i = 0; i < constraints_and_offsets.size(); ++i) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```