### PR TITLE
Suppress warning about unused variable

### DIFF
--- a/cvxpy/cvxcore/src/LinOpOperations.cpp
+++ b/cvxpy/cvxcore/src/LinOpOperations.cpp
@@ -726,16 +726,12 @@ Tensor get_rmul_mat(const LinOp &lin, int arg_idx) {
                       : 1;
 
   // Interpret as row or column vector as needed.
-  int arg_cols;
   int result_rows;
   if (lin.get_args()[0]->get_shape().size() == 0) {
-    arg_cols = 1;
     result_rows = 1;
   } else if (lin.get_args()[0]->get_shape().size() == 1) {
-    arg_cols = lin.get_args()[0]->get_shape()[0];
     result_rows = 1;
   } else {
-    arg_cols = lin.get_args()[0]->get_shape()[1];
     result_rows = lin.get_args()[0]->get_shape()[0];
   }
   int n = (lin.get_shape().size() > 0) ? result_rows : 1;
@@ -834,7 +830,7 @@ Tensor get_mul_mat(const LinOp &lin, int arg_idx) {
     // vectorized views.
     data_flattened = data_rows == 1 || data_cols == 1;
     Matrix coeffs = get_constant_data(*data, false);
-    mul_ten = build_tensor(coeffs); 
+    mul_ten = build_tensor(coeffs);
   } else {
     mul_ten = lin_to_tensor(*data);
   }


### PR DESCRIPTION
Fixes
```
cvxpy/cvxcore/src/LinOpOperations.cpp: In function ‘Tensor get_rmul_mat(const LinOp&, int)’:
cvxpy/cvxcore/src/LinOpOperations.cpp:729:7: warning: variable ‘arg_cols’ set but not used [-Wunused-but-set-variable]
  729 |   int arg_cols;
      |       ^~~~~~~~
```
But you may want to just drop the `arg_cols` variable here.