### PR TITLE
Disallow sparse constants in DGP

### DIFF
--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -19,6 +19,7 @@ import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.interface as intf
 from cvxpy.settings import EIGVAL_TOL
 from cvxpy.utilities import performance_utils as perf
+import scipy.sparse as sp
 from scipy.sparse.linalg import eigsh
 from scipy.sparse.linalg.eigen.arpack.arpack import ArpackError
 import numpy as np
@@ -77,7 +78,12 @@ class Constant(Leaf):
         """Returns whether the constant is elementwise positive.
         """
         if self._cached_is_pos is None:
-            self._cached_is_pos = np.all(self._value > 0)
+            if sp.issparse(self._value):
+                # sparse constants cannot be elementwise positive,
+                # since they (typically) have many entries which are zero.
+                self._cached_is_pos = False
+            else:
+                self._cached_is_pos = np.all(self._value > 0)
         return self._cached_is_pos
 
     @property

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -1,6 +1,7 @@
 import cvxpy
 from cvxpy.tests.base_test import BaseTest
 import numpy as np
+import scipy.sparse as sp
 
 
 class TestDgp(BaseTest):
@@ -202,3 +203,7 @@ class TestDgp(BaseTest):
         x = cvxpy.Variable(pos=True)
         self.assertTrue((x**1).is_nonneg())
         self.assertFalse((x**1).is_nonpos())
+
+    def test_sparse_constant_not_allowed(self) -> None:
+        sparse_matrix = cvxpy.Constant(sp.csc_matrix(np.array([1.0, 2.0])))
+        self.assertFalse(sparse_matrix.is_log_log_constant())


### PR DESCRIPTION
Sparse constants cannot be elementwise positive, since they generally have many entries which are zero. So in particular they shouldn't be used in DGP.

Without this change, the `is_pos` method fails with an error (a raised Python exception) on sparse constants.

In the future it might be possible to have an overloaded notion of sparsity for DGP, where the zero entries actually represent the value 1.