### PR TITLE
Fix edge case for vstack

### DIFF
--- a/cvxpy/atoms/affine/vstack.py
+++ b/cvxpy/atoms/affine/vstack.py
@@ -56,10 +56,12 @@ class Vstack(AffAtom):
     # All arguments must have the same width.
     def validate_arguments(self) -> None:
         model = self.args[0].shape
+        # Promote scalars.
         if model == ():
             model = (1,)
         for arg in self.args[1:]:
             arg_shape = arg.shape
+            # Promote scalars.
             if arg_shape == ():
                 arg_shape = (1,)
             if len(arg_shape) != len(model) or \

--- a/cvxpy/atoms/affine/vstack.py
+++ b/cvxpy/atoms/affine/vstack.py
@@ -56,10 +56,15 @@ class Vstack(AffAtom):
     # All arguments must have the same width.
     def validate_arguments(self) -> None:
         model = self.args[0].shape
+        if model == ():
+            model = (1,)
         for arg in self.args[1:]:
-            if len(arg.shape) != len(model) or \
-               (len(model) > 1 and model[1:] != arg.shape[1:]) or \
-               (len(model) <= 1 and model != arg.shape):
+            arg_shape = arg.shape
+            if arg_shape == ():
+                arg_shape = (1,)
+            if len(arg_shape) != len(model) or \
+               (len(model) > 1 and model[1:] != arg_shape[1:]) or \
+               (len(model) <= 1 and model != arg_shape):
                 raise ValueError(("All the input dimensions except"
                                   " for axis 0 must match exactly."))
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -500,6 +500,10 @@ class TestAtoms(BaseTest):
         with self.assertRaises(TypeError) as cm:
             cp.vstack()
 
+        # Test scalars with variables of shape (1,)
+        expr = cp.vstack([2, Variable((1,))])
+        self.assertEqual(expr.shape, (2, 1))
+
     def test_reshape(self) -> None:
         """Test the reshape class.
         """


### PR DESCRIPTION
This fixes #1338 by solving the edge case when vstack is applied to a mix of elements with shape () and elements with shape (1,).